### PR TITLE
fix(sure_eval): fail fast on model/dataset task mismatch

### DIFF
--- a/sure/skills/sure_eval/hooks/checkpoints.ts
+++ b/sure/skills/sure_eval/hooks/checkpoints.ts
@@ -218,7 +218,7 @@ export function runBackend(
 	};
 }
 
-export function failure(repair: string, message: string, counters?: Record<string, number>): SureHookResult {
+export function failure(repair: string, message: string, counters?: Record<string, number>, checkpoint?: RunCheckpoint): SureHookResult {
 	return {
 		ok: false,
 		repair,
@@ -226,6 +226,7 @@ export function failure(repair: string, message: string, counters?: Record<strin
 			phase: { id: "gate", label: "SURE eval gate blocked", status: "blocked" },
 			message,
 			counters,
+			checkpoint,
 			diagnostics: [{ severity: "error", message, repair }],
 		},
 	};

--- a/sure/skills/sure_eval/hooks/index.ts
+++ b/sure/skills/sure_eval/hooks/index.ts
@@ -441,6 +441,7 @@ function failOrRetry(
 			`${repair} (unit "${unit.id}" FAILED after ${attempts} retries; classify via failure_taxonomy and either repair manually or finish with status failed.)`,
 			`Gate "${unit.id}" exhausted retries: ${reason}`,
 			countersFor(next.data, attempts),
+			next,
 		);
 	}
 	return {

--- a/sure/skills/sure_eval/schemas/eval_input_resolved.schema.json
+++ b/sure/skills/sure_eval/schemas/eval_input_resolved.schema.json
@@ -25,7 +25,9 @@
 					"default_metrics": { "type": "array", "items": { "type": "string" } },
 					"source": { "type": ["string", "null"] },
 					"num_samples": { "type": ["number", "null"] },
-					"display_name": { "type": "string" }
+					"display_name": { "type": "string" },
+					"dataset_task": { "type": "string" },
+					"task_source": { "type": "string" }
 				},
 				"additionalProperties": false
 			}

--- a/sure/skills/sure_eval/scripts/resolve_eval_input.py
+++ b/sure/skills/sure_eval/scripts/resolve_eval_input.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from sure_eval.core.config import Config
 from sure_eval.datasets import DatasetManager
+from sure_eval.datasets.dataset_manager import CSV_DATASETS
 
 from evaluation_capabilities import default_metrics_for_task_language, supported_metrics_for_task_language
 from resolve_evaluation_engine import resolve_engine_root
@@ -106,6 +107,44 @@ def _effective_dataset_task(dataset_task: str, model_task: str, metrics: list[st
         if model_task in {"TTS", "VC"}:
             return model_task
     return task
+
+
+SYNTH_TASKS = {"TTS", "VC"}
+TASK_CHECK_EXEMPT = {"OMNI", "API"}
+TASK_WORDS = {"ASR": "speech recognition", "TTS": "speech synthesis", "VC": "voice conversion"}
+
+
+class EvalInputError(ValueError):
+    pass
+
+
+def _task_label(task: str) -> str:
+    word = TASK_WORDS.get(task)
+    return f"{task} ({word})" if word else task
+
+
+def _check_task_compatibility(model: dict[str, Any], datasets: list[dict[str, Any]]) -> None:
+    model_task = _normalize_task(model.get("declared_task"))
+    if not model_task or model_task in TASK_CHECK_EXEMPT:
+        return
+    model_synth = model_task in SYNTH_TASKS
+    mismatched = []
+    for item in datasets:
+        task = _normalize_task(item.get("task"))
+        if task and task != "UNKNOWN" and (task in SYNTH_TASKS) != model_synth:
+            mismatched.append(f"dataset '{item.get('name')}' has task {_task_label(task)}")
+    if not mismatched:
+        return
+    if model_synth:
+        suggestion = "e.g. the seedtts_test_eval or cv3_eval collections"
+    else:
+        names = _dedupe([str(item.get("config_name") or "") for item in CSV_DATASETS.values() if _normalize_task(item.get("task")) == model_task])[:4]
+        suggestion = f"e.g.: {', '.join(names)}" if names else "check the dataset registry for a compatible dataset"
+    raise EvalInputError(
+        f"Task mismatch: model '{model.get('name')}' declares task {_task_label(model_task)}, "
+        f"but {'; '.join(mismatched)}. Choose datasets that match the model task, {suggestion}. "
+        f"(Model task comes from the model's config.yaml; dataset task from dataset metadata.)"
+    )
 
 
 def _write_harness_config(*, run_dir: Path, config_path: str | None) -> Path:
@@ -468,6 +507,8 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         engine_root,
         model_task=str(model.get("declared_task") or ""),
     )
+    if args.strict_main_flow:
+        _check_task_compatibility(model, datasets)
     tasks = _dedupe([str(item.get("task") or "UNKNOWN") for item in datasets])
     languages = _dedupe([str(item.get("language") or "") for item in datasets if item.get("language")])
     metric_list = _dedupe([metric for item in datasets for metric in item.get("default_metrics", [])])
@@ -594,7 +635,11 @@ def main() -> int:
     parser.add_argument("--output")
     args = parser.parse_args()
 
-    payload = build_payload(args)
+    try:
+        payload = build_payload(args)
+    except EvalInputError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     text = json.dumps(payload, indent=2, ensure_ascii=False)
     print(text)
     if args.output:

--- a/sure/skills/sure_eval/scripts/resolve_evaluation_route_plan.py
+++ b/sure/skills/sure_eval/scripts/resolve_evaluation_route_plan.py
@@ -115,6 +115,12 @@ def build_route_plan(
             )
         except Exception as exc:
             issue = f"{dataset_name or '(unknown dataset)'}: {exc}"
+            if "No configured route" in str(exc):
+                issue += (
+                    " (common cause: the dataset task does not match the model task,"
+                    " e.g. an ASR model paired with a TTS dataset; check datasets="
+                    " against the task declared in the model's config.yaml)"
+                )
             blocking_issues.append(issue)
             dataset_plans.append(
                 {

--- a/sure/skills/sure_feed/hooks/checkpoints.ts
+++ b/sure/skills/sure_feed/hooks/checkpoints.ts
@@ -228,7 +228,7 @@ export function runBackend(
 	};
 }
 
-export function failure(repair: string, message: string, counters?: Record<string, number>): SureHookResult {
+export function failure(repair: string, message: string, counters?: Record<string, number>, checkpoint?: RunCheckpoint): SureHookResult {
 	return {
 		ok: false,
 		repair,
@@ -236,6 +236,7 @@ export function failure(repair: string, message: string, counters?: Record<strin
 			phase: { id: "gate", label: "SURE feed gate blocked", status: "blocked" },
 			message,
 			counters,
+			checkpoint,
 			diagnostics: [{ severity: "error", message, repair }],
 		},
 	};

--- a/sure/skills/sure_feed/hooks/index.ts
+++ b/sure/skills/sure_feed/hooks/index.ts
@@ -238,6 +238,7 @@ function failOrRetry(
 			`${repair} After ${attempts} consecutive blocked attempts, /sure_feed still cannot produce a valid artifact for unit "${unit.id}". Stop and ask the user to confirm the model link, access permissions, and whether the model card/README contains enough install, load, and inference information.`,
 			`Gate "${unit.id}" exhausted ${attempts} blocked attempts: ${reason}`,
 			countersFor(next.data, attempts),
+			next,
 		);
 	}
 	return {

--- a/sure/skills/sure_onboard/hooks/checkpoints.ts
+++ b/sure/skills/sure_onboard/hooks/checkpoints.ts
@@ -218,7 +218,7 @@ export function runBackend(
 	};
 }
 
-export function failure(repair: string, message: string, counters?: Record<string, number>): SureHookResult {
+export function failure(repair: string, message: string, counters?: Record<string, number>, checkpoint?: RunCheckpoint): SureHookResult {
 	return {
 		ok: false,
 		repair,
@@ -226,6 +226,7 @@ export function failure(repair: string, message: string, counters?: Record<strin
 			phase: { id: "gate", label: "SURE onboard gate blocked", status: "blocked" },
 			message,
 			counters,
+			checkpoint,
 			diagnostics: [{ severity: "error", message, repair }],
 		},
 	};

--- a/sure/skills/sure_onboard/hooks/index.ts
+++ b/sure/skills/sure_onboard/hooks/index.ts
@@ -843,6 +843,7 @@ function failOrRetry(
 			`${repair} After ${attempts} consecutive blocked attempts, /sure_onboard still cannot produce a valid artifact for unit "${unit.id}". Stop and ask the user to confirm the model_input_path or repo link, access permissions, and whether the referenced documentation contains enough install, load, inference, and artifact information.`,
 			`Gate "${unit.id}" exhausted ${attempts} blocked attempts: ${reason}`,
 			countersFor(next.data, attempts),
+			next,
 		);
 	}
 	return {


### PR DESCRIPTION
## Problem

Pairing an ASR model with a TTS dataset (e.g. `/sure_eval model=Qwen__Qwen3-ASR-0.6B-hf datasets=cv3_eval_zero_shot_zh metrics=wer max_samples=5 execution=local`) sails through the first six units (task_classification, tool_readiness_routing, plan, dataset_scope, script_routing, execution_surface) and only dies ~15 minutes later at `execution_readiness`, with an error that names the symptom, not the cause:

```
No configured route found for TTS (metric=wer)
```

The gate then retries 4 times with zero chance of success. Reproduced on run `20260722-103511-c3a15970`; also reproduces with the 1.7B model, `execution=vc`, and `cv3_eval_zero_shot_hard_zh`.

Root cause: `resolve_eval_input.py` already holds both the model's declared task (from the model's `config.yaml`) and each dataset's task (from dataset metadata) at pre_start, and `_effective_dataset_task` even computes the divergence — but it is only recorded as metadata, never enforced. `dataset_scope` validates names and JSON shape only.

## Fix (4 parts)

1. **Fail fast at input resolution** (`sure/skills/sure_eval/scripts/resolve_eval_input.py`): a hard validation compares the model task against each dataset's effective task. It blocks only clear synthesis-class mismatches — exactly one side in {TTS, VC} — and passes through when either task is empty/UNKNOWN or the model is OMNI/API, so no exotic-but-legal combos are hurt. Active only under `--strict-main-flow` (the default); `--no-strict-main-flow` keeps the old behavior. On mismatch the script prints one plain-English sentence to stderr and exits 2, which the pre_start hook already surfaces verbatim with no retry:

```
Task mismatch: model 'Qwen__Qwen3-ASR-0.6B-hf' declares task ASR (speech recognition), but dataset 'cv3_eval_zero_shot_zh' has task TTS (speech synthesis). Choose datasets that match the model task, e.g.: aishell1, aishell5, librispeech_clean, librispeech_other. (Model task comes from the model's config.yaml; dataset task from dataset metadata.)
```

2. **Hint on route-lookup failure** (`resolve_evaluation_route_plan.py`): when the engine raises "No configured route", the blocking issue now appends "(common cause: the dataset task does not match the model task, ...)" — a safety net for cases that slip past the resolver (e.g. engine or metadata unavailable at resolve time).

3. **Persist the final retry bump** (`sure_eval`/`sure_onboard`/`sure_feed` hooks): the retry-exhausted branch of `failOrRetry` previously returned `failure()` without the freshly bumped checkpoint, so the message said "FAILED after 4 retries" while `state.json` recorded 3. `failure()` gains an optional `checkpoint` parameter and the terminal branch passes it; all other call sites are unaffected (`state_patch` merge is truthy-guarded).

4. **Schema alignment** (`eval_input_resolved.schema.json`): the resolver's existing `dataset_task`/`task_source` divergence markers are now declared in the `datasets[]` item schema, which previously had `additionalProperties: false` without them.

## Verification (on the SJTU HPC cluster, checkout @ 5ce6224 + this patch)

- **Negative, direct**: the F13 command's resolver invocation now exits 2 with the message above, no traceback, no retries. Before the patch: exit 0.
- **Negative, e2e (TUI)**: the same `/sure_eval` command is blocked immediately at pre_start with the same message; the run directory shows no unit progression and an empty artifacts/.
- **Positive, direct**: `--datasets aishell1 --metrics cer` produces a payload byte-identical to the pre-patch baseline (only `generated_at` differs).
- **Positive, e2e (TUI)**: `/sure_eval model=Qwen__Qwen3-ASR-0.6B-hf datasets=aishell1 metrics=cer max_samples=5 execution=local` runs the full chain (12/12 units, run 20260723-071135-423a1bbb) and scores CER 0.0128 (5 samples), matching the pre-patch reference — no false-positive blocking.
- **Hint**: feeding the pre-patch TTS payload to `resolve_evaluation_route_plan.py` now yields the blocking issue with the "common cause" hint appended (count 2: top-level and per-dataset).
- **Hooks smoke**: `npx tsx` import of all three patched `checkpoints.ts` confirms `failure(..., checkpoint)` lands the checkpoint (retries persisted as 4) in `state_patch`.
