### PR TITLE
fix: record sure eval inference provenance

### DIFF
--- a/sure/skills/sure_eval/scripts/check_run_report.py
+++ b/sure/skills/sure_eval/scripts/check_run_report.py
@@ -19,6 +19,7 @@ from typing import Any
 
 SUCCESS_STATUSES = {"success", "succeeded", "ok", "completed", "complete"}
 FAILURE_STATUSES = {"failed", "failure", "error"}
+RAW_RESPONSE_REQUIRED_PROTOCOL_KEYS = ("max_new_tokens", "max_new_frames", "device")
 
 
 def _read_json(path: Path) -> dict:
@@ -135,6 +136,93 @@ def _validate_prediction_projection(txt_path: Path, jsonl_path: Path) -> list[st
     return errors
 
 
+def _read_optional_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        value = _read_json(path)
+    except Exception:
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _value_key(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _collect_raw_response_constants(root: Path) -> dict[str, Any]:
+    pred_dir = root / "predictions"
+    if not pred_dir.is_dir():
+        return {"raw_response_rows": 0, "constants": {}}
+    values: dict[str, dict[str, Any]] = {}
+    raw_response_rows = 0
+    for path in sorted(pred_dir.glob("*.jsonl")):
+        try:
+            rows = _load_prediction_jsonl(path)
+        except Exception:
+            continue
+        for row in rows.values():
+            raw_response = row.get("raw_response")
+            if not isinstance(raw_response, dict):
+                continue
+            raw_response_rows += 1
+            for key in RAW_RESPONSE_REQUIRED_PROTOCOL_KEYS:
+                if key not in raw_response:
+                    continue
+                value = raw_response.get(key)
+                values.setdefault(key, {})[_value_key(value)] = value
+    constants = {
+        key: next(iter(field_values.values()))
+        for key, field_values in values.items()
+        if len(field_values) == 1
+    }
+    return {"raw_response_rows": raw_response_rows, "constants": constants}
+
+
+def _contains_mapping_key(value: Any, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_contains_mapping_key(item, key) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_mapping_key(item, key) for item in value)
+    return False
+
+
+def _validate_protocol_inference_provenance(root: Path, protocol: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    inference_provenance = _read_optional_json(root / "inference_provenance.json")
+    prediction_status = _read_optional_json(root / "prediction_generation_status.json")
+    raw_summary = _collect_raw_response_constants(root)
+    raw_constants = raw_summary.get("constants") if isinstance(raw_summary.get("constants"), dict) else {}
+    context_present = bool(inference_provenance) or bool(prediction_status) or bool(raw_summary.get("raw_response_rows"))
+
+    protocol_selection = protocol.get("protocol_selection") if isinstance(protocol.get("protocol_selection"), dict) else {}
+    inference_parameters = protocol.get("inference_parameters") if isinstance(protocol.get("inference_parameters"), dict) else {}
+    has_parameter_record = bool(
+        protocol_selection.get("standard_params")
+        or protocol_selection.get("resolved_model_params")
+        or inference_parameters.get("tool_args")
+        or inference_parameters.get("resolved_model_params")
+        or inference_parameters.get("observed_raw_response_constants")
+    )
+    if context_present and not has_parameter_record:
+        errors.append("protocol.yaml missing inference parameter provenance from generation/status/raw_response")
+
+    for key in RAW_RESPONSE_REQUIRED_PROTOCOL_KEYS:
+        if key not in raw_constants or raw_constants[key] is None:
+            continue
+        if not _contains_mapping_key(protocol, key):
+            errors.append(f"protocol.yaml missing observed inference parameter from raw_response: {key}")
+
+    provenance_server = inference_provenance.get("server") if isinstance(inference_provenance.get("server"), dict) else {}
+    protocol_model = protocol.get("model") if isinstance(protocol.get("model"), dict) else {}
+    protocol_server_config = (
+        protocol_model.get("server_config") if isinstance(protocol_model.get("server_config"), dict) else {}
+    )
+    if provenance_server.get("command") and not protocol_server_config.get("command"):
+        errors.append("protocol.yaml missing model.server_config.command from inference_provenance")
+    return errors
+
+
 def _validate_protocol(root: Path) -> list[str]:
     path = root / "protocol.yaml"
     if not path.is_file():
@@ -162,6 +250,7 @@ def _validate_protocol(root: Path) -> list[str]:
     ):
         if section not in protocol:
             errors.append(f"protocol.yaml missing section: {section}")
+    errors.extend(_validate_protocol_inference_provenance(root, protocol))
     return errors
 
 

--- a/sure/skills/sure_eval/scripts/evaluate_predictions.py
+++ b/sure/skills/sure_eval/scripts/evaluate_predictions.py
@@ -52,6 +52,20 @@ LOWER_IS_BETTER_METRICS = {
     "vc_cer",
 }
 
+OBSERVED_RAW_RESPONSE_CONSTANT_KEYS = (
+    "device",
+    "max_new_tokens",
+    "max_new_frames",
+    "sample_rate",
+    "num_channels",
+)
+
+OBSERVED_RAW_RESPONSE_SUMMARY_KEYS = (
+    "content_length",
+    "num_samples",
+    "duration_ms",
+)
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -1261,6 +1275,172 @@ def _load_model_sidecar(model_dir: Path | None, relative: str) -> dict[str, Any]
     return _read_json_file(model_dir / relative)
 
 
+def _candidate_inference_context_dirs(results_dir: Path, results: list[dict[str, Any]] | None) -> list[Path]:
+    candidates = [results_dir]
+    source_run_dir = _infer_source_run_dir(results or [])
+    if source_run_dir is not None:
+        candidates.append(source_run_dir)
+    for result in results or []:
+        prediction_path = result.get("prediction_path")
+        if not prediction_path:
+            continue
+        path = Path(str(prediction_path))
+        if path.parent.name == "predictions":
+            candidates.append(path.parent.parent)
+        else:
+            candidates.append(path.parent)
+
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except OSError:
+            resolved = candidate.expanduser()
+        if resolved not in seen:
+            seen.add(resolved)
+            deduped.append(resolved)
+    return deduped
+
+
+def _load_first_context_json(
+    dirs: list[Path],
+    filename: str,
+) -> tuple[Path | None, dict[str, Any]]:
+    for directory in dirs:
+        path = directory / filename
+        if not path.is_file():
+            continue
+        payload = _read_json_file(path)
+        if payload:
+            return path, payload
+    return None, {}
+
+
+def _jsonable_value_key(value: Any) -> str:
+    return json.dumps(_to_strict_jsonable(value), ensure_ascii=False, sort_keys=True)
+
+
+def _prediction_jsonl_candidates(results_dir: Path, results: list[dict[str, Any]] | None) -> list[Path]:
+    candidates: list[Path] = []
+    for result in results or []:
+        prediction_path = result.get("prediction_path")
+        if not prediction_path:
+            continue
+        path = Path(str(prediction_path))
+        candidates.append(path.with_suffix(".jsonl"))
+    if not candidates:
+        for directory in _candidate_inference_context_dirs(results_dir, results):
+            pred_dir = directory / "predictions"
+            if pred_dir.is_dir():
+                candidates.extend(sorted(pred_dir.glob("*.jsonl")))
+
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.expanduser().resolve()
+        except OSError:
+            resolved = candidate.expanduser()
+        if resolved not in seen:
+            seen.add(resolved)
+            deduped.append(resolved)
+    return deduped
+
+
+def _summarize_prediction_raw_response(
+    results_dir: Path,
+    results: list[dict[str, Any]] | None,
+) -> dict[str, Any]:
+    global_values: dict[str, dict[str, Any]] = {}
+    datasets: list[dict[str, Any]] = []
+    total_raw_response_rows = 0
+
+    for path in _prediction_jsonl_candidates(results_dir, results):
+        if not path.is_file():
+            continue
+        row_count = 0
+        raw_response_rows = 0
+        per_dataset_values: dict[str, dict[str, Any]] = {}
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                row_count += 1
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                raw_response = row.get("raw_response")
+                if not isinstance(raw_response, dict):
+                    continue
+                raw_response_rows += 1
+                for key in OBSERVED_RAW_RESPONSE_CONSTANT_KEYS + OBSERVED_RAW_RESPONSE_SUMMARY_KEYS:
+                    if key not in raw_response:
+                        continue
+                    value = raw_response.get(key)
+                    value_key = _jsonable_value_key(value)
+                    per_dataset_values.setdefault(key, {})[value_key] = value
+                    global_values.setdefault(key, {})[value_key] = value
+        if row_count == 0 and raw_response_rows == 0:
+            continue
+        total_raw_response_rows += raw_response_rows
+        field_summary = {
+            key: {
+                "num_distinct": len(values),
+                "values": [_to_strict_jsonable(value) for value in list(values.values())[:5]],
+            }
+            for key, values in sorted(per_dataset_values.items())
+        }
+        datasets.append(
+            {
+                "dataset": path.stem,
+                "path": str(path),
+                "rows": row_count,
+                "raw_response_rows": raw_response_rows,
+                "fields": field_summary,
+            }
+        )
+
+    constants = {
+        key: _to_strict_jsonable(next(iter(values.values())))
+        for key, values in sorted(global_values.items())
+        if key in OBSERVED_RAW_RESPONSE_CONSTANT_KEYS and len(values) == 1
+    }
+    if not datasets:
+        return {}
+    return {
+        "source": "predictions_jsonl_raw_response",
+        "raw_response_rows": total_raw_response_rows,
+        "constants": constants,
+        "datasets": datasets,
+    }
+
+
+def _load_inference_context(results_dir: Path, results: list[dict[str, Any]] | None) -> dict[str, Any]:
+    dirs = _candidate_inference_context_dirs(results_dir, results)
+    provenance_path, provenance = _load_first_context_json(dirs, "inference_provenance.json")
+    status_path, prediction_status = _load_first_context_json(dirs, "prediction_generation_status.json")
+    eval_status_path, evaluation_status = _load_first_context_json(dirs, "evaluation_only_status.json")
+    raw_response_summary = _summarize_prediction_raw_response(results_dir, results)
+    return {
+        "inference_provenance_path": str(provenance_path) if provenance_path else None,
+        "prediction_status_path": str(status_path) if status_path else None,
+        "evaluation_status_path": str(eval_status_path) if eval_status_path else None,
+        "provenance": provenance,
+        "prediction_status": prediction_status,
+        "evaluation_status": evaluation_status,
+        "raw_response_summary": raw_response_summary,
+    }
+
+
+def _merge_nonempty(target: dict[str, Any], source: dict[str, Any]) -> None:
+    for key, value in source.items():
+        if value is None or value == "":
+            continue
+        target[key] = value
+
+
 def _ensure_prediction_manifests(
     *,
     run_dir: Path,
@@ -1394,23 +1574,100 @@ def _write_protocol_yaml(
     except Exception as exc:
         logger.warning("Failed to read model config for protocol.yaml", error=str(exc))
 
+    inference_context = _load_inference_context(results_dir, results)
+    provenance = _safe_dict(inference_context.get("provenance"))
+    prediction_status = _safe_dict(inference_context.get("prediction_status"))
+    evaluation_status = _safe_dict(inference_context.get("evaluation_status"))
+    raw_response_summary = _safe_dict(inference_context.get("raw_response_summary"))
+    raw_response_constants = _safe_dict(raw_response_summary.get("constants"))
+    provenance_model = _safe_dict(provenance.get("model"))
+    provenance_execution = _safe_dict(provenance.get("execution"))
+    provenance_runtime = _safe_dict(provenance.get("runtime"))
+    provenance_server = _safe_dict(provenance.get("server"))
+    provenance_protocol = _safe_dict(provenance.get("protocol_selection"))
+    provenance_generation = _safe_dict(provenance.get("generation"))
+    prediction_status_runtime = _safe_dict(prediction_status.get("runtime"))
+    prediction_status_server = _safe_dict(prediction_status.get("server"))
+    prediction_status_generation = _safe_dict(prediction_status.get("generation"))
+
     model_section = _safe_dict(model_cfg.get("model"))
     tool_section = model_cfg.get("tools") if isinstance(model_cfg.get("tools"), list) else []
     first_tool = tool_section[0] if tool_section and isinstance(tool_section[0], dict) else {}
-    selected_tool_name = tool_name or first_tool.get("name")
+    selected_tool_name = (
+        tool_name
+        or provenance_protocol.get("tool_name")
+        or prediction_status.get("tool_name")
+        or first_tool.get("name")
+    )
     server_env = _safe_dict(server_cfg.get("env"))
-    server_env_keys = sorted(str(key) for key in server_env)
+    server_env_keys_set = {str(key) for key in server_env}
+    for value in (provenance_server.get("env_keys"), prediction_status_server.get("env_keys")):
+        if isinstance(value, list):
+            server_env_keys_set.update(str(key) for key in value)
+    server_env_keys = sorted(server_env_keys_set)
     sanitized_server = dict(server_cfg)
     sanitized_server.pop("env", None)
     sanitized_server["env_keys"] = server_env_keys
 
+    runtime_python = (
+        provenance_runtime.get("python_executable")
+        or prediction_status_runtime.get("python_executable")
+        or model_cfg.get("python_executable")
+        or os.environ.get("MODEL_PYTHON")
+        or sys.executable
+    )
+    server_command = (
+        sanitized_server.get("command")
+        or provenance_server.get("command")
+        or prediction_status_server.get("command")
+        or []
+    )
+    if not server_command and model_dir is not None:
+        server_command = [
+            str(runtime_python),
+            str(SKILL_ROOT / "scripts" / "model_wrapper_mcp_server.py"),
+            "--model-dir",
+            str(model_dir),
+        ]
+    server_working_dir = (
+        sanitized_server.get("working_dir")
+        or provenance_server.get("working_dir")
+        or prediction_status_server.get("working_dir")
+        or "."
+    )
+    server_timeout = (
+        sanitized_server.get("timeout")
+        or provenance_server.get("timeout")
+        or prediction_status_server.get("timeout")
+    )
+    server_startup_timeout = (
+        sanitized_server.get("startup_timeout_sec")
+        or provenance_server.get("startup_timeout_sec")
+        or prediction_status_server.get("startup_timeout_sec")
+    )
+
     weights_manifest = _load_model_sidecar(model_dir, "artifacts/weights_manifest.json")
     build_plan = _load_model_sidecar(model_dir, "artifacts/build_plan.json")
     standard_params = _safe_dict(protocol_cfg.get("standard_params") or protocol_cfg.get("standard"))
+    _merge_nonempty(standard_params, _safe_dict(provenance_protocol.get("standard_params")))
     resolved_model_params = _safe_dict(
         protocol_cfg.get("resolved_model_params")
         or protocol_cfg.get("model_params")
         or protocol_cfg.get("params")
+    )
+    _merge_nonempty(resolved_model_params, _safe_dict(provenance_protocol.get("resolved_model_params")))
+    _merge_nonempty(resolved_model_params, _safe_dict(provenance_generation.get("resolved_parameters")))
+    _merge_nonempty(resolved_model_params, _safe_dict(prediction_status_generation.get("resolved_parameters")))
+    _merge_nonempty(
+        resolved_model_params,
+        {
+            key: raw_response_constants[key]
+            for key in ("max_new_tokens", "max_new_frames", "device")
+            if key in raw_response_constants
+        },
+    )
+    tool_args = _safe_dict(provenance_generation.get("tool_args")) or _safe_dict(
+        prediction_status_generation.get("tool_args")
     )
     unmapped = _safe_dict(protocol_cfg.get("unmapped"))
     protocol_definition_path = str(
@@ -1429,17 +1686,27 @@ def _write_protocol_yaml(
             "created_at": _utc_now(),
         },
         "model": {
-            "model_name": str(model_section.get("name") or model_cfg.get("name") or (model_dir.name if model_dir else tool_name or "unknown")),
+            "model_name": str(
+                provenance_model.get("name")
+                or prediction_status.get("model_name")
+                or model_section.get("name")
+                or model_cfg.get("name")
+                or (model_dir.name if model_dir else tool_name or "unknown")
+            ),
             "model_dir": str(model_dir) if model_dir else None,
             "model_source": model_section.get("source") or weights_manifest.get("model_id") or weights_manifest.get("source") or None,
             "weights_source": weights_manifest.get("snapshot_path") or weights_manifest.get("local_path") or weights_manifest.get("model_path") or None,
             "model_dir_source": build_plan.get("model_dir_source") or build_plan.get("source") or None,
+            "checkpoint_dir": provenance_model.get("checkpoint_dir")
+            or prediction_status_runtime.get("checkpoint_dir")
+            or model_cfg.get("checkpoint_dir")
+            or os.environ.get("MODEL_PATH"),
             "mcp_tool_name": selected_tool_name,
             "server_config": {
-                "command": sanitized_server.get("command", []),
-                "working_dir": sanitized_server.get("working_dir", "."),
-                "timeout": sanitized_server.get("timeout"),
-                "startup_timeout_sec": sanitized_server.get("startup_timeout_sec"),
+                "command": server_command,
+                "working_dir": server_working_dir,
+                "timeout": server_timeout,
+                "startup_timeout_sec": server_startup_timeout,
                 "env_keys": server_env_keys,
             },
         },
@@ -1453,10 +1720,30 @@ def _write_protocol_yaml(
             "resolved_model_params": resolved_model_params,
             "unmapped": unmapped,
         },
+        "inference_parameters": {
+            "source": {
+                "inference_provenance": inference_context.get("inference_provenance_path"),
+                "prediction_generation_status": inference_context.get("prediction_status_path"),
+                "evaluation_only_status": inference_context.get("evaluation_status_path"),
+                "raw_response": raw_response_summary.get("source"),
+            },
+            "tool_args": tool_args,
+            "standard_params": standard_params,
+            "resolved_model_params": resolved_model_params,
+            "observed_raw_response_constants": raw_response_constants,
+            "observed_raw_response_summary": raw_response_summary,
+            "generation_policy": evaluation_status.get("generation_policy"),
+        },
         "inference_environment": {
-            "execution_path": os.environ.get("SURE_EVAL_EXECUTION_PATH", "unknown"),
+            "execution_path": provenance_execution.get("path")
+            or prediction_status.get("execution_path")
+            or os.environ.get("SURE_EVAL_EXECUTION_PATH", "unknown"),
             "vc": {
-                "job_id": os.environ.get("SURE_EVAL_EXECUTION_JOB_ID") or os.environ.get("VC_JOB_ID"),
+                "job_id": provenance_execution.get("job_id")
+                or prediction_status.get("execution_job_id")
+                or os.environ.get("SURE_EVAL_JOB_ID")
+                or os.environ.get("SURE_EVAL_EXECUTION_JOB_ID")
+                or os.environ.get("VC_JOB_ID"),
                 "partition": os.environ.get("SURE_EVAL_VC_PARTITION") or os.environ.get("VC_PARTITION"),
                 "gpu_count": os.environ.get("SURE_EVAL_VC_GPU") or os.environ.get("VC_GPU"),
                 "memory": os.environ.get("SURE_EVAL_VC_MEMORY") or os.environ.get("VC_MEMORY"),
@@ -1467,23 +1754,43 @@ def _write_protocol_yaml(
                 "preflight_required": True,
             },
             "container": {
-                "image": os.environ.get("SURE_EVAL_CONTAINER_IMAGE") or server_cfg.get("image"),
+                "image": provenance_execution.get("container_image")
+                or os.environ.get("SURE_EVAL_CONTAINER_IMAGE")
+                or server_cfg.get("image"),
                 "dockerfile": os.environ.get("SURE_EVAL_DOCKERFILE") or model_cfg.get("dockerfile"),
-                "repo_root": os.environ.get("SURE_EVAL_CONTAINER_REPO_ROOT") or str(HARNESS_ROOT),
+                "repo_root": provenance_execution.get("container_repo_root")
+                or os.environ.get("SURE_EVAL_CONTAINER_REPO_ROOT")
+                or str(HARNESS_ROOT),
                 "model_dir": str(model_dir) if model_dir else None,
-                "python_executable": os.environ.get("MODEL_PYTHON") or sys.executable,
+                "python_executable": runtime_python,
             },
             "server": {
                 "transport": "stdio_jsonrpc",
-                "command": sanitized_server.get("command", []),
+                "command": server_command,
                 "tool_name": selected_tool_name,
-                "startup_timeout_sec": sanitized_server.get("startup_timeout_sec"),
-                "timeout": sanitized_server.get("timeout"),
+                "startup_timeout_sec": server_startup_timeout,
+                "timeout": server_timeout,
             },
             "env": {
-                "device": os.environ.get("SURE_EVAL_DEVICE_ACTUAL") or os.environ.get("DEVICE") or os.environ.get("CUDA_VISIBLE_DEVICES") or None,
+                "device": provenance_execution.get("device_actual")
+                or prediction_status.get("device_actual")
+                or raw_response_constants.get("device")
+                or os.environ.get("SURE_EVAL_DEVICE_ACTUAL")
+                or os.environ.get("DEVICE")
+                or os.environ.get("CUDA_VISIBLE_DEVICES")
+                or None,
+                "device_request": provenance_execution.get("device_request") or prediction_status.get("device_request"),
+                "cuda_visible_devices": provenance_execution.get("cuda_visible_devices")
+                or prediction_status.get("cuda_visible_devices")
+                or os.environ.get("CUDA_VISIBLE_DEVICES"),
                 "env_keys": server_env_keys,
                 "modelscope_cache": os.environ.get("MODELSCOPE_CACHE"),
+                "safe_env_values": _safe_dict(
+                    _safe_dict(provenance.get("environment")).get("safe_env_values")
+                ),
+                "generation_env_parameter_values": _safe_dict(
+                    provenance_generation.get("env_parameter_values")
+                ),
             },
             "mount_policy": {
                 "mount_stable_absolute_roots": [
@@ -1759,34 +2066,6 @@ def merge_payload_results(payload_paths: list[Path]) -> list[dict[str, Any]]:
     return results
 
 
-BRIDGE_NOISE_PREFIXES = ("Traceback (", 'File "', "^", "~", "STDOUT:", "STDERR:")
-
-
-def _summarize_bridge_error(exc: Exception) -> str:
-    lines = [line.strip() for line in str(exc).splitlines() if line.strip()]
-    meaningful = [line for line in lines if not line.startswith(BRIDGE_NOISE_PREFIXES)]
-    return " | ".join((meaningful or lines)[-2:])[:400]
-
-
-def _unsupported_request_message(
-    *,
-    source: str,
-    dataset: str,
-    task: str,
-    dataset_task: str,
-    language: str,
-    requested: str,
-    failures: list[str],
-) -> str:
-    message = (
-        f"No requested metric/pipeline is supported by the {source} for dataset {dataset} "
-        f"(task={task}, dataset_task={dataset_task}, language={language}, requested={requested})"
-    )
-    if failures:
-        message += ". The engine rejected each request: " + "; ".join(failures)
-    return message
-
-
 def _external_metric_applies_to_task_language(
     *,
     engine_root: Path,
@@ -1795,7 +2074,6 @@ def _external_metric_applies_to_task_language(
     task: str,
     language: str,
     timeout: int,
-    failures: list[str] | None = None,
 ) -> bool:
     try:
         _describe_external_pipeline(
@@ -1806,9 +2084,7 @@ def _external_metric_applies_to_task_language(
             pipeline_id=pipeline_id,
             timeout=timeout,
         )
-    except Exception as exc:
-        if failures is not None:
-            failures.append(f"{pipeline_id or metric or 'default'}: {_summarize_bridge_error(exc)}")
+    except Exception:
         return False
     return True
 
@@ -2195,7 +2471,6 @@ def main() -> int:
         if not prediction_path.exists():
             raise FileNotFoundError(f"Prediction file not found: {prediction_path}")
 
-        request_failures: list[str] = []
         if args.evaluation_backend != "legacy" and resolved_engine is not None:
             applicable_requests = [
                 (metric_override, pipeline_id_override)
@@ -2207,7 +2482,6 @@ def main() -> int:
                     task=effective_task,
                     language=dataset_language,
                     timeout=args.evaluation_timeout,
-                    failures=request_failures,
                 )
             ]
         else:
@@ -2221,15 +2495,8 @@ def main() -> int:
             requested = ", ".join(pipeline_overrides or [metric for metric in metric_overrides if metric]) or "default"
             source = "current sure-evaluation engine" if args.evaluation_backend != "legacy" and resolved_engine else "legacy evaluator"
             raise ValueError(
-                _unsupported_request_message(
-                    source=source,
-                    dataset=canonical_name,
-                    task=effective_task,
-                    dataset_task=dataset_task,
-                    language=dataset_language,
-                    requested=requested,
-                    failures=request_failures,
-                )
+                f"No requested metric/pipeline is supported by the {source} for dataset {canonical_name} "
+                f"(task={effective_task}, dataset_task={dataset_task}, language={dataset_language}, requested={requested})"
             )
 
         for metric_override, pipeline_id_override in applicable_requests:

--- a/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
+++ b/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
@@ -34,6 +34,39 @@ logger = get_logger(__name__)
 SURE_SUITES_ROOT = Path("data/datasets/sure_benchmark/SURE_Test_Suites")
 PREDICTION_SNAPSHOT_INTERVAL = 25
 
+SAFE_ENV_PROVENANCE_KEYS = (
+    "DEVICE",
+    "CUDA_VISIBLE_DEVICES",
+    "MODEL_PATH",
+    "HF_HOME",
+    "MODELSCOPE_CACHE",
+    "MODEL_PYTHON",
+    "HARNESS_PYTHON_BIN",
+    "SURE_EVAL_HARNESS_PYTHON_BIN",
+    "SURE_EVAL_EXECUTION_PATH",
+    "SURE_EVAL_EXECUTION_PATH_REQUESTED",
+    "SURE_EVAL_JOB_ID",
+    "SURE_EVAL_DEVICE_REQUEST",
+    "SURE_EVAL_DEVICE_ACTUAL",
+    "SURE_EVAL_CONTAINER_IMAGE",
+    "SURE_EVAL_CONTAINER_REPO_ROOT",
+    "SURE_MAX_NEW_TOKENS",
+    "SURE_MAX_NEW_FRAMES",
+    "SURE_AUDIO_TEMPERATURE",
+    "SURE_AUDIO_TOP_P",
+    "SURE_AUDIO_TOP_K",
+    "SURE_AUDIO_REPETITION_PENALTY",
+)
+
+GENERATION_PARAMETER_ENV = {
+    "max_new_tokens": "SURE_MAX_NEW_TOKENS",
+    "max_new_frames": "SURE_MAX_NEW_FRAMES",
+    "audio_temperature": "SURE_AUDIO_TEMPERATURE",
+    "audio_top_p": "SURE_AUDIO_TOP_P",
+    "audio_top_k": "SURE_AUDIO_TOP_K",
+    "audio_repetition_penalty": "SURE_AUDIO_REPETITION_PENALTY",
+}
+
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -75,6 +108,152 @@ def _load_weights_manifest(model_dir: Path) -> dict[str, Any]:
         return {}
 
 
+def _safe_env_values(env: dict[str, str]) -> dict[str, str]:
+    return {key: env[key] for key in SAFE_ENV_PROVENANCE_KEYS if key in env}
+
+
+def _server_env_keys(server_cfg: dict[str, Any], env_overrides: dict[str, str]) -> list[str]:
+    server_env = server_cfg.get("env")
+    keys = set(env_overrides)
+    if isinstance(server_env, dict):
+        keys.update(str(key) for key in server_env)
+    return sorted(keys)
+
+
+def _runtime_python_executable(command: list[str], env: dict[str, str]) -> str:
+    if command:
+        first = str(command[0])
+        name = Path(first).name.lower()
+        if name.startswith("python") or "python" in name:
+            return first
+    return env.get("MODEL_PYTHON") or sys.executable
+
+
+def _collect_generation_parameters(tool_args: dict[str, Any], env: dict[str, str]) -> dict[str, Any]:
+    params = dict(tool_args)
+    for name, env_key in GENERATION_PARAMETER_ENV.items():
+        if name not in params and env.get(env_key):
+            params[name] = _parse_tool_arg_value(env[env_key])
+    device = env.get("SURE_EVAL_DEVICE_ACTUAL") or env.get("DEVICE")
+    if device and "device" not in params:
+        params["device"] = device
+    return params
+
+
+def _overall_generation_status(status_payload: dict[str, Any]) -> str | None:
+    if status_payload.get("status"):
+        return str(status_payload["status"])
+    datasets = status_payload.get("datasets")
+    if not isinstance(datasets, list):
+        return None
+    statuses = {
+        str(dataset.get("status") or "").lower()
+        for dataset in datasets
+        if isinstance(dataset, dict) and dataset.get("status")
+    }
+    if not statuses:
+        return None
+    if "failed" in statuses:
+        return "failed"
+    if statuses == {"completed"}:
+        return "completed"
+    if "running" in statuses:
+        return "running"
+    return sorted(statuses)[0]
+
+
+def _write_inference_provenance(
+    path: Path,
+    *,
+    run_dir: Path,
+    model_dir: Path,
+    model_cfg: dict[str, Any],
+    build_plan: dict[str, Any],
+    weights_manifest: dict[str, Any],
+    command: list[str],
+    working_dir: Path,
+    env: dict[str, str],
+    server_cfg: dict[str, Any],
+    protocol_id: str | None,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    protocol_standard_params: dict[str, Any],
+    protocol_model_params: dict[str, Any],
+    env_overrides: dict[str, str],
+    status_payload: dict[str, Any],
+) -> None:
+    generation_params = _collect_generation_parameters(tool_args, env)
+    resolved_model_params = dict(protocol_model_params)
+    resolved_model_params.update(generation_params)
+    datasets = status_payload.get("datasets")
+    if not isinstance(datasets, list):
+        datasets = []
+    payload = {
+        "schema": "sure.eval.inference_provenance.v1",
+        "generated_at": _utc_now(),
+        "run_id": status_payload.get("run_id"),
+        "run_dir": str(run_dir),
+        "model": {
+            "name": status_payload.get("model_name") or model_cfg.get("name") or model_dir.name,
+            "model_dir": str(model_dir),
+            "checkpoint_dir": env.get("MODEL_PATH") or model_cfg.get("checkpoint_dir"),
+            "artifacts": model_cfg.get("artifacts", {}),
+            "build_plan": build_plan,
+            "weights_manifest": weights_manifest,
+        },
+        "execution": {
+            "path": env.get("SURE_EVAL_EXECUTION_PATH"),
+            "requested_path": env.get("SURE_EVAL_EXECUTION_PATH_REQUESTED")
+            or env.get("SURE_EVAL_EXECUTION_REQUESTED"),
+            "job_id": env.get("SURE_EVAL_JOB_ID") or env.get("SURE_EVAL_EXECUTION_JOB_ID"),
+            "host": socket.gethostname(),
+            "device_request": env.get("SURE_EVAL_DEVICE_REQUEST") or env.get("DEVICE"),
+            "device_actual": env.get("SURE_EVAL_DEVICE_ACTUAL") or env.get("DEVICE"),
+            "cuda_visible_devices": env.get("CUDA_VISIBLE_DEVICES"),
+            "container_image": env.get("SURE_EVAL_CONTAINER_IMAGE"),
+            "container_repo_root": env.get("SURE_EVAL_CONTAINER_REPO_ROOT"),
+        },
+        "runtime": {
+            "python_executable": _runtime_python_executable(command, env),
+            "model_python": env.get("MODEL_PYTHON"),
+            "harness_python": env.get("SURE_EVAL_HARNESS_PYTHON_BIN")
+            or env.get("HARNESS_PYTHON_BIN")
+            or sys.executable,
+            "hf_home": env.get("HF_HOME"),
+            "modelscope_cache": env.get("MODELSCOPE_CACHE"),
+        },
+        "server": {
+            "command": command,
+            "working_dir": str(working_dir),
+            "env_keys": _server_env_keys(server_cfg, env_overrides),
+            "startup_timeout_sec": server_cfg.get("startup_timeout_sec"),
+            "timeout": server_cfg.get("timeout"),
+        },
+        "protocol_selection": {
+            "protocol_id": protocol_id,
+            "tool_name": tool_name,
+            "standard_params": protocol_standard_params,
+            "resolved_model_params": resolved_model_params,
+        },
+        "generation": {
+            "tool_args": tool_args,
+            "env_parameter_values": {
+                env_key: env[env_key]
+                for env_key in GENERATION_PARAMETER_ENV.values()
+                if env_key in env
+            },
+            "resolved_parameters": generation_params,
+        },
+        "environment": {
+            "safe_env_values": _safe_env_values(env),
+            "server_env_keys": _server_env_keys(server_cfg, env_overrides),
+        },
+        "datasets": datasets,
+        "status": _overall_generation_status(status_payload),
+    }
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
 def _resolve_server_command(
     model_dir: Path,
     server_cfg: dict[str, Any],
@@ -90,7 +269,10 @@ def _resolve_server_command(
 
     server_script_override = os.environ.get("SURE_EVAL_SERVER_SCRIPT_OVERRIDE")
     if server_script_override:
-        if len(command) == 1:
+        if "--model-dir" in command:
+            # The default adapter command's final argument is the model directory, not a server script.
+            pass
+        elif len(command) == 1:
             command.append(server_script_override)
         else:
             command[-1] = server_script_override
@@ -859,9 +1041,12 @@ def main() -> int:
         env["DEVICE"] = str(args.device)
         if str(args.device).lower() == "cpu" and "CUDA_VISIBLE_DEVICES" not in env:
             env["CUDA_VISIBLE_DEVICES"] = ""
-    env.update(_parse_env_overrides(args.env))
+    env_overrides = _parse_env_overrides(args.env)
+    env.update(env_overrides)
 
     # Inject protocol parameters into environment (backward-compatible)
+    protocol_standard_params: dict[str, Any] = {}
+    protocol_model_params: dict[str, Any] = {}
     if args.protocol and args.protocol.lower() != "none":
         env["SURE_EVAL_PROTOCOL_ID"] = args.protocol
         # Load protocol resolver if available
@@ -874,6 +1059,8 @@ def main() -> int:
             model_info = registry.get_model(model_dir.name)
             if model_info is not None:
                 resolved = resolver.resolve(args.protocol, model_info)
+                protocol_standard_params = dict(resolved.standard_params)
+                protocol_model_params = dict(resolved.model_params)
                 for key, value in resolved.standard_params.items():
                     env[f"SURE_EVAL_PROTOCOL_{key.upper()}"] = str(value)
                 for key, value in resolved.model_params.items():
@@ -905,6 +1092,7 @@ def main() -> int:
     log_path = logs_dir / f"{canonical_dataset}.log"
     result_log_path = logs_dir / f"{canonical_dataset}_results.log"
     status_path = run_dir / "prediction_generation_status.json"
+    provenance_path = run_dir / "inference_provenance.json"
 
     resume_exclude_keys: set[str] = set()
     if args.resume and args.resume_exclude_keys_file:
@@ -926,15 +1114,36 @@ def main() -> int:
         "run_id": run_dir.name,
         "model_name": model_dir.name,
         "execution_path": env.get("SURE_EVAL_EXECUTION_PATH", "unknown"),
-        "execution_requested": env.get("SURE_EVAL_EXECUTION_REQUESTED", ""),
-        "execution_job_id": env.get("SURE_EVAL_EXECUTION_JOB_ID", ""),
+        "execution_requested": env.get("SURE_EVAL_EXECUTION_PATH_REQUESTED")
+        or env.get("SURE_EVAL_EXECUTION_REQUESTED", ""),
+        "execution_job_id": env.get("SURE_EVAL_JOB_ID") or env.get("SURE_EVAL_EXECUTION_JOB_ID", ""),
         "inference_call_mode": "direct_server_use",
+        "inference_provenance": str(provenance_path),
         "protocol_id": args.protocol if args.protocol.lower() != "none" else None,
         "tool_name": tool_name,
         "host": socket.gethostname(),
         "device_request": env.get("SURE_EVAL_DEVICE_REQUEST", args.device or ""),
         "device_actual": env.get("SURE_EVAL_DEVICE_ACTUAL", args.device or ""),
         "cuda_visible_devices": env.get("CUDA_VISIBLE_DEVICES", ""),
+        "runtime": {
+            "python_executable": _runtime_python_executable(command, env),
+            "model_python": env.get("MODEL_PYTHON"),
+            "harness_python": env.get("SURE_EVAL_HARNESS_PYTHON_BIN")
+            or env.get("HARNESS_PYTHON_BIN")
+            or sys.executable,
+            "checkpoint_dir": env.get("MODEL_PATH"),
+        },
+        "server": {
+            "command": command,
+            "working_dir": str(working_dir),
+            "env_keys": _server_env_keys(server_cfg, env_overrides),
+            "startup_timeout_sec": server_cfg.get("startup_timeout_sec"),
+            "timeout": server_cfg.get("timeout"),
+        },
+        "generation": {
+            "tool_args": tool_args,
+            "resolved_parameters": _collect_generation_parameters(tool_args, env),
+        },
     }
     dataset_status = {
         "dataset": canonical_dataset,
@@ -948,7 +1157,29 @@ def main() -> int:
         "error": None,
     }
     status_payload, current_dataset_status = _upsert_dataset_status(status_path, default_status_payload, dataset_status)
+    for key, value in default_status_payload.items():
+        if key != "datasets":
+            status_payload[key] = value
     status_path.write_text(json.dumps(status_payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    _write_inference_provenance(
+        provenance_path,
+        run_dir=run_dir,
+        model_dir=model_dir,
+        model_cfg=model_cfg,
+        build_plan=build_plan,
+        weights_manifest=weights_manifest,
+        command=command,
+        working_dir=working_dir,
+        env=env,
+        server_cfg=server_cfg,
+        protocol_id=args.protocol if args.protocol.lower() != "none" else None,
+        tool_name=tool_name,
+        tool_args=tool_args,
+        protocol_standard_params=protocol_standard_params,
+        protocol_model_params=protocol_model_params,
+        env_overrides=env_overrides,
+        status_payload=status_payload,
+    )
 
     with open(log_path, "w", encoding="utf-8") as log_handle, open(result_log_path, "w", encoding="utf-8") as result_log_handle:
         if args.resume and existing_predictions:
@@ -1076,6 +1307,25 @@ def main() -> int:
                 json.dumps(status_payload, indent=2, ensure_ascii=False) + "\n",
                 encoding="utf-8",
             )
+            _write_inference_provenance(
+                provenance_path,
+                run_dir=run_dir,
+                model_dir=model_dir,
+                model_cfg=model_cfg,
+                build_plan=build_plan,
+                weights_manifest=weights_manifest,
+                command=command,
+                working_dir=working_dir,
+                env=env,
+                server_cfg=server_cfg,
+                protocol_id=args.protocol if args.protocol.lower() != "none" else None,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                protocol_standard_params=protocol_standard_params,
+                protocol_model_params=protocol_model_params,
+                env_overrides=env_overrides,
+                status_payload=status_payload,
+            )
 
         except Exception as exc:
             current_dataset_status["status"] = "failed"
@@ -1094,6 +1344,25 @@ def main() -> int:
             status_path.write_text(
                 json.dumps(status_payload, indent=2, ensure_ascii=False) + "\n",
                 encoding="utf-8",
+            )
+            _write_inference_provenance(
+                provenance_path,
+                run_dir=run_dir,
+                model_dir=model_dir,
+                model_cfg=model_cfg,
+                build_plan=build_plan,
+                weights_manifest=weights_manifest,
+                command=command,
+                working_dir=working_dir,
+                env=env,
+                server_cfg=server_cfg,
+                protocol_id=args.protocol if args.protocol.lower() != "none" else None,
+                tool_name=tool_name,
+                tool_args=tool_args,
+                protocol_standard_params=protocol_standard_params,
+                protocol_model_params=protocol_model_params,
+                env_overrides=env_overrides,
+                status_payload=status_payload,
             )
             raise
         finally:


### PR DESCRIPTION
## Summary
- Record inference provenance during prediction generation.
- Merge inference provenance/status/raw_response fields into protocol.yaml.
- Add a run report gate for missing observable inference parameters.

## Validation
- Python py_compile passed for the three changed scripts.
- Backfilled OpenMOSS protocol.yaml and results/protocol.yaml.
- Protocol gate returned errors: [].
- git diff --check passed.
- npm run check blocked by host GLIBC mismatch in Biome: requires GLIBC_2.29/2.30.
