### PR TITLE
Fix non-interactive runs ending cancelled: gate path resolution, headless finish, SIGINT handling

### DIFF
--- a/packages/coding-agent/src/core/sure/extension.ts
+++ b/packages/coding-agent/src/core/sure/extension.ts
@@ -87,6 +87,21 @@ interface ActiveRun {
 	skillPackage: SureSkillPackage;
 	hooks: SureHookRunner;
 	previousActiveTools: string[];
+	/** Set when an agent turn ended without sure_finish (excluding user aborts). */
+	finishMissing?: boolean;
+	/** Headless continuation prompts sent for this run. */
+	finishNudges?: number;
+}
+
+/** Cap on automatic continuation prompts for headless (print/json) runs. */
+const MAX_FINISH_NUDGES = 3;
+
+function buildFinishNudge(run: SureRunRecord): string {
+	return [
+		`Sure run ${run.runId} is still active, but the last turn ended without calling ${FINISH_TOOL_NAME}.`,
+		`Continue the run now: complete the remaining work, then call ${FINISH_TOOL_NAME} with the final manifest.`,
+		`If the run cannot proceed, call ${FINISH_TOOL_NAME} with status "failed" and summarize the blocker.`,
+	].join(" ");
 }
 
 function formatDiagnostics(diagnostics: SureDiscoveryDiagnostic[]): string {
@@ -892,7 +907,7 @@ export function createSureExtension(): ExtensionFactory {
 			return undefined;
 		});
 
-		pi.on("agent_end", async (_event, ctx) => {
+		pi.on("agent_end", async (event, ctx) => {
 			const active = activeRun;
 			if (!active) {
 				return;
@@ -909,6 +924,19 @@ export function createSureExtension(): ExtensionFactory {
 				"finish_missing",
 			);
 			ctx.ui.notify(`Sure run ${active.record.runId} is still waiting for ${FINISH_TOOL_NAME}.`, "warning");
+			const lastAssistant = [...event.messages].reverse().find((message) => message.role === "assistant");
+			const aborted =
+				lastAssistant !== undefined && "stopReason" in lastAssistant && lastAssistant.stopReason === "aborted";
+			if (aborted) {
+				// A deliberate interrupt keeps its cancel semantics on shutdown.
+				return;
+			}
+			active.finishMissing = true;
+			const headless = ctx.mode === "print" || ctx.mode === "json";
+			if (headless && (active.finishNudges ?? 0) < MAX_FINISH_NUDGES) {
+				active.finishNudges = (active.finishNudges ?? 0) + 1;
+				await pi.sendUserMessage(buildFinishNudge(active.record), { deliverAs: "followUp" });
+			}
 		});
 
 		pi.on("session_shutdown", async (_event, ctx) => {
@@ -917,7 +945,13 @@ export function createSureExtension(): ExtensionFactory {
 				return;
 			}
 			const runManager = new SureRunManager(active.record.cwd);
-			active.record = runManager.setStatus(active.record, "cancelled", "session_shutdown");
+			// A run abandoned by the agent (turn ended, no sure_finish) failed;
+			// "cancelled" is reserved for runs interrupted mid-work.
+			active.record = runManager.setStatus(
+				active.record,
+				active.finishMissing ? "failed" : "cancelled",
+				"session_shutdown",
+			);
 			pi.appendEntry("sure.run", active.record);
 			const onError = await active.hooks.run("on_error", {
 				run: active.record,

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -46,16 +46,19 @@ export async function runPrintMode(runtimeHost: AgentSessionRuntime, options: Pr
 	};
 
 	const registerSignalHandlers = (): void => {
-		const signals: NodeJS.Signals[] = ["SIGTERM"];
+		const signals: Array<[NodeJS.Signals, number]> = [
+			["SIGTERM", 143],
+			["SIGINT", 130],
+		];
 		if (process.platform !== "win32") {
-			signals.push("SIGHUP");
+			signals.push(["SIGHUP", 129]);
 		}
 
-		for (const signal of signals) {
+		for (const [signal, code] of signals) {
 			const handler = () => {
 				killTrackedDetachedChildren();
 				void disposeRuntime().finally(() => {
-					process.exit(signal === "SIGHUP" ? 129 : 143);
+					process.exit(code);
 				});
 			};
 			process.on(signal, handler);

--- a/packages/coding-agent/test/suite/sure-extension.test.ts
+++ b/packages/coding-agent/test/suite/sure-extension.test.ts
@@ -1233,6 +1233,76 @@ describe("print mode extension notify", () => {
 		return () => spy.mockRestore();
 	}
 
+	it("marks an active run terminal when print mode receives SIGINT", async () => {
+		const harness = await createHarness({ extensionFactories: [sureExtension] });
+		setupSkillPackage(harness.tempDir);
+
+		let releaseTurn: (() => void) | undefined;
+		harness.setResponses([
+			() =>
+				new Promise((resolve) => {
+					releaseTurn = () => resolve(fauxAssistantMessage("interrupted", { stopReason: "aborted" }));
+				}),
+		]);
+
+		const runtimeHost = {
+			session: harness.session,
+			setRebindSession: () => {},
+			dispose: async () => {
+				await emitSessionShutdownEvent(harness.session.extensionRunner, {
+					type: "session_shutdown",
+					reason: "quit",
+				});
+			},
+		} as unknown as Parameters<typeof runPrintMode>[0];
+
+		const exitCalls: number[] = [];
+		const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+			exitCalls.push(code ?? 0);
+			return undefined as never;
+		}) as typeof process.exit);
+		const previousSigintListeners = process.listeners("SIGINT");
+		process.removeAllListeners("SIGINT");
+
+		const runFile = () => {
+			const runsDir = join(harness.tempDir, ".sure", "runs");
+			if (!existsSync(runsDir)) {
+				return undefined;
+			}
+			const runIds = readdirSync(runsDir);
+			if (runIds.length !== 1) {
+				return undefined;
+			}
+			return join(runsDir, runIds[0], "run.json");
+		};
+
+		try {
+			const printPromise = runPrintMode(runtimeHost, { mode: "text", initialMessage: "/sure_feed topic" });
+			await waitForCondition(() => {
+				const file = runFile();
+				return file !== undefined && JSON.parse(readFileSync(file, "utf-8")).status === "running";
+			});
+
+			process.emit("SIGINT");
+			await waitForCondition(() => exitCalls.length > 0);
+
+			expect(exitCalls[0]).toBe(130);
+			const file = runFile();
+			expect(file).toBeDefined();
+			expect(JSON.parse(readFileSync(file as string, "utf-8")).status).toBe("cancelled");
+
+			releaseTurn?.();
+			await printPromise;
+		} finally {
+			process.removeAllListeners("SIGINT");
+			for (const listener of previousSigintListeners) {
+				process.on("SIGINT", listener);
+			}
+			exitSpy.mockRestore();
+			harness.cleanup();
+		}
+	});
+
 	it("routes /sure notify output to stdout in print mode", async () => {
 		const harness = await createHarness({ extensionFactories: [sureExtension] });
 		const runtimeHost = {

--- a/packages/coding-agent/test/suite/sure-extension.test.ts
+++ b/packages/coding-agent/test/suite/sure-extension.test.ts
@@ -4,7 +4,8 @@ import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai/compat
 import { Type } from "typebox";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAgentSessionServices } from "../../src/core/agent-session-services.ts";
-import type { ExtensionFactory, ExtensionUIContext } from "../../src/core/extensions/index.ts";
+import type { ExtensionFactory, ExtensionMode, ExtensionUIContext } from "../../src/core/extensions/index.ts";
+import { emitSessionShutdownEvent } from "../../src/core/extensions/runner.ts";
 import { SettingsManager } from "../../src/core/settings-manager.ts";
 import { sureExtension } from "../../src/core/sure/index.ts";
 import { runPrintMode } from "../../src/modes/print-mode.ts";
@@ -133,6 +134,7 @@ function writeEvalModel(tempDir: string, modelName = "demo-asr"): string {
 async function createSureHarness(options?: {
 	projectTrusted?: boolean;
 	uiContext?: ExtensionUIContext;
+	mode?: ExtensionMode;
 }): Promise<Harness> {
 	const harness = await createHarness({
 		extensionFactories: [sureExtension],
@@ -143,6 +145,7 @@ async function createSureHarness(options?: {
 	}
 	await harness.session.bindExtensions({
 		uiContext: options?.uiContext,
+		mode: options?.mode ?? "tui",
 		onError: (error) => {
 			throw new Error(JSON.stringify(error));
 		},
@@ -678,6 +681,78 @@ describe("Sure extension", () => {
 		const run = JSON.parse(readFileSync(join(harness.tempDir, ".sure", "runs", runId, "run.json"), "utf-8"));
 		expect(run.status).toBe("success");
 		expect(run.lastRepair).toBeUndefined();
+	});
+
+	it("nudges a print-mode run to continue when a turn ends without sure_finish", async () => {
+		const harness = await createSureHarness({ mode: "print" });
+		cleanups.push(harness.cleanup);
+		setupSkillPackage(harness.tempDir);
+
+		harness.setResponses([
+			fauxAssistantMessage("pausing before the manifest"),
+			() => {
+				const runId = getOnlyRunId(harness.tempDir);
+				writeValidManifest(harness.tempDir, runId);
+				return fauxAssistantMessage(
+					fauxToolCall("sure_finish", {
+						status: "success",
+						manifest_path: `.sure/runs/${runId}/manifest.json`,
+						summary: "done",
+					}),
+				);
+			},
+		]);
+
+		await harness.session.prompt("/sure_feed topic");
+		await harness.session.agent.waitForIdle();
+
+		const runId = getOnlyRunId(harness.tempDir);
+		const run = JSON.parse(readFileSync(join(harness.tempDir, ".sure", "runs", runId, "run.json"), "utf-8"));
+		expect(run.status).toBe("success");
+		expect(getUserTexts(harness).some((text) => text.includes("is still active"))).toBe(true);
+	});
+
+	it("stops nudging a print-mode run after the retry budget and fails it on shutdown", async () => {
+		const harness = await createSureHarness({ mode: "print" });
+		cleanups.push(harness.cleanup);
+		setupSkillPackage(harness.tempDir);
+
+		harness.setResponses([
+			fauxAssistantMessage("turn 1"),
+			fauxAssistantMessage("turn 2"),
+			fauxAssistantMessage("turn 3"),
+			fauxAssistantMessage("turn 4"),
+			fauxAssistantMessage("turn 5"),
+		]);
+
+		await harness.session.prompt("/sure_feed topic");
+		await harness.session.agent.waitForIdle();
+
+		expect(harness.getPendingResponseCount()).toBe(1);
+
+		await emitSessionShutdownEvent(harness.session.extensionRunner, { type: "session_shutdown", reason: "quit" });
+
+		const runId = getOnlyRunId(harness.tempDir);
+		const run = JSON.parse(readFileSync(join(harness.tempDir, ".sure", "runs", runId, "run.json"), "utf-8"));
+		expect(run.status).toBe("failed");
+		expect(run.lastRepair).toContain("sure_finish");
+	});
+
+	it("keeps cancelled status when the run was interrupted rather than left unfinished", async () => {
+		const harness = await createSureHarness({ mode: "print" });
+		cleanups.push(harness.cleanup);
+		setupSkillPackage(harness.tempDir);
+
+		harness.setResponses([fauxAssistantMessage("interrupted", { stopReason: "aborted" })]);
+
+		await harness.session.prompt("/sure_feed topic");
+		await harness.session.agent.waitForIdle();
+
+		await emitSessionShutdownEvent(harness.session.extensionRunner, { type: "session_shutdown", reason: "quit" });
+
+		const runId = getOnlyRunId(harness.tempDir);
+		const run = JSON.parse(readFileSync(join(harness.tempDir, ".sure", "runs", runId, "run.json"), "utf-8"));
+		expect(run.status).toBe("cancelled");
 	});
 
 	it("accepts required artifacts recorded with concrete run-relative paths", async () => {

--- a/sure/skills/sure_eval/scripts/evaluate_predictions.py
+++ b/sure/skills/sure_eval/scripts/evaluate_predictions.py
@@ -2003,13 +2003,15 @@ def _write_run_artifacts(
         row = payload_rows[index] if index < len(payload_rows) and isinstance(payload_rows[index], dict) else _dataset_metric_row(result)
         row = dict(row)
         artifacts = dict(row.get("artifacts") or {})
+        # check_run_report resolves relative payload paths against the run
+        # root, so record absolute paths even when --run-dir was relative.
         artifacts.update(
             {
-                "metric_artifact_dir": str(metric_dir),
-                "report": str(report_path),
-                "pipeline_description": str(pipeline_path),
-                "sample_report": str(sample_report_path),
-                "prediction_file": str(Path(result["prediction_path"])),
+                "metric_artifact_dir": str(metric_dir.resolve()),
+                "report": str(report_path.resolve()),
+                "pipeline_description": str(pipeline_path.resolve()),
+                "sample_report": str(sample_report_path.resolve()),
+                "prediction_file": str(Path(result["prediction_path"]).resolve()),
             }
         )
         row["artifacts"] = artifacts
@@ -2017,8 +2019,8 @@ def _write_run_artifacts(
         pipeline_payload.update(
             {
                 "pipeline_id": row.get("pipeline_id") or result.get("pipeline_id"),
-                "report_path": str(report_path),
-                "description_path": str(pipeline_path),
+                "report_path": str(report_path.resolve()),
+                "description_path": str(pipeline_path.resolve()),
             }
         )
         row["pipeline"] = pipeline_payload

--- a/sure/skills/sure_eval/scripts/test_payload_artifact_paths.py
+++ b/sure/skills/sure_eval/scripts/test_payload_artifact_paths.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import check_run_report
+import evaluate_predictions
+
+
+class PayloadArtifactPathTests(unittest.TestCase):
+    """The vc runner invokes evaluate_predictions.py with a repo-relative
+    --run-dir, so payload artifact paths must never depend on the cwd the
+    writer happened to run from (check_run_report resolves relative paths
+    against the run root)."""
+
+    def setUp(self) -> None:
+        self._previous_cwd = Path.cwd()
+        self._temporary = tempfile.TemporaryDirectory()
+        os.chdir(self._temporary.name)
+
+    def tearDown(self) -> None:
+        os.chdir(self._previous_cwd)
+        self._temporary.cleanup()
+
+    def _write_artifacts(self, run_dir: Path) -> dict:
+        external = Path("external_artifacts")
+        external.mkdir(parents=True, exist_ok=True)
+        sample_source = external / "sample.jsonl"
+        sample_source.write_text('{"key": "utt1"}\n', encoding="utf-8")
+        prediction_source = external / "ds__v1.txt"
+        prediction_source.write_text("utt1\thello\n", encoding="utf-8")
+        result = {
+            "schema": "sure.eval.payload.dataset_metric.v2",
+            "dataset": "ds__v1",
+            "metric": "cer",
+            "pipeline_id": "p1",
+            "result": {"score": 0.1},
+            "prediction_path": str(prediction_source),
+            "sample_report_path": str(sample_source),
+        }
+        evaluate_predictions._write_run_artifacts(
+            run_dir=run_dir,
+            tool_name="model",
+            protocol_id="standard_system",
+            model_dir=None,
+            payload={"schema": "sure.eval.payload.v2", "results": [dict(result)]},
+            results=[result],
+        )
+        return json.loads((run_dir / "evaluation_payload.json").read_text(encoding="utf-8"))
+
+    def test_artifact_paths_do_not_depend_on_writer_cwd(self) -> None:
+        run_dir = Path("sure/results/model/standard_system/run-1")
+        payload = self._write_artifacts(run_dir)
+        artifacts = payload["results"][0]["artifacts"]
+        metric_dir = run_dir.resolve() / "metrics" / "ds__v1" / "cer"
+        self.assertEqual(Path(artifacts["metric_artifact_dir"]), metric_dir)
+        self.assertEqual(Path(artifacts["report"]), metric_dir / "report.json")
+        self.assertEqual(Path(artifacts["pipeline_description"]), metric_dir / "pipeline_description.json")
+        self.assertEqual(
+            Path(artifacts["sample_report"]),
+            run_dir.resolve() / "sample_reports" / "ds__v1" / "cer.jsonl",
+        )
+        self.assertTrue(Path(artifacts["prediction_file"]).is_absolute())
+        pipeline = payload["results"][0]["pipeline"]
+        self.assertEqual(Path(pipeline["report_path"]), metric_dir / "report.json")
+        self.assertEqual(Path(pipeline["description_path"]), metric_dir / "pipeline_description.json")
+
+    def test_gate_locates_metric_artifacts_written_from_relative_run_dir(self) -> None:
+        run_dir = Path("sure/results/model/standard_system/run-1")
+        self._write_artifacts(run_dir)
+        errors = check_run_report._validate_completed_artifacts(run_dir.resolve())
+        missing = [
+            error
+            for error in errors
+            if "missing metric report" in error
+            or "missing pipeline description" in error
+            or "missing sample report" in error
+        ]
+        self.assertEqual(missing, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Non-interactive runs (`pi-test.sh --approve -p "/sure_eval ..."`) were consistently ending in `cancelled` even when the underlying evaluation succeeded. Three independent bugs, one commit each:

## 1. `fix(sure): resolve payload artifact paths at write time`

`evaluate_predictions.py` recorded artifact paths exactly as derived from `--run-dir`. When the run dir was passed as a relative path, the payload contained cwd-relative paths, but `check_run_report.py` resolves relative payload paths against the run root — producing a doubled, nonexistent path and failing the gate. A 69-minute vc run whose evaluation had actually succeeded was killed by this. Artifact paths are now resolved to absolute at write time.

**Note:** payloads already written by older versions keep their relative paths — re-validating an old run (e.g. reval reuse) can still trip the gate; regenerate the payload or fix the paths in place.

## 2. `fix(sure): keep headless runs alive until sure_finish`

In print/json mode, `session.prompt()` returns when the agent *turn* ends, not when the *run* ends. Any mid-run turn termination (LLM timeout, provider hiccup) ended the process, and the `session_shutdown` handler stamped the still-active run `cancelled` — indistinguishable from a deliberate interrupt. Now:

- In headless modes (`print`/`json`), a turn ending without `sure_finish` queues a follow-up message nudging the agent to continue or finish with status `failed` (bounded at 3 attempts).
- If the session still shuts down with the run unfinished, the run is stamped `failed` instead of `cancelled`.
- Turns aborted by the user (`stopReason === "aborted"`) keep the `cancelled` semantics.

## 3. `fix(print): handle SIGINT like SIGTERM`

Print mode only handled SIGTERM, so Ctrl-C skipped cleanup entirely and left runs stuck in `running` forever. SIGINT (exit 130) and, on POSIX, SIGHUP (exit 129) now go through the same cleanup path as SIGTERM.

## Verification

- New python unittest (`test_payload_artifact_paths.py`) reproduces the exact doubled-path failure and goes green with the fix; all 21 sure_eval script test files pass.
- 4 new vitest cases: nudge-then-finish reaches `success`, nudge bound then shutdown reaches `failed`, user-aborted turn stays `cancelled`, SIGINT exits 130 with a terminal run state.
- Full vitest suite baseline comparison on Linux: no new failures introduced (failing files went 16 → 12; 4 previously failing files now pass).
- End-to-end: a real non-interactive `/sure_eval` against the vc cluster (aishell-1-test, `max_samples=8`) completed with `run.json` status `success` and the run-report gate passing.
