### PR TITLE
fix(coding-agent): preserve harness runtime binding schema

### DIFF
--- a/packages/coding-agent/test/suite/sure-runtime-binding.test.ts
+++ b/packages/coding-agent/test/suite/sure-runtime-binding.test.ts
@@ -50,6 +50,26 @@ describe("SURE skill runtime responsibility binding", () => {
 		expect(payload.runtimes.evaluation.required).toBe(false);
 	});
 
+	it("normalizes a bootstrap manifest schema into a Harness Runtime binding", () => {
+		const manifestContract = {
+			...harness,
+			schema: "sure.harness.runtime.manifest.v1",
+		} as HarnessRuntimeContract;
+		const path = writeSkillRuntimeBinding({
+			runDir: root,
+			skill: "sure_feed",
+			harnessRuntime: manifestContract,
+			harnessRole: "research and gates",
+			modelRuntimeReason: "no inference",
+			evaluationRuntime: { reason: "no evaluation" },
+		});
+
+		const payload = JSON.parse(readFileSync(path, "utf-8"));
+		expect(payload.runtimes.harness.binding.schema).toBe("sure.harness.runtime.binding.v1");
+		expect(payload.runtimes.harness.binding.runtime_type).toBe("harness_python");
+		expect(validateSkillRuntimeBinding(path, "sure_feed", false)).toBeUndefined();
+	});
+
 	it("validates Reval with Harness and Evaluation runtimes cross-bound", () => {
 		const evaluationRoot = join(root, "evaluation");
 		const evaluationPython = join(evaluationRoot, "bin", "python");

--- a/sure/runtime/usage.ts
+++ b/sure/runtime/usage.ts
@@ -28,9 +28,9 @@ export interface SkillRuntimeBindingOptions {
 
 function harnessBinding(contract: HarnessRuntimeContract): Record<string, unknown> {
 	return {
+		...contract,
 		schema: "sure.harness.runtime.binding.v1",
 		runtime_type: "harness_python",
-		...contract,
 	};
 }
 


### PR DESCRIPTION
## Summary

- Preserve the Harness Runtime binding schema when serializing a bootstrap runtime contract.
- Keep `runtime_type` normalized to `harness_python`.
- Add a regression test using the manifest schema produced by bootstrap.

## Root cause

`harnessBinding()` assigned the binding fields before spreading the bootstrap contract. Because that contract carries `sure.harness.runtime.manifest.v1`, the spread silently overwrote the required `sure.harness.runtime.binding.v1` schema and produced an artifact rejected by validation and `sure_finish`.

The fix only moves the contract spread before the two normalized binding fields.

## Verification

- Targeted Vitest suite: 4/4 tests passed.
- Biome check on both changed files: passed.
- Full `npm run check`: 9/11 check groups passed.

The two full-check failures are unrelated to this diff:

- Existing Biome import-order issue in `packages/coding-agent/src/core/sure/output-dir.ts` (unchanged on this branch).
- `check:site-boundary` invokes the system Python, where PyYAML is unavailable in this environment.
