### PR TITLE
docs: clarify approved model handoff

### DIFF
--- a/sure/skills/sure_feed/SKILL.md
+++ b/sure/skills/sure_feed/SKILL.md
@@ -144,6 +144,6 @@ Each unit below lists: **Inputs** (what to read), **Output** (produces + schema)
 
 ## Cross-Skill Handoff
 
-`sure/handoffs/<model_name>/model_input.yaml` → `/sure_onboard model=<model_name>` or `/sure_onboard model_input_path=sure/handoffs/<model_name>/model_input.yaml` → model onboarded into global `sure/models/<model_id>/` with `verdict.json` → `/sure_eval model=<id>` reads that `verdict.json` to judge readiness. `sure/handoffs/<model_name>/artifacts/feed_report.json` is the user-facing run summary; `artifacts/debug/handoff_manifest.json` is retained as the terminal state-machine artifact.
+`sure/handoffs/<model_name>/model_input.yaml` → `/sure_onboard model=<model_name>` or `/sure_onboard model_input_path=sure/handoffs/<model_name>/model_input.yaml` → model staged under `sure/models/<model_name>/` with `artifacts/deployment_ready.json` → an operator reviews and copies the complete model directory into a configured `approved_models_roots` entry → `/sure_eval model=<model_name>` resolves only that approved copy. `sure/handoffs/<model_name>/artifacts/feed_report.json` is the user-facing run summary; `artifacts/debug/handoff_manifest.json` is retained as the terminal state-machine artifact.
 
 See `references/agents.md` for the full matching contract, false-positive case, and backend routing table.


### PR DESCRIPTION
## Summary

- Correct the `/sure_feed` cross-skill handoff documentation.
- Identify `sure/models/<model_name>` as onboarding staging, not an Eval input.
- Include the required operator promotion into `approved_models_roots` before `/sure_eval`.

## Why

The previous handoff sentence said `/sure_eval` reads the staged verdict under `sure/models`. The Eval contract intentionally rejects that directory and resolves only human-approved model copies, so following the Feed document could lead directly to a failed Eval invocation.

## Verification

- `git diff --check`
- `npm run check:sure-hooks`
