### PR TITLE
fix(coding-agent): decouple reval from model runtime

### DIFF
--- a/sure/skills/sure_eval/scripts/resolve_model_dir.py
+++ b/sure/skills/sure_eval/scripts/resolve_model_dir.py
@@ -26,6 +26,7 @@ APPROVED_MODELS_ROOT = (
     else None
 )
 MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+SUCCESSFUL_VERDICT_STATUSES = frozenset({"pass", "passed", "success"})
 
 
 def configured_approved_models_root() -> Path:
@@ -44,13 +45,10 @@ def _is_relative_to(path: Path, root: Path) -> bool:
 def _verdict_path(model_dir: Path | None) -> Path | None:
     if model_dir is None:
         return None
-    for path in (model_dir / "verdict.json", model_dir / "artifacts" / "verdict.json"):
+    for path in (model_dir / "artifacts" / "verdict.json", model_dir / "verdict.json"):
         if path.is_file() and _is_relative_to(path.resolve(), model_dir):
             return path
     return None
-
-
-TERMINAL_VERDICT_STATUSES = {"success", "passed", "pass"}
 
 
 def verdict_is_ready(model_dir: Path | None) -> bool:
@@ -59,14 +57,8 @@ def verdict_is_ready(model_dir: Path | None) -> bool:
     The file existing proves a transformation ran, not that it succeeded; a
     bundle sealed alongside a failed verdict would otherwise resolve as ready.
     """
-    path = _verdict_path(model_dir)
-    if path is None:
-        return False
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return False
-    return isinstance(value, dict) and str(value.get("status", "")).lower() in TERMINAL_VERDICT_STATUSES
+    ready, _, _ = _successful_verdict(_verdict_path(model_dir))
+    return ready
 
 
 def _checks(model_dir: Path | None) -> dict[str, bool]:
@@ -101,7 +93,28 @@ def _checks(model_dir: Path | None) -> dict[str, bool]:
     }
 
 
-def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_MODELS_ROOT) -> dict[str, Any]:
+def _successful_verdict(path: Path | None) -> tuple[bool, str | None, str | None]:
+    if path is None:
+        return False, None, "approved model verdict is missing"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, None, f"approved model verdict is invalid: {exc}"
+    if not isinstance(value, dict):
+        return False, None, "approved model verdict must be a JSON object"
+    status = str(value.get("status") or "")
+    if status.lower() not in SUCCESSFUL_VERDICT_STATUSES:
+        return False, status or None, f"approved model verdict status is not successful: {status!r}"
+    return True, status, None
+
+
+def resolve_approved_model_identity(
+    model: str,
+    *,
+    approved_root: Path | None = APPROVED_MODELS_ROOT,
+) -> dict[str, Any]:
+    """Resolve approved model identity without requiring an inference runtime."""
+
     if not MODEL_ID_RE.fullmatch(model):
         raise ValueError(f"invalid model id {model!r}; path separators and aliases are not allowed")
     root = (approved_root or configured_approved_models_root()).expanduser().resolve()
@@ -114,6 +127,30 @@ def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_
     selected = model_dir if model_dir.is_dir() else None
     verdict = _verdict_path(selected)
     checks = _checks(selected)
+    verdict_ready, verdict_status, verdict_error = _successful_verdict(verdict)
+    config_ready = checks["config_yaml"]
+    identity_error = verdict_error
+    if selected is not None and not config_ready:
+        identity_error = "approved model config.yaml is missing"
+    return {
+        "schema": "sure.approved_model.identity.v1",
+        "ok": bool(selected and config_ready and verdict_ready),
+        "model": model,
+        "model_dir": str(selected) if selected else None,
+        "source": "approved_nfs_models",
+        "approved_models_root": str(root),
+        "config_path": str((selected / "config.yaml").resolve()) if selected and config_ready else None,
+        "verdict_path": str(verdict.resolve()) if verdict else None,
+        "verdict_status": verdict_status,
+        "verdict_ready": verdict_ready,
+        "identity_error": identity_error,
+        "checks": checks,
+    }
+
+
+def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_MODELS_ROOT) -> dict[str, Any]:
+    identity = resolve_approved_model_identity(model, approved_root=approved_root)
+    selected = Path(identity["model_dir"]) if identity["model_dir"] else None
     deployment_binding = None
     deployment_error = None
     if selected is not None:
@@ -122,20 +159,22 @@ def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_
         except DeploymentBindingError as exc:
             deployment_error = str(exc)
     runtime_ready = deployment_binding is not None
-    verdict_ready = verdict_is_ready(selected)
+    verdict_ready = bool(identity["verdict_ready"])
     return {
         "schema": "sure.eval.approved_model_resolution.v1",
-        "ok": bool(selected and runtime_ready and verdict_ready),
+        "ok": bool(identity["ok"] and runtime_ready),
         "model": model,
-        "model_dir": str(selected) if selected else None,
-        "source": "approved_nfs_models",
-        "approved_models_root": str(root),
-        "verdict_path": str(verdict.resolve()) if verdict else None,
+        "model_dir": identity["model_dir"],
+        "source": identity["source"],
+        "approved_models_root": identity["approved_models_root"],
+        "verdict_path": identity["verdict_path"],
+        "verdict_status": identity["verdict_status"],
         "runtime_ready": runtime_ready,
         "verdict_ready": verdict_ready,
         "deployment_binding": deployment_binding,
         "deployment_error": deployment_error,
-        "checks": checks,
+        "identity_error": identity["identity_error"],
+        "checks": identity["checks"],
     }
 
 

--- a/sure/skills/sure_eval/scripts/resolve_prediction_source.py
+++ b/sure/skills/sure_eval/scripts/resolve_prediction_source.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import yaml
 
-from resolve_model_dir import APPROVED_MODELS_ROOT, resolve_approved_model
+from resolve_model_dir import APPROVED_MODELS_ROOT, resolve_approved_model_identity
 
 for _parent in Path(__file__).resolve().parents:
     if (_parent / "sure" / "site" / "loader.py").is_file():
@@ -160,9 +160,10 @@ def build_payload(
     if len(requested) != len(set(requested)):
         raise ValueError("requested datasets contain duplicate canonical identities")
 
-    model_resolution = resolve_approved_model(model, approved_root=approved_models_root)
+    model_resolution = resolve_approved_model_identity(model, approved_root=approved_models_root)
     if not model_resolution["ok"]:
-        raise ValueError(f"model {model!r} is not approved and runtime-ready in NFS")
+        detail = model_resolution.get("identity_error") or "approved model identity is incomplete"
+        raise ValueError(f"model {model!r} is not approved with a successful verdict in NFS: {detail}")
     model_dir = Path(str(model_resolution["model_dir"]))
 
     if approved_results_root is None:

--- a/sure/skills/sure_eval/scripts/test_reval_prediction_source.py
+++ b/sure/skills/sure_eval/scripts/test_reval_prediction_source.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from resolve_model_dir import resolve_approved_model_identity
+from resolve_prediction_source import build_payload
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+class RevalPredictionSourceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        root = Path(self.temp.name)
+        self.models = root / "models"
+        self.results = root / "results"
+        self.model = self.models / "demo"
+        self.model.mkdir(parents=True)
+        (self.model / "config.yaml").write_text("task: ASR\n", encoding="utf-8")
+        write_json(self.model / "artifacts" / "verdict.json", {"status": "success"})
+
+        result = self.results / "demo" / "approved-run"
+        predictions = result / "predictions"
+        predictions.mkdir(parents=True)
+        (result / "protocol.yaml").write_text("protocol_id: standard_system\n", encoding="utf-8")
+        write_json(
+            result / "report.jsonl",
+            {
+                "dataset": {"name": "aishell1__v1.0.2"},
+                "run": {"protocol_id": "standard_system"},
+                "model": {"model_name": "demo"},
+                "prediction": {"file": "aishell1__v1.0.2.txt"},
+            },
+        )
+        (predictions / "aishell1__v1.0.2.txt").write_text("sample-1\tprediction\n", encoding="utf-8")
+
+    def args(self) -> argparse.Namespace:
+        return argparse.Namespace(
+            model="demo",
+            datasets=["aishell1__v1.0.2"],
+            protocol_id="standard_system",
+        )
+
+    def test_resolves_approved_predictions_without_deployment_runtime_artifacts(self) -> None:
+        payload = build_payload(
+            self.args(),
+            approved_models_root=self.models,
+            approved_results_root=self.results,
+        )
+
+        self.assertEqual(payload["model_name"], "demo")
+        self.assertFalse(payload["inference_allowed"])
+        self.assertFalse((self.model / "artifacts" / "deployment_ready.json").exists())
+
+    def test_identity_rejects_non_successful_verdict(self) -> None:
+        write_json(self.model / "artifacts" / "verdict.json", {"status": "partial"})
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertFalse(identity["ok"])
+        self.assertIn("not successful", identity["identity_error"])
+        with self.assertRaisesRegex(ValueError, "successful verdict"):
+            build_payload(
+                self.args(),
+                approved_models_root=self.models,
+                approved_results_root=self.results,
+            )
+
+    def test_identity_prefers_artifacts_verdict_over_legacy_top_level(self) -> None:
+        write_json(self.model / "verdict.json", {"status": "success"})
+        write_json(self.model / "artifacts" / "verdict.json", {"status": "failed"})
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertFalse(identity["ok"])
+        self.assertEqual(identity["verdict_status"], "failed")
+        self.assertEqual(identity["verdict_path"], str((self.model / "artifacts" / "verdict.json").resolve()))
+
+    def test_identity_falls_back_to_legacy_top_level_verdict(self) -> None:
+        (self.model / "artifacts" / "verdict.json").unlink()
+        write_json(self.model / "verdict.json", {"status": "success"})
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertTrue(identity["ok"])
+        self.assertEqual(identity["verdict_path"], str((self.model / "verdict.json").resolve()))
+
+    def test_identity_requires_config(self) -> None:
+        (self.model / "config.yaml").unlink()
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertFalse(identity["ok"])
+        self.assertEqual(identity["identity_error"], "approved model config.yaml is missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_reval/SKILL.md
+++ b/sure/skills/sure_reval/SKILL.md
@@ -42,7 +42,7 @@ Example:
 
 ## State Machine
 
-1. `resolve_approved_model`: resolve the exact model below the NFS model root and require runtime files plus verdict existence.
+1. `resolve_approved_model`: resolve the exact model below the NFS model root and require `config.yaml` plus a successful verdict. Model deployment runtime files are not read because re-evaluation never runs inference.
 2. `resolve_approved_result`: inspect only immediate approved result directories for that model.
 3. `verify_source_identity`: require exact model, protocol, and sorted dataset-set equality; bind the NFS report, model fingerprint, prediction hashes, and sample counts.
 4. `resolve_evaluation_route`: resolve every requested exact `pipeline_id` through the standalone sure-evaluation engine.


### PR DESCRIPTION
## Summary

- separate approved model identity validation from inference runtime readiness
- let `/sure_reval` resolve successful approved models without Docker deployment artifacts
- keep `/sure_eval` on the existing runtime-ready deployment resolver
- add regression coverage for prediction-source resolution without container sidecars

## Tests

- `python -m unittest test_reval_prediction_source.py test_dataset_alias.py test_deployment_binding.py` using the locked Harness Python: 29 passed
- `npm run check:sure-hooks`
- `npm run check:site-boundary` using the locked Harness Python
- `npm run check`: 9/11 checks passed; target branch already fails Biome on import order in `packages/coding-agent/src/core/sure/output-dir.ts`, and the default system Python lacks PyYAML
- `./test.sh`: agent and TUI suites passed; coding-agent has 99 environment/baseline failures dominated by missing `packages/tui/dist` and root-only permission behavior
