### PR TITLE
feat(sure): support approved local Python evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A model score is useful only when people can establish exactly how it was produc
 SURE gives you both automation and experimental credibility:
 
 - **Deploy and evaluate with integrated commands.** Start a complete discovery, adaptation, deployment, or evaluation stage with one slash command instead of manually assembling scripts and environments.
-- **Reproduce the whole system, not just the score.** Every result is tied to the inference implementation, model and Harness Runtime, immutable image digest, parameters, dataset version, evaluation engine commit, exact pipeline, and reports.
+- **Reproduce the whole system, not just the score.** Every result is tied to the inference implementation, approved model and Harness Runtime identities, parameters, dataset version, evaluation engine commit, exact pipeline, and reports. Container runs also bind an immutable image digest.
 - **Make results credible and comparable.** Two results can be compared against the concrete framework, configuration, inputs, normalization, and metric route that produced them, rather than against an unexplained number.
 - **Keep automation accountable.** Agents handle research and adaptation, while deterministic state machines, schemas, smoke tests, and container checks reject incomplete or inconsistent work.
 
@@ -39,7 +39,7 @@ Model repository       Runnable deployment       Predictions + metrics       New
 | Workflow | What the agent does | Reproducible product |
 | --- | --- | --- |
 | Discover | Researches a Hugging Face, ModelScope, or GitHub model and resolves its capabilities, runtime, fixtures, and I/O contract | Canonical `model_input.yaml` plus source evidence |
-| Onboard | Adapts and validates the model, generates a runnable inference package when needed, and seals local models in a digest-pinned OCI image | Portable model bundle plus `deployment_ready.json` |
+| Onboard | Adapts and validates the model, then seals either an approved Python runtime or a digest-pinned OCI image | Portable model bundle plus `deployment_ready.json` |
 | Evaluate | Runs approved inference, resolves a deterministic evaluation route, and computes metrics | Predictions, protocol, reports, metrics, and sample-level evidence |
 | Re-evaluate | Reuses approved predictions with an explicit pipeline | A new evaluation batch without repeating inference |
 
@@ -64,9 +64,9 @@ The following path was designed for a Bash-compatible Linux environment.
 - Git
 - Python 3.11 and [uv](https://docs.astral.sh/uv/)
 - Credentials for at least one supported coding-agent provider
-- Docker and access to an OCI registry when onboarding or evaluating a local model
+- Docker and access to an OCI registry only when using `package=docker-registry`
 
-The registry must support authenticated push and digest-pinned pull from the machine that runs SURE. API-only model onboarding does not require a local model image.
+`uv` bootstraps SURE's locked Harness Runtime. Model runtimes may use `uv`, `pip`, `conda`, or `pixi`. For container delivery, the registry must support authenticated push and digest-pinned pull from the machine that runs SURE.
 
 ### 2. Clone and install
 
@@ -111,6 +111,9 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container
 EOF
 
 npm run sure:site-info
@@ -167,7 +170,7 @@ Consume the handoff by its normalized directory name:
 /sure_onboard model=Qwen__Qwen3-ASR-1.7B
 ```
 
-For a local model, SURE researches the upstream implementation, materializes an isolated model runtime, generates or repairs the adapter, validates import/load/inference and the tool contract, builds an OCI image, pushes it, and verifies the immutable digest. A successful bundle ends with:
+For a local model, SURE researches the upstream implementation, materializes an isolated model runtime, generates or repairs the adapter, and validates import/load/inference and the tool contract. The default public policy publishes that locked Python runtime directly. A successful bundle ends with:
 
 ```text
 sure/models/Qwen__Qwen3-ASR-1.7B/artifacts/deployment_ready.json
@@ -175,7 +178,7 @@ sure/models/Qwen__Qwen3-ASR-1.7B/artifacts/deployment_ready.json
 
 `deployment_ready.json` is a readiness marker, not an approval. Review the complete model directory, then copy that directory into one of the configured `approved_models_roots`. `/sure_eval` only accepts the exact directory name below an approved root.
 
-Local models require the default `docker-registry` package profile and a usable registry; a local-only Docker tag is not Eval-ready. See [`/sure_onboard`](./sure/skills/sure_onboard/SKILL.md) for API models, explicit handoff paths, device selection, and repair flows.
+Use `package=docker-registry` when you need immutable container delivery or VC execution; it adds image build, validation, registry push, digest resolution, and pull verification. `package=docker-local` remains diagnostic-only. See [`/sure_onboard`](./sure/skills/sure_onboard/SKILL.md) for runtime selection, API models, explicit handoff paths, device selection, and repair flows.
 
 ### Evaluate an approved model with `/sure_eval`
 
@@ -236,7 +239,7 @@ Each metric is an explicit pipeline of versioned nodes. You can select different
 Provider credentials and site policy are separate:
 
 - `/sure_init` configures the coding-agent provider and authentication.
-- The site policy configures approved storage roots, forbidden output roots, dataset roots, a runtime cache root, and allowed execution surfaces.
+- The site policy configures approved storage roots, forbidden output roots, dataset roots, a runtime cache root, allowed execution surfaces, and allowed local runtime kinds.
 
 Site-policy sources use this fixed precedence:
 

--- a/config/site.example.yaml
+++ b/config/site.example.yaml
@@ -18,3 +18,6 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -46,6 +46,7 @@ The machine-readable contract is [sure/site/policy.schema.json](../sure/site/pol
 | `storage.runtime_root` | yes | Declared site-owned cache root for adapters and future runtime placement |
 | `datasets.allowed_source_roots` | yes | Roots accepted by the strict dataset source resolver |
 | `execution.surfaces` | yes | Enabled execution surfaces: `local`, `vc`, or both |
+| `execution.local_runtimes` | optional | Local runtime kinds: `python`, `container`, or both; omitted policies default to `container` |
 | `execution.vc_partitions` | when needed | Declared VC partitions for adapters and deployment documentation |
 | `execution.vc_partition_priority` | optional | Numeric priority map used by automatic VC selection |
 | `network` | optional | Non-secret site endpoints used by private adapters and documentation |
@@ -55,6 +56,8 @@ Unknown fields, duplicate list values, unsupported surfaces, and relative paths 
 Policy v1 accepts exactly one path in each root list. The list shape leaves room for a future multi-root contract, but the current workflow preserves its historical single-root selection semantics.
 
 `execution.surfaces` constrains automatic and explicit execution selection. `execution.vc_partitions` documents site choices but does not replace the existing live `vc info -u` authorization check; changing partition authorization semantics is outside this separation phase.
+
+`execution.local_runtimes` is an execution permission, not a package-manager choice. `python` allows an approved model runtime created by `uv`, `pip`, `conda`, or `pixi`; `container` allows local Docker execution. Existing policy files that omit the field remain container-only.
 
 ## Path Semantics
 
@@ -89,6 +92,9 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container
 ```
 
 For shared storage, replace these placeholders with roots visible to every host and container that executes a workflow. For a local-only fixture, create temporary model, result, dataset, and runtime roots and point the local policy at them.

--- a/packages/coding-agent/test/suite/sure-eval-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-eval-state-machine.test.ts
@@ -157,6 +157,7 @@ function seedCompletedEvaluationArtifacts(runDir: string): string {
 			"  env: {}",
 			"  runtime_inventory:",
 			"    schema: sure.onboard.runtime_inventory.v2",
+			"    execution_mode: container_only",
 			"  mount_policy:",
 			"    nfs_models_read_only: true",
 			"inference_constraints: {}",

--- a/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
@@ -637,6 +637,7 @@ describe("sure_onboard MODEL_INPUT materializer", () => {
 		expect(existsSync(join(cwd, "sure", "models", "rednote-hilab__dots.tts-base"))).toBe(false);
 		expect(context.selected_references.task_playbooks).toContain("references/task_playbooks/TTS.md");
 		expect(context.selected_references.environment_playbooks).toContain("references/playbooks/env_uv.md");
+		expect(context.selected_references.environment_playbooks).not.toContain("references/playbooks/env_docker.md");
 	});
 
 	it("falls back to scalar parsing for legacy handoffs with unquoted multiline code", () => {
@@ -694,6 +695,7 @@ describe("sure_onboard MODEL_INPUT materializer", () => {
 		expect(context.selected_references.task_playbooks).toContain("references/task_playbooks/SPEECH_UNDERSTANDING.md");
 		expect(context.selected_references.task_playbooks).toContain("references/task_playbooks/ASR.md");
 		expect(context.selected_references.environment_playbooks).toContain("references/playbooks/env_conda.md");
+		expect(context.selected_references.environment_playbooks).toContain("references/playbooks/env_docker.md");
 	});
 
 	// sure/handoffs/ is listed in .gitignore, so these fixtures exist only on a
@@ -831,6 +833,12 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 			const content = name === "model.py" ? "class Model:\n\tpass\n" : `${name}\n`;
 			writeFileSync(join(modelDir, name), content, "utf-8");
 		}
+		writeFileSync(
+			join(modelDir, "config.yaml"),
+			"server:\n  command: [.venv/bin/python, server.py]\ntools:\n  - name: synthesize\nresources:\n  gpu: false\n",
+			"utf-8",
+		);
+		writeFileSync(join(modelDir, "requirements.lock"), "sure-replay-fixture==1.0.0\n", "utf-8");
 		const checkpointDir = join(modelDir, "checkpoints", "tiny");
 		mkdirSync(checkpointDir, { recursive: true });
 		writeFileSync(join(checkpointDir, "config.json"), "{}\n", "utf-8");
@@ -969,7 +977,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 			python_executable: pythonExecutable,
 			model_dir: modelDir,
 			artifacts_dir: modelArtifacts,
-			lockfile_path: null,
+			lockfile_path: "requirements.lock",
 			duration_seconds: 0,
 			log_path: "build.log",
 			failures: [],
@@ -1154,10 +1162,20 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 			{ encoding: "utf-8" },
 		);
 		expect(inventory.status, inventory.stderr || inventory.stdout).toBe(0);
-		advance("verdict");
+		const previousSitePolicy = process.env.SURE_SITE_POLICY;
+		process.env.SURE_SITE_POLICY = resolve(PACKAGE_DIR, "../../../config/site.example.yaml");
+		try {
+			advance("verdict");
+		} finally {
+			if (previousSitePolicy === undefined) {
+				delete process.env.SURE_SITE_POLICY;
+			} else {
+				process.env.SURE_SITE_POLICY = previousSitePolicy;
+			}
+		}
 
 		writeArtifact(runDir, "verdict.json", {
-			status: "partial",
+			status: "passed",
 			model_id: resolved.model_id,
 			model_name: resolved.model_name,
 			package: { profile: "none" },
@@ -1200,11 +1218,11 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 		expect(terminal.completedUnits).toContain("finalize_model_bundle");
 
 		ctx.point = "pre_finish";
-		ctx.event = { finish: { status: "incomplete" } } as never;
+		ctx.event = { finish: { status: "success" } } as never;
 		const finish = preFinish(ctx);
 		const patch = statePatch(finish);
 		expect(finish.ok, finish.repair).toBe(true);
-		expect(patch.phase?.status).toBe("incomplete");
+		expect(patch.phase?.status).toBe("success");
 	});
 });
 
@@ -2845,7 +2863,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		expect(proc.status, proc.stderr || proc.stdout).toBe(0);
 	});
 
-	it("rejects a success verdict for a non-registry local package", () => {
+	it("accepts a success verdict for a Python-ready local package", () => {
 		const { ctx, runDir } = freshCtx("verdict-local-ready-pass");
 		const modelDir = seedLocalReadyArtifacts(runDir);
 		seedModelInputResolved(runDir, { model_dir: modelDir });
@@ -2913,8 +2931,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 			},
 		});
 		const result = postToolResult(ctx);
-		expect(result.ok).toBe(false);
-		expect(result.repair).toContain("local_only");
+		expect(result.ok).toBe(true);
 	});
 
 	it("accepts verdict artifact paths relative to the repository root", () => {

--- a/sure/site/loader.py
+++ b/sure/site/loader.py
@@ -79,10 +79,17 @@ def validate_site_policy(value: Any) -> dict[str, Any]:
     datasets = _mapping(root.get("datasets"), "datasets")
     _reject_unknown(datasets, {"allowed_source_roots"}, "datasets")
     execution = _mapping(root.get("execution"), "execution")
-    _reject_unknown(execution, {"surfaces", "vc_partitions", "vc_partition_priority"}, "execution")
+    _reject_unknown(execution, {"surfaces", "local_runtimes", "vc_partitions", "vc_partition_priority"}, "execution")
     surfaces = _unique_strings(execution.get("surfaces"), "execution.surfaces", absolute=False)
     if any(surface not in {"local", "vc"} for surface in surfaces):
         raise SitePolicyError("execution.surfaces contains an unsupported value")
+    local_runtimes = _unique_strings(
+        execution.get("local_runtimes", ["container"]),
+        "execution.local_runtimes",
+        absolute=False,
+    )
+    if any(runtime not in {"container", "python"} for runtime in local_runtimes):
+        raise SitePolicyError("execution.local_runtimes contains an unsupported value")
 
     policy: dict[str, Any] = {
         "schema": SITE_POLICY_SCHEMA,
@@ -97,7 +104,7 @@ def validate_site_policy(value: Any) -> dict[str, Any]:
         "datasets": {
             "allowed_source_roots": _unique_strings(datasets.get("allowed_source_roots"), "datasets.allowed_source_roots", absolute=True),
         },
-        "execution": {"surfaces": surfaces},
+        "execution": {"surfaces": surfaces, "local_runtimes": local_runtimes},
     }
     if "vc_partitions" in execution:
         policy["execution"]["vc_partitions"] = _unique_strings(execution["vc_partitions"], "execution.vc_partitions", absolute=False)

--- a/sure/site/loader.ts
+++ b/sure/site/loader.ts
@@ -8,6 +8,7 @@ export const SITE_POLICY_ENV = "SURE_SITE_POLICY";
 export const SITE_POLICY_SCHEMA = "sure.site.policy.v1";
 
 export type ExecutionSurface = "local" | "vc";
+export type LocalRuntime = "container" | "python";
 export type SitePolicySource = "environment" | "bundled" | "local";
 
 export interface SitePolicy {
@@ -25,6 +26,7 @@ export interface SitePolicy {
 	};
 	execution: {
 		surfaces: ExecutionSurface[];
+		local_runtimes: LocalRuntime[];
 		vc_partitions?: string[];
 		vc_partition_priority?: Record<string, number>;
 	};
@@ -100,10 +102,18 @@ export function validateSitePolicy(value: unknown): SitePolicy {
 	const datasets = expectRecord(root.datasets, "datasets");
 	rejectUnknown(datasets, ["allowed_source_roots"], "datasets");
 	const execution = expectRecord(root.execution, "execution");
-	rejectUnknown(execution, ["surfaces", "vc_partitions", "vc_partition_priority"], "execution");
+	rejectUnknown(execution, ["surfaces", "local_runtimes", "vc_partitions", "vc_partition_priority"], "execution");
 	const surfaces = expectUniqueStrings(execution.surfaces, "execution.surfaces", false);
 	if (surfaces.some((surface) => surface !== "local" && surface !== "vc")) {
 		throw new Error("execution.surfaces contains an unsupported value");
+	}
+	const localRuntimes = expectUniqueStrings(
+		execution.local_runtimes ?? ["container"],
+		"execution.local_runtimes",
+		false,
+	);
+	if (localRuntimes.some((runtime) => runtime !== "container" && runtime !== "python")) {
+		throw new Error("execution.local_runtimes contains an unsupported value");
 	}
 
 	let network: SitePolicy["network"];
@@ -140,6 +150,7 @@ export function validateSitePolicy(value: unknown): SitePolicy {
 		},
 		execution: {
 			surfaces: surfaces as ExecutionSurface[],
+			local_runtimes: localRuntimes as LocalRuntime[],
 		},
 	};
 	if (execution.vc_partitions !== undefined) {

--- a/sure/site/policy.schema.json
+++ b/sure/site/policy.schema.json
@@ -39,6 +39,13 @@
 					"uniqueItems": true,
 					"items": { "enum": ["local", "vc"] }
 				},
+				"local_runtimes": {
+					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": { "enum": ["container", "python"] },
+					"default": ["container"]
+				},
 				"vc_partitions": {
 					"type": "array",
 					"minItems": 1,

--- a/sure/site/public.example.yaml
+++ b/sure/site/public.example.yaml
@@ -18,3 +18,6 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container

--- a/sure/site/test_loader.py
+++ b/sure/site/test_loader.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import unittest
+
+from sure.site.loader import SitePolicyError, validate_site_policy
+
+
+def policy(execution: dict) -> dict:
+    return {
+        "schema": "sure.site.policy.v1",
+        "site_id": "test",
+        "policy_version": 1,
+        "storage": {
+            "approved_models_roots": ["/srv/sure/models"],
+            "approved_results_roots": ["/srv/sure/results"],
+            "forbidden_output_roots": ["/srv/sure"],
+            "runtime_root": "/var/cache/sure/runtime",
+        },
+        "datasets": {"allowed_source_roots": ["/srv/sure/datasets"]},
+        "execution": execution,
+    }
+
+
+class SitePolicyTests(unittest.TestCase):
+    def test_legacy_policy_defaults_to_container_only(self) -> None:
+        parsed = validate_site_policy(policy({"surfaces": ["local"]}))
+
+        self.assertEqual(parsed["execution"]["local_runtimes"], ["container"])
+
+    def test_python_runtime_requires_explicit_valid_value(self) -> None:
+        parsed = validate_site_policy(
+            policy({"surfaces": ["local"], "local_runtimes": ["python", "container"]})
+        )
+        self.assertEqual(parsed["execution"]["local_runtimes"], ["python", "container"])
+
+        with self.assertRaisesRegex(SitePolicyError, "unsupported value"):
+            validate_site_policy(policy({"surfaces": ["local"], "local_runtimes": ["host"]}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/SKILL.md
+++ b/sure/skills/sure_eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sure-eval
-description: Run reproducible inference from an approved NFS model's immutable container binding, then execute the selected evaluation pipeline and stage complete results for review.
+description: Run reproducible inference from an approved Python or immutable container binding, then execute the selected evaluation pipeline and stage complete results for review.
 ---
 
 # /sure_eval
@@ -24,7 +24,8 @@ Control principle: **agent decides scope, scripts enforce format and execution.*
 | `target` | — | Target metric or paper to compare against. |
 | `max_samples` | — | Sample cap for bounded validation runs. Omitted or `0` means full dataset. |
 | `execution` | — | `auto \| local \| vc`. Default `auto`; `local` is an explicit user choice, `vc` requires a real vc submission, `auto` prefers vc when available. |
-| `execution_path` | — | Legacy alias: `auto \| vc_submit \| local_docker`. `local_bash` is normalized to `local_docker`; host inference is forbidden. |
+| `runtime` | — | `auto \| python \| container`. Default `auto` selects the approved model binding; an explicit value must match it. |
+| `execution_path` | — | Legacy alias: `auto \| vc_submit \| local_python \| local_docker`. `local_bash` is normalized to the approved local runtime. |
 | `vc_partition` / `vc_cpu` / `vc_mem` / `vc_gpu` | — | Optional VC resource overrides. The image cannot be overridden and always comes from the approved deployment binding. |
 | `metrics` | — | Comma-separated reported metrics, e.g. `metrics=cer`. Selects the current default route per metric; use an exact `pipeline_id` via `/sure_reval` for route variants. |
 | `vc_job_name` | — | Optional vc job name recorded with the submit result. |
@@ -91,15 +92,15 @@ Advance happens **only** when the current unit's `produces` artifact is complian
 Each unit must satisfy: **Inputs** (previous unit's produces + evidence sources to read) → **Output** (`produces` JSON, schema in `schemas/`) → **Allowed** (value domain) → **Must Not Do** (forbidden fields that belong to later units — anti step-merge) → **Failure** classification.
 
 - **task_classification**: Inputs = `eval_input_resolved.json` + exact NFS model. Output = `task_classification.json` {task_type, reason, need_tool_workflow, confidence, input_signals}. Allowed: task_type ∈ {onboarding_then_evaluate,evaluate_existing_model,repair_broken_model,audit_results}. Must Not Do: do not select datasets or set `execution_path`/`report_persisted` (later units).
-- **tool_readiness_routing**: Inputs = exact approved NFS model with `artifacts/deployment_ready.json`, `runtime_inventory.json`, `package_gate.json`, and their declared hashes. Local readiness requires `docker-registry`, `container_only`, a digest-pinned image, disabled image/host overrides, and a read-only NFS model policy. Missing or inconsistent fields route back to `/sure_onboard` and human promotion.
+- **tool_readiness_routing**: Inputs = exact approved NFS model with `artifacts/deployment_ready.json`, `runtime_inventory.json`, `package_gate.json`, and their declared hashes. Readiness requires either an approved Python binding from `package=none` or a digest-pinned container binding from `package=docker-registry`, with disabled fallbacks and a read-only model policy. Missing or inconsistent fields route back to `/sure_onboard` and human promotion.
 - **plan**: Inputs = task classification + tool readiness + `eval_input_resolved.json`. Output follows `main_agent_plan.schema.json` and describes execution order only.
 - **dataset_scope**: Inputs = `eval_input_resolved.json` + explicit human constraints. Output = {selection_basis, selected_datasets, skipped_datasets}. User-provided datasets are validated/canonicalized here; this unit should not silently invent a different dataset scope.
 - **execution_surface** / **execute_wait**: produce the declared JSON; see `schemas/`. Do not emit later-unit fields.
 - **script_routing**: Output steps[] each {name, script}. name ∈ the whitelist (see `schemas/script_routing.schema.json`); `script` must resolve under `scripts/`.
-- **execution_surface**: Output {entrypoint_path or entrypoint, source_provenance.template_file, deployment_binding}. The script comes only from `scripts/templates/`. Copy the approved binding summary from `eval_input_resolved.json`: schema, image ref, bundle identity, `container_only`, read-only model mount, and writable result mount. Do not declare a host model interpreter or a mutable image.
-- **execution_readiness**: `check_execution_surface_compliance.py` compares the surface binding with the approved input, rejects `local_bash`, `.venv`, `/usr/bin/python3`, image changes, writable NFS models, and tool mismatches. It also preserves template isolation and validates the standalone evaluation route plan.
-- **smoke_test**: bounded smoke on a tiny slice using local Docker and the approved digest-pinned image; `smoke_passed` true.
-- **submit_vc_run**: `execution=vc` uses the same approved image through `vc_submit`; `execution=local` uses `local_docker`; `auto` prefers VC when available. VC precheck verifies the immutable image, partition, mounts, and resources. It does not infer or rewrite a model `.venv`.
+- **execution_surface**: Output {entrypoint_path or entrypoint, source_provenance.template_file, deployment_binding}. The script comes only from `scripts/templates/`. Copy the approved binding summary from `eval_input_resolved.json`: schema, runtime kind, model Python or image ref, bundle identity, read-only model mount, and writable result mount. Do not declare an unapproved interpreter or mutable image.
+- **execution_readiness**: `check_execution_surface_compliance.py` compares the surface binding with the approved input, rejects `local_bash`, runtime changes, writable approved models, and tool mismatches, then live-probes the selected Python or container runtime. It also preserves template isolation and validates the standalone evaluation route plan.
+- **smoke_test**: bounded smoke on a tiny slice using the approved local Python or Docker runtime; `smoke_passed` true.
+- **submit_vc_run**: `execution=local` uses `local_python` or `local_docker` according to the approved binding. `execution=vc` requires a container binding and uses its image through `vc_submit`; container `auto` prefers VC when available, while Python is local-only.
 - **assessment**: {anomaly_detected, user_confirmed}. Anomaly (e.g. WER/CER > 50%, Accuracy < 20%) requires user confirmation.
 - **run_report**: {report_persisted, execution_path_actual}. Record `execution_path_requested`, `execution_path_actual`, `device_request`, `device_actual`, `max_samples`, total dataset samples, and evaluated samples. Non-vc paths are valid for explicit `execution=local`; auto local fallback requires a reason and, if vc was available, explicit fallback approval.
 
@@ -123,7 +124,7 @@ When materializing the execution surface (run_evaluation.sh):
 [SYSTEM_CONSTRAINT: EXECUTION_POLICY]
 The user controls where formal model inference runs:
 1. EXECUTION_REQUEST:
-   - `execution=local`: run the materialized surface in local Docker. Host model inference is never valid.
+   - `execution=local`: run the materialized surface through the approved `local_python` or `local_docker` binding.
    - `execution=vc`: submit through vc. If `which vc && vc info` fails, the run must fail instead of falling back.
    - `execution=auto` or omitted: prefer vc when available; otherwise local fallback is allowed and must record the reason.
 2. DEVICE_REQUEST:
@@ -131,7 +132,7 @@ The user controls where formal model inference runs:
    - `device=cuda:<index>` records the user request, sets `CUDA_VISIBLE_DEVICES=<index>` for local execution, and records process-visible `device_actual=cuda:0`.
    - For `execution=vc`, `device=auto|cuda|cuda:<index>` resolves to the container-visible `cuda:0`; a nonzero requested ordinal is preserved in provenance with an explanatory note because VC physical GPU selection is controlled by `vc_partition`/`vc_gpu`.
 3. PROVENANCE:
-   - `submit_result.json`, `execution_result.json`, `prediction_generation_status.json`, `protocol.yaml`, and `main_agent_run_report.json` record the exact image digest, execution location, device, and mount policy.
+   - `submit_result.json`, `execution_result.json`, `prediction_generation_status.json`, `protocol.yaml`, and `main_agent_run_report.json` record the exact runtime identity, execution location, device, and mount policy. Container runs also record the image digest.
 ```
 
 ## Artifact Protocol
@@ -140,7 +141,7 @@ Generated prediction runs write `prediction_generation_status.json` with schema
 `sure.eval.prediction_generation_status.v2`. The source of truth is what the
 harness actually sent and where it executed:
 
-- `runtime`: MCP server command, container working directory/Python, exact image ref, and `runtime_inventory.json` v2 summary. Local onboard Python remains evidence only.
+- `runtime`: MCP server command, approved working directory/Model Python, optional exact image ref, and `runtime_inventory.json` v2 summary.
 - `environment`: allowlisted safe env values, all env keys, redacted secret-key names, execution path, and device binding.
 - `generation`: protocol resolver output, explicit `--tool-arg` values, argument key policy, and raw-response observation.
 - `datasets`: per-dataset prediction file, structured prediction file, generation count, logs, and status.
@@ -181,7 +182,7 @@ in `scripts/templates/`. Run them as:
 ```
 
 For `execution=local`, call `scripts/run_local_execution.py --run-dir <sure_run_dir>`
-from the submit unit. It runs `run_evaluation.sh` inside the approved image and writes
+from the submit unit. It runs `run_evaluation.sh` through the approved Python or container binding and writes
 both `submit_result.json` and `execution_result.json`. For `execution=vc`, use
 `scripts/run_vc_execution.py --run-dir <sure_run_dir>` from the submit unit. It
 writes `submit_result.json`, includes the exact `vc submit` command and a
@@ -190,11 +191,11 @@ persistent `<sure_run_dir>/vc_logs/job.log`, and leaves final
 are selected at submit time, the effective digest-pinned image, partition, CPU,
 GPU, memory, entrypoint, and log snapshot is recorded in both `submit_result.vc_submission`
 and `execution_surface.vc_runtime.resolved_submission`.
-Both local Docker and VC inject the Model Python and server command declared by
+All execution paths inject the Model Python and server command declared by
 `runtime_inventory.json`, plus the independently resolved, versioned common
 `HARNESS_PYTHON_BIN`. The two executables are validated separately and must not
-silently collapse to the same interpreter. Host model-interpreter overrides and
-`.venv` rewrites are rejected.
+silently collapse to the same interpreter. Unapproved interpreter overrides and
+runtime rewrites are rejected.
 The standalone evaluator uses a third role, `SURE_EVALUATION_PYTHON`. Its root
 dependencies are resolved from the versioned contract under
 `sure/runtime/evaluation/`, cached by engine commit and lock hash under
@@ -242,9 +243,9 @@ contract according to the selected route's required roles. Repeated `--metric`
 values produce one dataset-metric result each, and `--merge-payload` merges
 segmented TTS/VC evaluation payloads without rerunning metrics.
 
-`run_smoke.py` launches the approved local container with a bounded sample.
+`run_smoke.py` launches the approved local Python or container runtime with a bounded sample.
 `generate_predictions_via_server.py --device cpu` hides `CUDA_VISIBLE_DEVICES`
-inside that container; it never starts a host model runtime.
+inside the selected runtime and verifies its identity before starting the server.
 
 ## Gate Checks (enforced by hooks)
 

--- a/sure/skills/sure_eval/hooks/index.ts
+++ b/sure/skills/sure_eval/hooks/index.ts
@@ -99,7 +99,7 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (missing.length > 0) {
 		return failure(
-			`Missing required /sure_eval parameters: ${missing.join(", ")}. Usage: /sure_eval model=<name> datasets=<dataset__version[,dataset__version...]> [protocol=standard_system|strict_core] [execution=auto|local|vc] [device=auto|cpu|cuda[:index]] [max_samples=...]`,
+			`Missing required /sure_eval parameters: ${missing.join(", ")}. Usage: /sure_eval model=<name> datasets=<dataset__version[,dataset__version...]> [protocol=standard_system|strict_core] [execution=auto|local|vc] [runtime=auto|python|container] [device=auto|cpu|cuda[:index]] [max_samples=...]`,
 			"Missing required parameters.",
 		);
 	}
@@ -167,6 +167,9 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (typeof args.execution_path === "string") {
 		resolveArgs.push("--execution-path", args.execution_path);
+	}
+	if (typeof args.runtime === "string") {
+		resolveArgs.push("--runtime", args.runtime);
 	}
 	for (const [argKey, cliKey] of [
 		["vc_partition", "--vc-partition"],

--- a/sure/skills/sure_eval/references/contracts/main_agent_tool_readiness_unit.md
+++ b/sure/skills/sure_eval/references/contracts/main_agent_tool_readiness_unit.md
@@ -14,14 +14,14 @@ This unit prevents `/sure_eval` from repairing, guessing, or executing an unappr
 
 For a local model, `ready` requires all of the following:
 
-- `artifacts/deployment_ready.json` with status `ready` and package `docker-registry`;
-- `artifacts/runtime_inventory.json` schema v2 with `container_only` execution;
-- `artifacts/package_gate.json` schema v2 with local, Docker, registry, and bundle readiness;
-- exact tag, digest, and digest-pinned image agreement across those files;
+- `artifacts/deployment_ready.json` with status `ready` and package `none` or `docker-registry`;
+- `artifacts/runtime_inventory.json` schema v2 with `python_only` or `container_only` execution matching that package;
+- `artifacts/package_gate.json` schema v2 with local readiness for Python, or local, Docker, registry, and bundle readiness for a container;
+- exact interpreter, lockfile hashes, server command, and tool names for Python, or exact tag, digest, and digest-pinned image agreement for a container;
 - valid hashes declared by the deployment marker;
 - read-only NFS model policy, writable separate results, no host Python fallback, and no image override.
 
-`config.yaml`, `model.py`, `server.py`, and verdict remain model evidence, but they cannot replace the deployment binding. `.venv`, Dockerfile text, logs, local image listings, and similar image names are never readiness sources.
+`config.yaml`, `model.py`, `server.py`, and verdict remain model evidence, but they cannot replace the deployment binding. An unbound `.venv`, Dockerfile text, logs, local image listings, and similar image names are never readiness sources.
 
 ## Routing
 

--- a/sure/skills/sure_eval/schemas/execution_result.schema.json
+++ b/sure/skills/sure_eval/schemas/execution_result.schema.json
@@ -11,8 +11,9 @@
 			"enum": ["succeeded", "running", "failed", "partial"]
 		},
 		"vc_job_id": { "type": "string" },
-		"execution_path": { "type": "string", "enum": ["vc_submit", "local_bash", "local_docker"] },
+		"execution_path": { "type": "string", "enum": ["vc_submit", "local_bash", "local_python", "local_docker"] },
 		"execution_requested": { "type": "string", "enum": ["auto", "local", "vc"] },
+		"runtime_kind": { "type": "string", "enum": ["python", "container"] },
 		"predictions_path": { "type": "string" },
 		"log_path": { "type": "string" },
 		"host": { "type": "string" },

--- a/sure/skills/sure_eval/schemas/execution_surface.schema.json
+++ b/sure/skills/sure_eval/schemas/execution_surface.schema.json
@@ -22,12 +22,14 @@
 		"execution": { "type": "object", "additionalProperties": true },
 		"deployment_binding": {
 			"type": "object",
-			"required": ["schema", "target_image_ref", "execution_mode", "model_mount_read_only", "result_mount_writable"],
+			"required": ["schema", "runtime_kind", "execution_mode", "model_mount_read_only", "result_mount_writable"],
 			"properties": {
 				"schema": { "const": "sure.eval.deployment_binding.v1" },
-				"target_image_ref": { "type": "string", "pattern": "@sha256:[0-9a-f]{64}$" },
+				"runtime_kind": { "enum": ["python", "container"] },
+				"target_image_ref": { "type": ["string", "null"], "pattern": "@sha256:[0-9a-f]{64}$" },
+				"model_python": { "type": ["string", "null"] },
 				"bundle_identity_sha256": { "type": ["string", "null"] },
-				"execution_mode": { "const": "container_only" },
+				"execution_mode": { "enum": ["python", "container_only"] },
 				"model_mount_read_only": { "const": true },
 				"result_mount_writable": { "const": true }
 			},

--- a/sure/skills/sure_eval/schemas/run_report.schema.json
+++ b/sure/skills/sure_eval/schemas/run_report.schema.json
@@ -79,7 +79,7 @@
 		},
 		"execution_path_actual": {
 			"type": "string",
-			"description": "Actual execution path used: vc_submit | local_bash | local_docker."
+			"description": "Actual execution path used: vc_submit | local_bash | local_python | local_docker."
 		},
 		"execution_path_requested": {
 			"type": "string",

--- a/sure/skills/sure_eval/schemas/submit_result.schema.json
+++ b/sure/skills/sure_eval/schemas/submit_result.schema.json
@@ -8,7 +8,7 @@
 	"properties": {
 		"execution_path": {
 			"type": "string",
-			"enum": ["vc_submit", "local_bash", "local_docker"]
+			"enum": ["vc_submit", "local_bash", "local_python", "local_docker"]
 		},
 		"vc_available": {
 			"type": "boolean",
@@ -17,6 +17,7 @@
 		"vc_job_id": { "type": "string" },
 		"vc_info": { "type": "string" },
 		"execution_requested": { "type": "string", "enum": ["auto", "local", "vc"] },
+		"runtime_kind": { "type": "string", "enum": ["python", "container"] },
 		"execution": { "type": "object", "additionalProperties": true },
 		"fallback_approved": { "type": "boolean" },
 		"local_fallback_reason": { "type": "string" },

--- a/sure/skills/sure_eval/scripts/check_execution_surface_compliance.py
+++ b/sure/skills/sure_eval/scripts/check_execution_surface_compliance.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -247,11 +248,15 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
         issues.append(str(exc))
         approved_harness = {}
 
+    runtime_kind = str(approved.get("runtime_kind") or "container")
+    approved_python = approved.get("python") if isinstance(approved.get("python"), dict) else {}
     expected_fields = {
         "schema": approved.get("schema"),
-        "target_image_ref": approved.get("target_image_ref"),
+        "runtime_kind": runtime_kind,
+        "target_image_ref": approved.get("target_image_ref") if runtime_kind == "container" else None,
+        "model_python": approved_python.get("python_executable") if runtime_kind == "python" else None,
         "bundle_identity_sha256": (approved.get("evidence") or {}).get("bundle_identity_sha256"),
-        "execution_mode": "container_only",
+        "execution_mode": "python" if runtime_kind == "python" else "container_only",
         "model_mount_read_only": True,
         "result_mount_writable": True,
     }
@@ -259,13 +264,16 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
         if declared_binding.get(key) != expected:
             issues.append(f"deployment_binding.{key} must equal approved value {expected!r}")
     path_planned = str(execution.get("path_planned") or "")
-    if path_planned not in {"local_docker", "vc_submit"}:
-        issues.append("formal inference path must be local_docker or vc_submit")
-    if isinstance(env.get("SURE_EVAL_CONTAINER_IMAGE"), str) and env["SURE_EVAL_CONTAINER_IMAGE"] != approved.get("target_image_ref"):
+    allowed_paths = {"local_python"} if runtime_kind == "python" else {"local_docker", "vc_submit"}
+    if path_planned not in allowed_paths:
+        issues.append(f"formal {runtime_kind} inference path must be one of {sorted(allowed_paths)}")
+    if runtime_kind == "container" and isinstance(env.get("SURE_EVAL_CONTAINER_IMAGE"), str) and env["SURE_EVAL_CONTAINER_IMAGE"] != approved.get("target_image_ref"):
         issues.append("execution surface image differs from the approved digest-pinned image")
     for key in ("MODEL_PYTHON", "PYTHON_BIN"):
         value = env.get(key)
-        if isinstance(value, str) and (".venv" in value or value == "/usr/bin/python3"):
+        if runtime_kind == "python" and isinstance(value, str) and value and value != approved_python.get("python_executable"):
+            issues.append(f"{key} differs from the approved Model Python")
+        elif runtime_kind == "container" and isinstance(value, str) and (".venv" in value or value == "/usr/bin/python3"):
             issues.append(f"{key} must not bind a host interpreter; the container runner injects approved runtime Python")
     declared_harness_python = env.get("HARNESS_PYTHON_BIN")
     if isinstance(declared_harness_python, str) and declared_harness_python:
@@ -281,7 +289,8 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
         (value for value in (env.get("TOOL_NAME"), resolved_inputs.get("tool_name")) if isinstance(value, str) and value),
         "",
     )
-    approved_tools = ((approved.get("container") or {}).get("tool_names") or [])
+    approved_runtime = approved_python if runtime_kind == "python" else (approved.get("container") or {})
+    approved_tools = approved_runtime.get("tool_names") or []
     if declared_tool and declared_tool not in approved_tools:
         issues.append(f"tool name {declared_tool!r} is not in the approved deployment binding: {approved_tools}")
 
@@ -298,7 +307,7 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
     return {
         "passed": True,
         "live_runtime_probe": live_probe,
-        "evidence": f"approved container-only deployment verified: {approved.get('target_image_ref')}",
+        "evidence": f"approved {runtime_kind} deployment verified",
     }
 
 
@@ -308,6 +317,55 @@ def _live_runtime_probe(
     *,
     run=subprocess.run,
 ) -> dict[str, Any]:
+    if binding.get("runtime_kind") == "python":
+        python = binding.get("python") if isinstance(binding.get("python"), dict) else {}
+        model_python = str(python.get("python_executable") or "")
+        harness_python = str(host_harness.get("python_executable") or "")
+        if not model_python or not harness_python or model_python == harness_python:
+            return {
+                "passed": False,
+                "failure_class": "HARNESS_MODEL_RUNTIME_ALIAS",
+                "exit_code": None,
+                "evidence": "approved Harness Python and Model Python must be distinct",
+            }
+        imports = [str(item) for item in python.get("required_imports") or [] if isinstance(item, str)]
+        script = (
+            "import importlib,json; "
+            f"[importlib.import_module(name) for name in json.loads({json.dumps(imports)!r})]"
+        )
+        env = os.environ.copy()
+        env.pop("PYTHONHOME", None)
+        env.pop("PYTHONPATH", None)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        try:
+            completed = run(
+                [model_python, "-c", script],
+                cwd=str(python.get("working_dir") or binding.get("model_dir") or ""),
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {
+                "passed": False,
+                "failure_class": "MODEL_RUNTIME_NOT_MATERIALIZED",
+                "exit_code": None,
+                "evidence": f"Python runtime probe could not start: {exc}",
+            }
+        detail = (completed.stderr or completed.stdout or "").strip()
+        return {
+            "passed": completed.returncode == 0,
+            "failure_class": None if completed.returncode == 0 else "MODEL_RUNTIME_NEEDS_REPAIR",
+            "exit_code": completed.returncode,
+            "model_python": model_python,
+            "backend": python.get("backend"),
+            "required_imports": imports,
+            "evidence": "approved Python runtime probe passed"
+            if completed.returncode == 0
+            else f"MODEL_RUNTIME_NEEDS_REPAIR: {detail or f'exit {completed.returncode}'}",
+        }
     repo_root = Path(__file__).resolve().parents[4]
     try:
         harness, mounted = resolve_container_harness_runtime(binding, host_harness, repo_root)

--- a/sure/skills/sure_eval/scripts/check_run_report.py
+++ b/sure/skills/sure_eval/scripts/check_run_report.py
@@ -175,16 +175,28 @@ def _validate_protocol(root: Path) -> list[str]:
         errors.append("protocol.yaml inference_parameters.argument_policy is required for generated predictions")
     provenance = protocol.get("provenance") if isinstance(protocol.get("provenance"), dict) else {}
     inference_environment = protocol.get("inference_environment") if isinstance(protocol.get("inference_environment"), dict) else {}
+    model_runtime = inference_environment.get("model_runtime") if isinstance(inference_environment.get("model_runtime"), dict) else {}
     container = inference_environment.get("container") if isinstance(inference_environment.get("container"), dict) else {}
     runtime_inventory = inference_environment.get("runtime_inventory") if isinstance(inference_environment.get("runtime_inventory"), dict) else {}
     harness_runtime = inference_environment.get("harness_runtime") if isinstance(inference_environment.get("harness_runtime"), dict) else {}
     mount_policy = inference_environment.get("mount_policy") if isinstance(inference_environment.get("mount_policy"), dict) else {}
-    if "@sha256:" not in str(container.get("image_ref") or ""):
-        errors.append("protocol.yaml container.image_ref must be digest-pinned")
-    if container.get("execution_mode") != "container_only":
-        errors.append("protocol.yaml container.execution_mode must be container_only")
-    if container.get("host_python_fallback") is not False:
-        errors.append("protocol.yaml must disable container host_python_fallback")
+    runtime_mode = runtime_inventory.get("execution_mode")
+    if runtime_mode == "container_only":
+        if model_runtime.get("kind") not in {None, "container"}:
+            errors.append("protocol.yaml model_runtime.kind must be container")
+        if "@sha256:" not in str(container.get("image_ref") or ""):
+            errors.append("protocol.yaml container.image_ref must be digest-pinned")
+        if container.get("execution_mode") != "container_only":
+            errors.append("protocol.yaml container.execution_mode must be container_only")
+        if container.get("host_python_fallback") is not False:
+            errors.append("protocol.yaml must disable container host_python_fallback")
+    elif runtime_mode == "python_only":
+        if model_runtime.get("kind") != "python" or not model_runtime.get("python_executable"):
+            errors.append("protocol.yaml must record the approved Python Model Runtime")
+        if not model_runtime.get("lockfile_sha256"):
+            errors.append("protocol.yaml Python Model Runtime must record lockfile hashes")
+    else:
+        errors.append("protocol.yaml runtime_inventory.execution_mode must be python_only or container_only")
     if runtime_inventory.get("schema") != "sure.onboard.runtime_inventory.v2":
         errors.append("protocol.yaml must record runtime_inventory schema v2")
     if not prediction_reuse.get("enabled"):
@@ -412,7 +424,7 @@ def _execution_requested(data: dict[str, Any], run_dir: Path, report_path: Path)
                 return value
             if value == "vc_submit":
                 return "vc"
-            if value in {"local_bash", "local_docker"}:
+            if value in {"local_bash", "local_python", "local_docker"}:
                 return "local"
 
     eval_input = _read_optional_json(run_dir / "artifacts" / "eval_input_resolved.json")
@@ -424,7 +436,7 @@ def _execution_requested(data: dict[str, Any], run_dir: Path, report_path: Path)
     execution_path_declared = str(data.get("execution_path_declared") or "")
     if execution_path_declared == "vc_submit":
         return "vc"
-    if execution_path_declared in {"local_bash", "local_docker"}:
+    if execution_path_declared in {"local_bash", "local_python", "local_docker"}:
         return "local"
     return "auto"
 
@@ -513,6 +525,10 @@ def _validate_failed_execution_report(run_dir: Path, report_path: Path, data: di
 
 
 def _submitted_image_error(execution_path: str, submit_result: dict, approved: dict) -> str | None:
+    if approved.get("runtime_kind") == "python":
+        if execution_path != "local_python" or submit_result.get("runtime_kind") != "python":
+            return "local Python execution differs from approved runtime identity"
+        return None
     approved_ref = str(approved.get("target_image_ref") or "")
     if execution_path != "vc_submit":
         actual_ref = ((submit_result.get("container_binding") or {}).get("image_ref")) or submit_result.get("vc_image")
@@ -564,7 +580,7 @@ def main() -> int:
     if not execution_path_actual:
         print(
             "RUN_REPORT_UNIT gate: execution_path_actual must be declared "
-            "(vc_submit / local_bash / local_docker).",
+            "(vc_submit / local_bash / local_python / local_docker).",
             file=sys.stderr,
         )
         return 1
@@ -579,7 +595,7 @@ def main() -> int:
         fallback_reason = data.get("local_fallback_reason") or submit_result.get("local_fallback_reason", "")
         if execution_path_actual == "local_bash" and not evaluation_only and not failed_pre_submit:
             print(
-                "RUN_REPORT_UNIT gate: formal model inference cannot use local_bash; expected local_docker.",
+                "RUN_REPORT_UNIT gate: formal model inference cannot use local_bash; expected local_python or local_docker.",
                 file=sys.stderr,
             )
             return 1

--- a/sure/skills/sure_eval/scripts/deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/deployment_binding.py
@@ -5,8 +5,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 from typing import Any
+
+for _parent in Path(__file__).resolve().parents:
+    if (_parent / "sure" / "site" / "loader.py").is_file():
+        sys.path.insert(0, str(_parent))
+        break
+
+from sure.site.loader import load_site_policy
 
 
 class DeploymentBindingError(ValueError):
@@ -61,6 +69,147 @@ def _require(condition: bool, message: str) -> None:
         raise DeploymentBindingError(message)
 
 
+def _verified_bundle_evidence(model_dir: Path, marker: dict[str, Any]) -> tuple[dict[str, str], str]:
+    declared_hashes = marker.get("required_artifact_sha256")
+    _require(isinstance(declared_hashes, dict) and bool(declared_hashes), "deployment artifact hashes are missing")
+    verified_hashes: dict[str, str] = {}
+    for relative, expected in declared_hashes.items():
+        _require(isinstance(relative, str) and isinstance(expected, str), "deployment artifact hash entry is invalid")
+        actual = _sha256(_artifact_path(model_dir, relative))
+        _require(actual == expected, f"deployment artifact hash mismatch: {relative}")
+        verified_hashes[relative] = actual
+    bundle_identity = str(marker.get("bundle_identity_sha256") or "")
+    calculated_bundle_identity = hashlib.sha256(
+        json.dumps(declared_hashes, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    _require(bundle_identity == calculated_bundle_identity, "deployment bundle identity does not match required artifact hashes")
+    return verified_hashes, bundle_identity
+
+
+def _python_runtime_path(
+    model_dir: Path,
+    raw: object,
+    scope: object,
+    *,
+    executable: bool = True,
+) -> Path:
+    _require(isinstance(raw, str) and bool(raw), "approved Model Python path is missing")
+    path = Path(raw).expanduser()
+    if scope == "model_relative":
+        _require(not path.is_absolute(), "model_relative Python path must be relative")
+        candidate = model_dir / path
+        resolved = candidate.parent.resolve() / candidate.name if executable else candidate.resolve()
+        _require(_is_relative_to(resolved, model_dir), "model_relative Python path escapes approved model")
+    elif scope == "site_runtime":
+        _require(path.is_absolute(), "site_runtime Python path must be absolute")
+        configured = load_site_policy(required=True)
+        runtime_root = Path(configured["policy"]["storage"]["runtime_root"]).expanduser().resolve()
+        resolved = path.parent.resolve() / path.name if executable else path.resolve()
+        _require(_is_relative_to(resolved, runtime_root), f"site_runtime Python path escapes {runtime_root}")
+    else:
+        raise DeploymentBindingError(f"unsupported Python runtime path_scope: {scope!r}")
+    _require(resolved.is_file(), f"approved runtime path does not exist: {resolved}")
+    if executable:
+        _require(bool(resolved.stat().st_mode & 0o111), f"approved Model Python is not executable: {resolved}")
+    return resolved
+
+
+def _load_python_deployment_binding(
+    model_dir: Path,
+    model_name: str,
+    marker: dict[str, Any],
+    inventory: dict[str, Any],
+    package: dict[str, Any],
+) -> dict[str, Any]:
+    site_policy = load_site_policy(required=True)["policy"]
+    _require(
+        "python" in site_policy["execution"]["local_runtimes"],
+        "local Python Eval is disabled by site policy; add python to execution.local_runtimes",
+    )
+    _require(marker.get("schema") == "sure.onboard.deployment_ready.v1", "unsupported deployment_ready schema")
+    _require(marker.get("status") == "ready", "deployment_ready status must be ready")
+    _require(marker.get("model_name") == model_name, "deployment_ready model_name does not match requested model")
+    _require(marker.get("package_profile") == "none", "approved Python model must use package=none")
+    execution_policy = marker.get("execution_policy")
+    _require(isinstance(execution_policy, dict), "deployment_ready execution_policy is missing")
+    _require(execution_policy.get("container_only") is False, "Python deployment must not be container_only")
+    _require(execution_policy.get("eval_runtime") == "python", "deployment is not approved for Python Eval")
+    _require(execution_policy.get("nfs_models_read_only") is True, "approved model policy must remain read-only")
+    _require(execution_policy.get("host_python_fallback") is False, "Python runtime must be explicit, not a fallback")
+
+    _require(inventory.get("schema") == "sure.onboard.runtime_inventory.v2", "unsupported runtime_inventory schema")
+    _require(inventory.get("status") == "ready", "runtime_inventory status must be ready")
+    model = inventory.get("model")
+    policy = inventory.get("policy")
+    local = inventory.get("local_runtime")
+    _require(isinstance(model, dict) and model.get("name") == model_name, "runtime_inventory model does not match")
+    _require(isinstance(policy, dict) and policy.get("eval_runtime") == "python_only", "runtime inventory is not Python-ready")
+    _require(policy.get("host_python_fallback") is False, "runtime inventory enables host fallback")
+    _require(policy.get("nfs_models_mutable_by_eval") is False, "runtime inventory allows approved model mutation")
+    _require(isinstance(local, dict) and local.get("eligible_for_eval") is True, "approved Python runtime is missing")
+    _require(local.get("backend") in {"uv", "pip", "conda", "pixi"}, "approved Python backend is unsupported")
+    python = _python_runtime_path(model_dir, local.get("python_executable"), local.get("path_scope"))
+
+    lockfiles = local.get("lockfiles")
+    lock_scopes = local.get("lockfile_scopes")
+    lock_hashes = local.get("lockfile_sha256")
+    _require(isinstance(lockfiles, list) and bool(lockfiles), "approved Python runtime has no lockfile")
+    _require(isinstance(lock_scopes, dict) and isinstance(lock_hashes, dict), "approved Python lock evidence is missing")
+    verified_locks: dict[str, str] = {}
+    for lockfile in lockfiles:
+        lock_path = _python_runtime_path(model_dir, lockfile, lock_scopes.get(lockfile), executable=False)
+        actual = _sha256(lock_path)
+        _require(lock_hashes.get(lockfile) == actual, f"approved Python lockfile hash mismatch: {lockfile}")
+        verified_locks[str(lock_path)] = actual
+
+    command = local.get("server_command")
+    tools = local.get("tool_names")
+    _require(isinstance(command, list) and bool(command) and all(isinstance(item, str) and item for item in command), "approved Python server_command is invalid")
+    _require(command[0] == local.get("python_executable"), "approved Python server_command must use the bound interpreter")
+    _require(isinstance(tools, list) and bool(tools) and all(isinstance(item, str) and item for item in tools), "approved Python tool_names are invalid")
+    working_dir = (model_dir / str(local.get("working_dir") or ".")).resolve()
+    _require(_is_relative_to(working_dir, model_dir) and working_dir.is_dir(), "approved Python working_dir is invalid")
+
+    _require(package.get("schema") == "sure.onboard.package_gate.v2", "unsupported package_gate schema")
+    _require(package.get("status") == "passed" and package.get("package_profile") == "none", "package_gate is not Python-ready")
+    readiness = package.get("readiness")
+    _require(isinstance(readiness, dict) and readiness.get("local_ready") is True, "package_gate local readiness is missing")
+    verified_hashes, bundle_identity = _verified_bundle_evidence(model_dir, marker)
+    return {
+        "schema": "sure.eval.deployment_binding.v1",
+        "runtime_kind": "python",
+        "model_name": model_name,
+        "model_dir": str(model_dir),
+        "source": "approved_nfs_models",
+        "package_profile": "none",
+        "python": {
+            "backend": local.get("backend"),
+            "python_executable": str(python),
+            "python_version": local.get("python_version"),
+            "working_dir": str(working_dir),
+            "server_command": [str(python), *command[1:]],
+            "tool_names": tools,
+            "required_imports": local.get("required_imports") if isinstance(local.get("required_imports"), list) else [],
+            "gpu_required": local.get("gpu_required") is True,
+            "lock_sha256": verified_locks,
+        },
+        "policy": {
+            "execution_mode": "python",
+            "host_python_fallback": False,
+            "image_override_allowed": False,
+            "nfs_models_read_only": True,
+        },
+        "evidence": {
+            "deployment_ready": str(_artifact_path(model_dir, "artifacts/deployment_ready.json")),
+            "runtime_inventory": str(_artifact_path(model_dir, "artifacts/runtime_inventory.json")),
+            "package_gate": str(_artifact_path(model_dir, "artifacts/package_gate.json")),
+            "verified_sha256": verified_hashes,
+            "bundle_identity_sha256": bundle_identity,
+            "runtime_lock_sha256": verified_locks,
+        },
+    }
+
+
 def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
     """Return the only execution binding that `/sure_eval` may consume."""
 
@@ -68,6 +217,9 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
     marker = _read_json(model_dir, "artifacts/deployment_ready.json")
     inventory = _read_json(model_dir, "artifacts/runtime_inventory.json")
     package = _read_json(model_dir, "artifacts/package_gate.json")
+
+    if marker.get("package_profile") == "none":
+        return _load_python_deployment_binding(model_dir, model_name, marker, inventory, package)
 
     _require(marker.get("schema") == "sure.onboard.deployment_ready.v1", "unsupported deployment_ready schema")
     _require(marker.get("status") == "ready", "deployment_ready status must be ready")
@@ -168,22 +320,11 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
     else:
         normalized_harness = None
 
-    declared_hashes = marker.get("required_artifact_sha256")
-    _require(isinstance(declared_hashes, dict) and declared_hashes, "deployment_ready artifact hashes are missing")
-    verified_hashes: dict[str, str] = {}
-    for relative, expected in declared_hashes.items():
-        _require(isinstance(relative, str) and isinstance(expected, str), "deployment artifact hash entry is invalid")
-        actual = _sha256(_artifact_path(model_dir, relative))
-        _require(actual == expected, f"deployment artifact hash mismatch: {relative}")
-        verified_hashes[relative] = actual
-    bundle_identity = str(marker.get("bundle_identity_sha256") or "")
-    calculated_bundle_identity = hashlib.sha256(
-        json.dumps(declared_hashes, sort_keys=True, separators=(",", ":")).encode()
-    ).hexdigest()
-    _require(bundle_identity == calculated_bundle_identity, "deployment bundle identity does not match required artifact hashes")
+    verified_hashes, bundle_identity = _verified_bundle_evidence(model_dir, marker)
 
     return {
         "schema": "sure.eval.deployment_binding.v1",
+        "runtime_kind": "container",
         "model_name": model_name,
         "model_dir": str(model_dir),
         "source": "approved_nfs_models",

--- a/sure/skills/sure_eval/scripts/evaluate_predictions.py
+++ b/sure/skills/sure_eval/scripts/evaluate_predictions.py
@@ -1618,6 +1618,18 @@ def _write_protocol_yaml(
         },
         "inference_environment": {
             "execution_path": os.environ.get("SURE_EVAL_EXECUTION_PATH", "unknown"),
+            "model_runtime": {
+                "kind": "python" if inventory_policy.get("eval_runtime") == "python_only" else "container",
+                "backend": inventory_local.get("backend"),
+                "python_executable": (
+                    os.environ.get("MODEL_PYTHON")
+                    if inventory_policy.get("eval_runtime") == "python_only"
+                    else inventory_container.get("python_executable")
+                ),
+                "python_version": inventory_local.get("python_version"),
+                "working_dir": server_working_dir,
+                "lockfile_sha256": inventory_local.get("lockfile_sha256"),
+            },
             "vc": {
                 "job_id": os.environ.get("SURE_EVAL_EXECUTION_JOB_ID") or os.environ.get("VC_JOB_ID"),
                 "partition": os.environ.get("SURE_EVAL_VC_PARTITION") or os.environ.get("VC_PARTITION"),
@@ -1685,8 +1697,16 @@ def _write_protocol_yaml(
                     if path is not None
                 ],
                 "reject_repo_internal_runtime_mount_overlays": True,
-                "nfs_models_read_only": _nested_dict(inventory_container, "mount_policy").get("nfs_models_read_only"),
-                "result_workspace": _nested_dict(_nested_dict(inventory_container, "mount_policy"), "result_workspace"),
+                "nfs_models_read_only": (
+                    _nested_dict(inventory_container, "mount_policy").get("nfs_models_read_only")
+                    if inventory_policy.get("eval_runtime") == "container_only"
+                    else inventory_policy.get("nfs_models_mutable_by_eval") is False
+                ),
+                "result_workspace": (
+                    _nested_dict(_nested_dict(inventory_container, "mount_policy"), "result_workspace")
+                    if inventory_policy.get("eval_runtime") == "container_only"
+                    else {"target": str(results_dir), "read_only": False}
+                ),
             },
         },
         "inference_constraints": {

--- a/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
+++ b/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
@@ -65,22 +65,42 @@ def _resolve_server_command(
     model_dir: Path,
     runtime_inventory: dict[str, Any],
 ) -> list[str]:
-    container = runtime_inventory.get("container_runtime")
     policy = runtime_inventory.get("policy")
     if runtime_inventory.get("schema") != "sure.onboard.runtime_inventory.v2":
         raise ValueError(f"approved model has unsupported runtime inventory: {model_dir}")
     if runtime_inventory.get("status") != "ready":
         raise ValueError("approved model runtime inventory is not ready")
-    if not isinstance(policy, dict) or policy.get("eval_runtime") != "container_only":
-        raise ValueError("approved model is not bound to container-only execution")
+    if not isinstance(policy, dict):
+        raise ValueError("approved model runtime policy is missing")
     if policy.get("host_python_fallback") is not False or policy.get("image_override_allowed") is not False:
         raise ValueError("approved model runtime policy permits a forbidden fallback or image override")
-    if not isinstance(container, dict):
+    runtime_kind = policy.get("eval_runtime")
+    if runtime_kind == "python_only":
+        runtime = runtime_inventory.get("local_runtime")
+        if not isinstance(runtime, dict) or runtime.get("eligible_for_eval") is not True:
+            raise ValueError("approved model Python runtime is missing")
+        command = runtime.get("server_command")
+        if not isinstance(command, list) or not all(isinstance(item, str) and item for item in command):
+            raise ValueError("approved model Python server_command is invalid")
+        python = Path(str(runtime.get("python_executable") or ""))
+        if runtime.get("path_scope") == "model_relative":
+            python = model_dir / python
+        python = Path(os.path.abspath(python))
+        if not python.is_file() or os.environ.get("MODEL_PYTHON") != str(python):
+            raise ValueError(
+                "inference Model Python does not match the approved runtime: "
+                f"expected={str(python)!r} actual={os.environ.get('MODEL_PYTHON', '')!r}"
+            )
+        return [str(python), *command[1:]]
+    if runtime_kind != "container_only":
+        raise ValueError(f"approved model has unsupported Eval runtime: {runtime_kind!r}")
+    runtime = runtime_inventory.get("container_runtime")
+    if not isinstance(runtime, dict):
         raise ValueError("approved model container runtime is missing")
-    command = container.get("server_command")
+    command = runtime.get("server_command")
     if not isinstance(command, list) or not all(isinstance(item, str) and item for item in command):
         raise ValueError("approved model container server_command is invalid")
-    expected_image = str(container.get("target_image_ref") or "")
+    expected_image = str(runtime.get("target_image_ref") or "")
     actual_image = os.environ.get("SURE_EVAL_CONTAINER_IMAGE", "")
     if "@sha256:" not in expected_image or actual_image != expected_image:
         raise ValueError(
@@ -91,11 +111,16 @@ def _resolve_server_command(
 
 
 def _resolve_working_dir(model_dir: Path, runtime_inventory: dict[str, Any]) -> Path:
-    container = runtime_inventory.get("container_runtime")
-    working_dir = container.get("working_dir") if isinstance(container, dict) else None
+    policy = runtime_inventory.get("policy") if isinstance(runtime_inventory.get("policy"), dict) else {}
+    runtime_key = "local_runtime" if policy.get("eval_runtime") == "python_only" else "container_runtime"
+    runtime = runtime_inventory.get(runtime_key)
+    working_dir = runtime.get("working_dir") if isinstance(runtime, dict) else None
     path = Path(str(working_dir or ""))
-    if not path.is_absolute() or not path.is_dir():
-        raise ValueError(f"approved container working_dir does not exist: {path}")
+    if runtime_key == "local_runtime" and not path.is_absolute():
+        path = model_dir / path
+    path = path.resolve()
+    if not path.is_dir():
+        raise ValueError(f"approved model working_dir does not exist: {path}")
     return path
 
 
@@ -458,6 +483,7 @@ def _runtime_inventory_summary(model_dir: Path) -> dict[str, Any]:
         "path": str(model_dir / "artifacts" / "runtime_inventory.json"),
         "status": inventory.get("status"),
         "schema": inventory.get("schema"),
+        "local_runtime": inventory.get("local_runtime") if isinstance(inventory.get("local_runtime"), dict) else {},
         "container_runtime": inventory.get("container_runtime") if isinstance(inventory.get("container_runtime"), dict) else {},
         "policy": inventory.get("policy") if isinstance(inventory.get("policy"), dict) else {},
         "evidence": inventory.get("evidence") if isinstance(inventory.get("evidence"), dict) else {},
@@ -1063,8 +1089,10 @@ def main() -> int:
     tool_name = args.tool_name or (tools[0]["name"] if tools else None)
     if not tool_name:
         raise ValueError("No tool name provided and config.yaml has no tools entry")
-    container_runtime = runtime_inventory_document.get("container_runtime")
-    approved_tools = container_runtime.get("tool_names") if isinstance(container_runtime, dict) else []
+    inventory_policy = runtime_inventory_document.get("policy") if isinstance(runtime_inventory_document.get("policy"), dict) else {}
+    runtime_key = "local_runtime" if inventory_policy.get("eval_runtime") == "python_only" else "container_runtime"
+    approved_runtime = runtime_inventory_document.get(runtime_key)
+    approved_tools = approved_runtime.get("tool_names") if isinstance(approved_runtime, dict) else []
     if tool_name not in approved_tools:
         raise ValueError(f"tool {tool_name!r} is not present in the approved runtime inventory: {approved_tools}")
     tool_args = _merge_protocol_tool_args(

--- a/sure/skills/sure_eval/scripts/python_execution.py
+++ b/sure/skills/sure_eval/scripts/python_execution.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Build a local host-Python command from an approved deployment binding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from container_execution import surface_env
+from evaluation_runtime import evaluation_runtime_from_eval_input
+from harness_runtime import harness_runtime_from_eval_input
+
+
+def deployment_binding(eval_input: dict[str, Any]) -> dict[str, Any]:
+    model = eval_input.get("model") if isinstance(eval_input.get("model"), dict) else {}
+    binding = model.get("deployment_binding")
+    if not isinstance(binding, dict):
+        runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+        binding = runtime.get("deployment_binding")
+    if not isinstance(binding, dict) or binding.get("schema") != "sure.eval.deployment_binding.v1":
+        raise ValueError("eval input does not contain an approved deployment binding")
+    policy = binding.get("policy") if isinstance(binding.get("policy"), dict) else {}
+    if binding.get("runtime_kind") != "python" or policy.get("execution_mode") != "python":
+        raise ValueError("approved deployment binding is not a Python runtime")
+    if policy.get("host_python_fallback") is not False:
+        raise ValueError("approved Python runtime must be selected explicitly")
+    return binding
+
+
+def build_local_python_command(
+    *,
+    surface: dict[str, Any],
+    eval_input: dict[str, Any],
+    entrypoint: Path,
+    repo_root: Path,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[list[str], dict[str, str], dict[str, Any]]:
+    binding = deployment_binding(eval_input)
+    python = binding.get("python") if isinstance(binding.get("python"), dict) else {}
+    model_python = Path(str(python.get("python_executable") or "")).expanduser()
+    model_dir = Path(str(binding.get("model_dir") or "")).resolve()
+    working_dir = Path(str(python.get("working_dir") or model_dir)).resolve()
+    if not model_python.is_file() or not model_dir.is_dir() or not working_dir.is_dir():
+        raise ValueError("approved Python deployment paths are not materialized")
+
+    harness_runtime = harness_runtime_from_eval_input(eval_input)
+    harness_python = Path(str(harness_runtime["python_executable"])).expanduser()
+    if model_python == harness_python:
+        raise ValueError("Harness Python and Model Python must be separate execution roles")
+    evaluation_runtime = evaluation_runtime_from_eval_input(eval_input, prepare=False)
+    output_dir = Path(str((eval_input.get("runtime") or {}).get("run_dir") or "")).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    skill_root = (repo_root / "sure" / "skills" / "sure_eval").resolve()
+    if not (skill_root / "scripts").is_dir():
+        raise ValueError(f"SURE-EVAL skill root is invalid: {skill_root}")
+    cache_root = output_dir / ".runtime" / "cache"
+    source_provenance = surface.get("source_provenance") if isinstance(surface.get("source_provenance"), dict) else {}
+
+    env = surface_env(surface)
+    env.update(extra_env or {})
+    env.update(
+        {
+            "MODEL_DIR": str(model_dir),
+            "REPO_ROOT": str(skill_root),
+            "SURE_EVAL_APPROVED_MODEL_DIR": str(model_dir),
+            "RUN_DIR": str(output_dir),
+            "MODEL_PYTHON": str(model_python),
+            "PYTHON_BIN": str(model_python),
+            "HARNESS_PYTHON_BIN": str(harness_python),
+            "SURE_HARNESS_RUNTIME_ID": str(harness_runtime["runtime_id"]),
+            "SURE_HARNESS_LOCK_SHA256": str(harness_runtime["lock_sha256"]),
+            "SURE_HARNESS_MANIFEST_PATH": str(harness_runtime["manifest_path"]),
+            "SURE_HARNESS_RUNTIME_ROOT": str(harness_runtime["runtime_root"]),
+            "SURE_EVAL_EXECUTION_SURFACE_TYPE": "main_flow_script",
+            "SURE_EVAL_EXECUTION_ENTRYPOINT": str(entrypoint.resolve()),
+            "SURE_EVAL_EXECUTION_GENERATION_METHOD": str(surface.get("generation_method") or "harness_template"),
+            "SURE_EVAL_EXECUTION_TEMPLATE_FILE": str(source_provenance.get("template_file") or ""),
+            "SURE_EVAL_EXECUTION_TEMPLATE_SHA256": str(source_provenance.get("template_sha256") or ""),
+            "SURE_EVAL_PUBLISHED_RUN_DIR": str(output_dir),
+            "SURE_EVAL_MODEL_RUNTIME_KIND": "python",
+            "SURE_EVAL_MODEL_WORKING_DIR": str(working_dir),
+            "SURE_EVAL_WRITABLE_CACHE_ROOT": str(cache_root),
+            "SURE_EVAL_CACHE_DIR": str(cache_root / "sure-eval"),
+            "HF_HOME": str(cache_root / "huggingface"),
+            "HF_HUB_CACHE": str(cache_root / "huggingface" / "hub"),
+            "TRANSFORMERS_CACHE": str(cache_root / "huggingface" / "transformers"),
+            "MODELSCOPE_CACHE": str(cache_root / "modelscope"),
+            "TORCH_HOME": str(cache_root / "torch"),
+            "XDG_CACHE_HOME": str(cache_root / "xdg"),
+            "PYTHONDONTWRITEBYTECODE": "1",
+        }
+    )
+    if evaluation_runtime is not None:
+        env.update(
+            {
+                "SURE_EVALUATION_PYTHON": str(evaluation_runtime["python_executable"]),
+                "SURE_EVALUATION_RUNTIME_ID": str(evaluation_runtime["runtime_id"]),
+                "SURE_EVALUATION_LOCK_SHA256": str(evaluation_runtime["lock_sha256"]),
+                "SURE_EVALUATION_RUNTIME_MANIFEST": str(evaluation_runtime["manifest_path"]),
+                "SURE_EVALUATION_HOME": str(evaluation_runtime["engine_root"]),
+            }
+        )
+    return ["bash", str(entrypoint.resolve())], env, {
+        "runtime_kind": "python",
+        "model_runtime": python,
+        "harness_runtime": harness_runtime,
+        "evaluation_runtime": evaluation_runtime,
+        "model_dir": str(model_dir),
+        "working_dir": str(working_dir),
+    }

--- a/sure/skills/sure_eval/scripts/resolve_eval_input.py
+++ b/sure/skills/sure_eval/scripts/resolve_eval_input.py
@@ -359,6 +359,8 @@ def _normalize_execution(
     execution: str | None,
     execution_path: str | None,
     allowed_surfaces: list[str] | None = None,
+    runtime_kind: str = "container",
+    allowed_local_runtimes: list[str] | None = None,
 ) -> dict[str, Any]:
     requested_raw = (execution or "").strip().lower()
     path_raw = (execution_path or "").strip().lower()
@@ -366,6 +368,7 @@ def _normalize_execution(
         "vc_submit": "vc",
         "local_bash": "local",
         "local_docker": "local",
+        "local_python": "local",
         "auto": "auto",
     }
     if not requested_raw:
@@ -377,6 +380,7 @@ def _normalize_execution(
         "local": "local",
         "local_bash": "local",
         "local_docker": "local",
+        "local_python": "local",
         "bash": "local",
         "auto": "auto",
     }
@@ -391,31 +395,47 @@ def _normalize_execution(
                 "Use execution=auto|local|vc, or the matching legacy execution_path."
             )
 
+    if requested == "vc" and runtime_kind != "container":
+        raise ValueError("execution=vc requires an approved container runtime")
+    local_path = "local_python" if runtime_kind == "python" else "local_docker"
     if path_raw and path_raw != "auto":
-        planned_path = "local_docker" if path_raw == "local_bash" else path_raw
+        planned_path = local_path if path_raw == "local_bash" else path_raw
+        if planned_path.startswith("local_") and planned_path != local_path:
+            raise ValueError(
+                f"execution_path={planned_path} conflicts with approved runtime={runtime_kind}; expected {local_path}"
+            )
     elif requested == "vc":
         planned_path = "vc_submit"
     elif requested == "local":
-        planned_path = "local_docker"
+        planned_path = local_path
     else:
         planned_path = "auto"
-    if planned_path not in {"auto", "vc_submit", "local_bash", "local_docker"}:
-        raise ValueError(f"Unsupported execution_path: {execution_path}. Use auto, vc_submit, local_bash, or local_docker.")
+    if planned_path not in {"auto", "vc_submit", "local_bash", "local_docker", "local_python"}:
+        raise ValueError(
+            f"Unsupported execution_path: {execution_path}. Use auto, vc_submit, local_python, or local_docker."
+        )
 
     available = _vc_available()
+    allowed = set(allowed_surfaces or ("local", "vc"))
+    local_runtime_allowed = runtime_kind in set(allowed_local_runtimes or ("container",))
     if planned_path == "auto":
-        allowed = set(allowed_surfaces or ("local", "vc"))
-        if available and "vc" in allowed:
+        if runtime_kind == "container" and available and "vc" in allowed:
             planned_path = "vc_submit"
-        elif "local" in allowed:
-            planned_path = "local_docker"
-        elif "vc" in allowed:
+        elif "local" in allowed and local_runtime_allowed:
+            planned_path = local_path
+        elif runtime_kind == "container" and "vc" in allowed:
             planned_path = "vc_submit"
         else:
-            raise ValueError("site policy enables no supported execution surface")
+            raise ValueError(
+                f"site policy enables no execution surface for the approved {runtime_kind} runtime"
+            )
     planned = "vc" if planned_path == "vc_submit" else "local"
     if allowed_surfaces is not None and planned not in set(allowed_surfaces):
         raise ValueError(f'execution surface "{planned}" is not enabled by the active site policy')
+    if planned == "local" and not local_runtime_allowed:
+        raise ValueError(
+            f'local runtime "{runtime_kind}" is not enabled by execution.local_runtimes'
+        )
     reason = (
         "user_requested_vc"
         if requested == "vc"
@@ -677,6 +697,15 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             f"{model.get('approved_models_root')}"
         )
     model_dir = Path(str(model["model_dir"]))
+    deployment_binding = model.get("deployment_binding") or {}
+    approved_runtime = str(deployment_binding.get("runtime_kind") or "container")
+    requested_runtime = str(getattr(args, "runtime", None) or "auto")
+    selected_runtime = approved_runtime if requested_runtime == "auto" else requested_runtime
+    if selected_runtime != approved_runtime:
+        raise EvalInputError(
+            f"runtime={requested_runtime} is not available in the approved model binding; "
+            f"approved runtime is {approved_runtime}"
+        )
     image_harness = ((model.get("deployment_binding") or {}).get("container") or {}).get("harness_runtime")
     if isinstance(image_harness, dict):
         if image_harness.get("runtime_id") != harness_runtime.get("runtime_id"):
@@ -709,7 +738,14 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     languages = _dedupe([str(item.get("language") or "") for item in datasets if item.get("language")])
     metric_list = _dedupe([metric for item in datasets for metric in item.get("default_metrics", [])])
     allowed_surfaces = list(active_site_policy["policy"]["execution"]["surfaces"])
-    execution = _normalize_execution(args.execution, args.execution_path, allowed_surfaces)
+    allowed_local_runtimes = list(active_site_policy["policy"]["execution"]["local_runtimes"])
+    execution = _normalize_execution(
+        args.execution,
+        args.execution_path,
+        allowed_surfaces=allowed_surfaces,
+        runtime_kind=selected_runtime,
+        allowed_local_runtimes=allowed_local_runtimes,
+    )
     device = _resolve_device(args.device, execution)
     vc_request = _vc_request(args)
     approved_image = str((model.get("deployment_binding") or {}).get("target_image_ref") or "")
@@ -749,6 +785,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "device_resolved": device["resolved"],
             "execution": execution,
             "execution_path": execution["path_planned"],
+            "model_runtime": selected_runtime,
             "max_samples": args.max_samples,
             "deployment_binding": model["deployment_binding"],
             "harness_runtime": harness_runtime,
@@ -767,6 +804,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "max_samples": args.max_samples,
             "execution": execution["requested"],
             "execution_path": args.execution_path or "auto",
+            "runtime": requested_runtime,
             "user_goal": args.user_goal,
             "vc": vc_request,
         },
@@ -788,6 +826,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "device": device,
             "execution": execution,
             "execution_path": execution["path_planned"],
+            "model_runtime": selected_runtime,
             "vc": vc_request,
             "deployment_binding": model["deployment_binding"],
             "harness_runtime": harness_runtime,
@@ -823,7 +862,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--metrics", nargs="*", default=[])
     parser.add_argument("--max-samples", type=int, default=0)
     parser.add_argument("--execution", choices=("auto", "local", "vc"))
-    parser.add_argument("--execution-path", default="auto", choices=("local_bash", "local_docker", "vc_submit", "auto"))
+    parser.add_argument("--execution-path", default="auto", choices=("local_bash", "local_docker", "local_python", "vc_submit", "auto"))
+    parser.add_argument("--runtime", default="auto", choices=("auto", "python", "container"))
     parser.add_argument("--vc-partition", default="")
     parser.add_argument("--vc-cpu", type=int, default=0)
     parser.add_argument("--vc-mem", default="")

--- a/sure/skills/sure_eval/scripts/run_local_execution.py
+++ b/sure/skills/sure_eval/scripts/run_local_execution.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from container_execution import build_local_container_command, effective_container_exit_code
+from python_execution import build_local_python_command
 
 
 def _utc_now() -> str:
@@ -68,7 +69,9 @@ def _execution_from_surface(surface: dict[str, Any], eval_input: dict[str, Any])
         execution = runtime.get("execution") if isinstance(runtime.get("execution"), dict) else {}
     requested = str(execution.get("requested") or "local")
     planned = str(execution.get("planned") or ("vc" if execution.get("path_planned") == "vc_submit" else "local"))
-    path_planned = str(execution.get("path_planned") or ("vc_submit" if planned == "vc" else "local_docker"))
+    runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+    local_path = "local_python" if runtime.get("model_runtime") == "python" else "local_docker"
+    path_planned = str(execution.get("path_planned") or ("vc_submit" if planned == "vc" else local_path))
     return {
         "requested": requested,
         "planned": planned,
@@ -151,9 +154,14 @@ def main() -> int:
     vc_available = _vc_available()
     if execution["requested"] == "vc" or execution["path_planned"] == "vc_submit":
         raise RuntimeError("Refusing local execution because the resolved execution plan requires vc_submit.")
-    if execution["path_planned"] != "local_docker":
-        raise RuntimeError("Refusing host execution: local inference must use local_docker.")
-    if execution["requested"] == "auto" and vc_available and not args.allow_auto_local_override:
+    if execution["path_planned"] not in {"local_python", "local_docker"}:
+        raise RuntimeError("Resolved local execution path must be local_python or local_docker.")
+    if (
+        execution["path_planned"] == "local_docker"
+        and execution["requested"] == "auto"
+        and vc_available
+        and not args.allow_auto_local_override
+    ):
         raise RuntimeError("Refusing local execution because execution=auto and vc is available; submit through vc instead.")
 
     entrypoint = _entrypoint(surface)
@@ -170,47 +178,64 @@ def main() -> int:
     fallback_approved = False
     if execution["requested"] == "auto" and not vc_available:
         local_fallback_reason = "execution=auto selected local execution because vc is unavailable"
+    elif execution["requested"] == "auto" and execution["path_planned"] == "local_python":
+        local_fallback_reason = "execution=auto selected the approved Python runtime, which is local-only"
+        fallback_approved = True
     elif execution["requested"] == "auto" and vc_available and args.allow_auto_local_override:
         local_fallback_reason = "execution=auto local override was explicitly allowed while vc was available"
         fallback_approved = True
 
-    command, container_binding = build_local_container_command(
-        surface=surface,
-        eval_input=eval_input,
-        control_run_dir=run_dir,
-        entrypoint=entrypoint,
-        repo_root=cwd,
-        device_request=device_request,
-        extra_env={
-            **device_env,
-            "SURE_EVAL_EXECUTION_PATH": "local_docker",
-            "SURE_EVAL_EXECUTION_REQUESTED": execution["requested"],
-            "SURE_EVAL_EXECUTION_JOB_ID": f"local:{host}:{run_dir.name}",
-            "SURE_EVAL_CONTAINER_REPO_ROOT": str(cwd),
-            "SURE_EVAL_VC_PARTITION": "",
-            "SURE_EVAL_VC_GPU": "0",
-            "SURE_EVAL_VC_CPU": "",
-            "SURE_EVAL_VC_MEMORY": "",
-            "SURE_EVAL_VC_NODES": "0",
-        },
-    )
+    execution_path = execution["path_planned"]
+    extra_env = {
+        **device_env,
+        "SURE_EVAL_EXECUTION_PATH": execution_path,
+        "SURE_EVAL_EXECUTION_REQUESTED": execution["requested"],
+        "SURE_EVAL_EXECUTION_JOB_ID": f"local:{host}:{run_dir.name}",
+        "SURE_EVAL_VC_PARTITION": "",
+        "SURE_EVAL_VC_GPU": "0",
+        "SURE_EVAL_VC_CPU": "",
+        "SURE_EVAL_VC_MEMORY": "",
+        "SURE_EVAL_VC_NODES": "0",
+    }
+    if execution_path == "local_python":
+        command, python_env, launch_binding = build_local_python_command(
+            surface=surface,
+            eval_input=eval_input,
+            entrypoint=entrypoint,
+            repo_root=cwd,
+            extra_env=extra_env,
+        )
+        process_env = {**os.environ, **python_env}
+    else:
+        command, launch_binding = build_local_container_command(
+            surface=surface,
+            eval_input=eval_input,
+            control_run_dir=run_dir,
+            entrypoint=entrypoint,
+            repo_root=cwd,
+            device_request=device_request,
+            extra_env={**extra_env, "SURE_EVAL_CONTAINER_REPO_ROOT": str(cwd)},
+        )
+        process_env = os.environ.copy()
 
     start = time.monotonic()
     started_at = _utc_now()
     with stdout_path.open("w", encoding="utf-8") as stdout, stderr_path.open("w", encoding="utf-8") as stderr:
-        process = subprocess.Popen(command, cwd=cwd, env=os.environ.copy(), stdout=stdout, stderr=stderr, text=True)
+        process = subprocess.Popen(command, cwd=cwd, env=process_env, stdout=stdout, stderr=stderr, text=True)
         submit_payload = {
-            "execution_path": "local_docker",
+            "execution_path": execution_path,
+            "runtime_kind": "python" if execution_path == "local_python" else "container",
             "execution_requested": execution["requested"],
             "execution": {
                 "requested": execution["requested"],
                 "actual": "local",
-                "path_actual": "local_docker",
+                "path_actual": execution_path,
             },
             "vc_available": vc_available,
             "vc_job_id": "",
             "vc_info": "local execution selected by user or auto policy",
-            "vc_image": str(container_binding["image_ref"]),
+            "vc_image": str(launch_binding.get("image_ref") or ""),
+            "deployment_binding": launch_binding,
             "fallback_approved": fallback_approved,
             "local_fallback_reason": local_fallback_reason,
             "submitted_at": started_at,
@@ -228,12 +253,14 @@ def main() -> int:
         returncode = process.wait()
     stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace") if stdout_path.exists() else ""
     stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace") if stderr_path.exists() else ""
-    returncode = effective_container_exit_code(returncode, stdout_text, stderr_text)
+    if execution_path == "local_docker":
+        returncode = effective_container_exit_code(returncode, stdout_text, stderr_text)
     duration = time.monotonic() - start
     job_status = "succeeded" if returncode == 0 else "failed"
     execution_payload = {
         "job_status": job_status,
-        "execution_path": "local_docker",
+        "execution_path": execution_path,
+        "runtime_kind": "python" if execution_path == "local_python" else "container",
         "execution_requested": execution["requested"],
         "host": host,
         "pid": submit_payload["pid"],

--- a/sure/skills/sure_eval/scripts/run_smoke.py
+++ b/sure/skills/sure_eval/scripts/run_smoke.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from container_execution import build_local_container_command, effective_container_exit_code
+from python_execution import build_local_python_command
 
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -164,6 +165,15 @@ def _execution_requested(surface: dict[str, Any]) -> str:
     return "local"
 
 
+def _execution_path(surface: dict[str, Any], eval_input: dict[str, Any]) -> str:
+    execution = surface.get("execution") if isinstance(surface.get("execution"), dict) else {}
+    path = execution.get("path_planned")
+    if isinstance(path, str) and path:
+        return path
+    runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+    return "local_python" if runtime.get("model_runtime") == "python" else "local_docker"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--run-dir", required=True)
@@ -254,29 +264,48 @@ def main() -> int:
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / "smoke_test.log"
     device_request = _device_request(surface, eval_input)
-    command, _ = build_local_container_command(
-        surface=surface,
-        eval_input=eval_input,
-        control_run_dir=run_dir.resolve(),
-        entrypoint=entrypoint_path.resolve(),
-        repo_root=Path(__file__).resolve().parents[4],
-        device_request=device_request,
-        extra_env={
-            **_local_device_env(device_request),
-            "SMOKE_ONLY": "1",
-            "SMOKE_TEST_SAMPLES": str(smoke_samples),
-            "SURE_EVAL_EXECUTION_PATH": "local_docker_smoke",
-            "SURE_EVAL_EXECUTION_REQUESTED": _execution_requested(surface),
-        },
-    )
+    execution_path = _execution_path(surface, eval_input)
+    extra_env = {
+        **_local_device_env(device_request),
+        "SMOKE_ONLY": "1",
+        "SMOKE_TEST_SAMPLES": str(smoke_samples),
+        "SURE_EVAL_EXECUTION_PATH": f"{execution_path}_smoke",
+        "SURE_EVAL_EXECUTION_REQUESTED": _execution_requested(surface),
+    }
+    repo_root = Path(__file__).resolve().parents[4]
+    if execution_path == "local_python":
+        command, python_env, _ = build_local_python_command(
+            surface=surface,
+            eval_input=eval_input,
+            entrypoint=entrypoint_path.resolve(),
+            repo_root=repo_root,
+            extra_env=extra_env,
+        )
+        process_env = {**os.environ, **python_env}
+    elif execution_path == "local_docker":
+        command, _ = build_local_container_command(
+            surface=surface,
+            eval_input=eval_input,
+            control_run_dir=run_dir.resolve(),
+            entrypoint=entrypoint_path.resolve(),
+            repo_root=repo_root,
+            device_request=device_request,
+            extra_env=extra_env,
+        )
+        process_env = os.environ.copy()
+    else:
+        message = f"smoke test requires a local execution path, got {execution_path!r}"
+        _write_result(path, passed=False, sample_count=0, exit_code=1, stdout="", failures=[message])
+        print(message, file=sys.stderr)
+        return 1
 
     exit_code = 1
     try:
         with log_path.open("w", encoding="utf-8") as log:
             completed = subprocess.run(
                 command,
-                cwd=str(Path(__file__).resolve().parents[4]),
-                env=os.environ.copy(),
+                cwd=str(repo_root),
+                env=process_env,
                 stdout=log,
                 stderr=subprocess.STDOUT,
                 text=True,
@@ -298,7 +327,8 @@ def main() -> int:
         return 1
 
     log_text = log_path.read_text(encoding="utf-8", errors="replace") if log_path.exists() else ""
-    exit_code = effective_container_exit_code(exit_code, log_text)
+    if execution_path == "local_docker":
+        exit_code = effective_container_exit_code(exit_code, log_text)
     canonical_dataset = _canonical_dataset(eval_input, dataset)
     pred_path = eval_run_dir / "predictions" / f"{canonical_dataset}.txt"
     total, valid = _count_valid_predictions(pred_path)

--- a/sure/skills/sure_eval/scripts/templates/main_agent_execution_surface.json
+++ b/sure/skills/sure_eval/scripts/templates/main_agent_execution_surface.json
@@ -16,9 +16,11 @@
   },
   "deployment_binding": {
     "schema": "sure.eval.deployment_binding.v1",
-    "target_image_ref": "",
+    "runtime_kind": "",
+    "target_image_ref": null,
+    "model_python": null,
     "bundle_identity_sha256": null,
-    "execution_mode": "container_only",
+    "execution_mode": "",
     "model_mount_read_only": true,
     "result_mount_writable": true
   },

--- a/sure/skills/sure_eval/scripts/test_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_deployment_binding.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,6 +12,7 @@ from unittest.mock import patch
 from container_execution import build_local_container_command
 from deployment_binding import DeploymentBindingError, load_deployment_binding
 from check_run_report import _submitted_image_error
+from python_execution import build_local_python_command
 from run_vc_execution import _approved_memory_gb, _job_name, _normalize_job_name, _write_entrypoint
 
 
@@ -214,10 +216,135 @@ class DeploymentBindingTests(unittest.TestCase):
             },
         )
 
+    def _write_python_bundle(self) -> Path:
+        model_python = self.model / ".venv" / "bin" / "python"
+        model_python.parent.mkdir(parents=True)
+        model_python.symlink_to(sys.executable)
+        lockfile = self.model / "requirements.lock"
+        lockfile.write_text("demo==1.0\n", encoding="utf-8")
+        write_json(
+            self.artifacts / "runtime_inventory.json",
+            {
+                "schema": "sure.onboard.runtime_inventory.v2",
+                "status": "ready",
+                "model": {"name": "demo"},
+                "local_runtime": {
+                    "purpose": "eval_runtime",
+                    "eligible_for_eval": True,
+                    "backend": "pip",
+                    "python_executable": ".venv/bin/python",
+                    "path_scope": "model_relative",
+                    "python_version": "3.11.5",
+                    "lockfiles": ["requirements.lock"],
+                    "lockfile_scopes": {"requirements.lock": "model_relative"},
+                    "lockfile_sha256": {"requirements.lock": sha256(lockfile)},
+                    "working_dir": ".",
+                    "server_command": [".venv/bin/python", "server.py"],
+                    "tool_names": ["transcribe_audio"],
+                    "required_imports": [],
+                    "gpu_required": False,
+                },
+                "container_runtime": {"required": False},
+                "policy": {
+                    "eval_runtime": "python_only",
+                    "host_python_fallback": False,
+                    "image_override_allowed": False,
+                    "nfs_models_mutable_by_eval": False,
+                },
+            },
+        )
+        write_json(
+            self.artifacts / "package_gate.json",
+            {
+                "schema": "sure.onboard.package_gate.v2",
+                "status": "passed",
+                "package_profile": "none",
+                "readiness": {
+                    "local_ready": True,
+                    "docker_ready": False,
+                    "registry_ready": False,
+                    "bundle_ready": False,
+                },
+            },
+        )
+        hashes = {
+            "artifacts/runtime_inventory.json": sha256(self.artifacts / "runtime_inventory.json"),
+            "artifacts/package_gate.json": sha256(self.artifacts / "package_gate.json"),
+        }
+        bundle_identity = hashlib.sha256(
+            json.dumps(hashes, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        write_json(
+            self.artifacts / "deployment_ready.json",
+            {
+                "schema": "sure.onboard.deployment_ready.v1",
+                "status": "ready",
+                "model_name": "demo",
+                "package_profile": "none",
+                "bundle_identity_sha256": bundle_identity,
+                "required_artifact_sha256": hashes,
+                "execution_policy": {
+                    "container_only": False,
+                    "eval_runtime": "python",
+                    "nfs_models_read_only": True,
+                    "host_python_fallback": False,
+                    "approved_image_override": False,
+                },
+            },
+        )
+        return model_python
+
+    def _python_site_policy(self, *runtimes: str) -> dict:
+        return {
+            "policy": {
+                "storage": {"runtime_root": str(self.root / "runtime")},
+                "execution": {"local_runtimes": list(runtimes)},
+            }
+        }
+
     def test_loads_exact_digest_binding(self) -> None:
         binding = load_deployment_binding(self.model, "demo")
         self.assertEqual(binding["target_image_ref"], self.image_ref)
         self.assertTrue(binding["container"]["model_mount"]["read_only"])
+
+    def test_loads_python_binding_without_container_artifacts(self) -> None:
+        model_python = self._write_python_bundle()
+
+        with patch("deployment_binding.load_site_policy", return_value=self._python_site_policy("python", "container")):
+            binding = load_deployment_binding(self.model, "demo")
+
+        self.assertEqual(binding["runtime_kind"], "python")
+        self.assertEqual(binding["python"]["python_executable"], str(model_python))
+        self.assertNotIn("target_image_ref", binding)
+
+    def test_python_binding_requires_site_policy_opt_in(self) -> None:
+        self._write_python_bundle()
+
+        with patch("deployment_binding.load_site_policy", return_value=self._python_site_policy("container")):
+            with self.assertRaisesRegex(DeploymentBindingError, "execution.local_runtimes"):
+                load_deployment_binding(self.model, "demo")
+
+    def test_python_command_uses_approved_interpreter_without_docker(self) -> None:
+        model_python = self._write_python_bundle()
+        with patch("deployment_binding.load_site_policy", return_value=self._python_site_policy("python")):
+            binding = load_deployment_binding(self.model, "demo")
+        command, env, provenance = build_local_python_command(
+            surface={"env": {"TOOL_NAME": "transcribe_audio"}},
+            eval_input={
+                "model": {"deployment_binding": binding},
+                "runtime": {
+                    "run_dir": str(self.output),
+                    "harness_runtime": self._runtime_binding(),
+                },
+            },
+            entrypoint=self.entrypoint,
+            repo_root=Path(__file__).resolve().parents[4],
+        )
+
+        self.assertEqual(command, ["bash", str(self.entrypoint)])
+        self.assertEqual(env["MODEL_PYTHON"], str(model_python))
+        self.assertEqual(provenance["runtime_kind"], "python")
+        self.assertNotIn("docker", " ".join(command).lower())
 
     def test_hash_tamper_is_rejected(self) -> None:
         package = json.loads((self.artifacts / "package_gate.json").read_text())

--- a/sure/skills/sure_eval/scripts/test_eval_input_policy.py
+++ b/sure/skills/sure_eval/scripts/test_eval_input_policy.py
@@ -71,6 +71,28 @@ class ExecutionSurfacePolicyTests(unittest.TestCase):
                 resolve_eval_input._normalize_execution("vc", "auto", ["local"])
         self.assertIn("not enabled by the active site policy", str(ctx.exception))
 
+    def test_python_runtime_selects_local_python_when_allowed(self) -> None:
+        with mock.patch.object(resolve_eval_input, "_vc_available", return_value=False):
+            execution = resolve_eval_input._normalize_execution(
+                "auto",
+                "auto",
+                ["local"],
+                runtime_kind="python",
+                allowed_local_runtimes=["python"],
+            )
+        self.assertEqual(execution["path_planned"], "local_python")
+
+    def test_explicit_local_container_requires_policy_permission(self) -> None:
+        with mock.patch.object(resolve_eval_input, "_vc_available", return_value=False):
+            with self.assertRaisesRegex(ValueError, "execution.local_runtimes"):
+                resolve_eval_input._normalize_execution(
+                    "local",
+                    "auto",
+                    ["local", "vc"],
+                    runtime_kind="container",
+                    allowed_local_runtimes=["python"],
+                )
+
 
 class OutputDirPolicyTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/sure/skills/sure_eval/scripts/test_execution_surface_checks.py
+++ b/sure/skills/sure_eval/scripts/test_execution_surface_checks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -29,9 +30,11 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
             },
         )
         live.start()
+        self.live_probe_patch = live
         self.addCleanup(live.stop)
         self.approved = {
             "schema": "sure.eval.deployment_binding.v1",
+            "runtime_kind": "container",
             "target_image_ref": IMAGE_REF,
             "container": {"tool_names": ["transcribe_audio"]},
             "policy": {"execution_mode": "container_only", "host_python_fallback": False},
@@ -79,6 +82,7 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
             "execution": {"requested": "local", "path_planned": "local_docker"},
             "deployment_binding": {
                 "schema": "sure.eval.deployment_binding.v1",
+                "runtime_kind": "container",
                 "target_image_ref": IMAGE_REF,
                 "bundle_identity_sha256": "b" * 64,
                 "execution_mode": "container_only",
@@ -113,6 +117,7 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
     def test_image_mismatch_is_rejected(self) -> None:
         declared = {
             "schema": "sure.eval.deployment_binding.v1",
+            "runtime_kind": "container",
             "target_image_ref": "registry.example.com/sure/other@sha256:" + "c" * 64,
             "bundle_identity_sha256": "b" * 64,
             "execution_mode": "container_only",
@@ -150,6 +155,26 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
         )
         self.assertFalse(result["passed"])
         self.assertIn("separate execution roles", result["evidence"])
+
+    def test_python_runtime_probe_uses_model_interpreter_without_docker(self) -> None:
+        self.live_probe_patch.stop()
+        result = checks._live_runtime_probe(
+            {
+                "runtime_kind": "python",
+                "model_dir": self.temp.name,
+                "python": {
+                    "backend": "pip",
+                    "python_executable": sys.executable,
+                    "working_dir": self.temp.name,
+                    "required_imports": ["json"],
+                },
+            },
+            {"python_executable": str(self.harness_python)},
+        )
+
+        self.assertTrue(result["passed"], result["evidence"])
+        self.assertEqual(result["model_python"], sys.executable)
+        self.assertEqual(result["required_imports"], ["json"])
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_eval/scripts/test_local_execution_exit.py
+++ b/sure/skills/sure_eval/scripts/test_local_execution_exit.py
@@ -63,6 +63,54 @@ class LocalExecutionExitTests(unittest.TestCase):
         self.assertEqual(result["exit_code"], 37)
         self.assertEqual(result["job_status"], "failed")
 
+    def test_local_python_dispatch_never_builds_a_docker_command(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            run_dir = Path(temporary) / "run"
+            artifacts = run_dir / "artifacts"
+            artifacts.mkdir(parents=True)
+            entrypoint = artifacts / "run.sh"
+            entrypoint.write_text("#!/bin/sh\n", encoding="utf-8")
+            (artifacts / "execution_surface.json").write_text(
+                json.dumps(
+                    {
+                        "entrypoint_path": str(entrypoint),
+                        "execution": {
+                            "requested": "local",
+                            "planned": "local",
+                            "path_planned": "local_python",
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (artifacts / "eval_input_resolved.json").write_text(
+                json.dumps({"runtime": {"model_runtime": "python"}}),
+                encoding="utf-8",
+            )
+            argv = ["run_local_execution.py", "--run-dir", str(run_dir)]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(run_local_execution, "_vc_available", return_value=False),
+                patch.object(
+                    run_local_execution,
+                    "build_local_python_command",
+                    return_value=(
+                        ["bash", "-c", "exit 0"],
+                        {},
+                        {"runtime_kind": "python"},
+                    ),
+                ) as python_builder,
+                patch.object(run_local_execution, "build_local_container_command") as container_builder,
+            ):
+                return_code = run_local_execution.main()
+
+            self.assertEqual(return_code, 0)
+            python_builder.assert_called_once()
+            container_builder.assert_not_called()
+            result = json.loads((artifacts / "execution_result.json").read_text(encoding="utf-8"))
+            self.assertEqual(result["execution_path"], "local_python")
+            self.assertEqual(result["runtime_kind"], "python")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sure/skills/sure_eval/scripts/vc_check.py
+++ b/sure/skills/sure_eval/scripts/vc_check.py
@@ -4,7 +4,7 @@
 Probes vc availability (`which vc && vc info`) and validates that the produced
 submit_result.json matches the user-requested execution surface:
 - execution=vc must submit through vc.
-- execution=local must run through the approved local Docker binding.
+- execution=local must run through the approved local Python or Docker binding.
 - execution=auto prefers vc when available; local auto fallback must explain why.
 The environment-derived vc_available field is stamped into the artifact.
 
@@ -66,7 +66,7 @@ def _execution_requested(data: dict, run_dir: Path) -> str:
     execution_path = str(data.get("execution_path") or "")
     if execution_path == "vc_submit":
         return "vc"
-    if execution_path in {"local_bash", "local_docker"}:
+    if execution_path in {"local_bash", "local_python", "local_docker"}:
         return "local"
     return "auto"
 
@@ -101,7 +101,7 @@ def main() -> int:
 
     execution_path = data.get("execution_path", "")
     requested = _execution_requested(data, run_dir)
-    local_paths = {"local_docker"}
+    local_paths = {"local_python", "local_docker"}
 
     if requested == "vc" and execution_path != "vc_submit":
         print(
@@ -118,7 +118,7 @@ def main() -> int:
         return 1
     if requested == "local" and execution_path not in local_paths:
         print(
-            "SUBMIT_EXECUTION gate: user requested execution=local, so execution_path must be local_docker.",
+            "SUBMIT_EXECUTION gate: user requested execution=local, so execution_path must be local_python or local_docker.",
             file=sys.stderr,
         )
         return 1

--- a/sure/skills/sure_onboard/SKILL.md
+++ b/sure/skills/sure_onboard/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: sure-onboard
-description: Adapt an audio model, validate it locally and in Docker, publish a digest-pinned image, and seal a container-only deployment bundle for SURE Eval.
+description: Adapt and validate an audio model, then seal an approved Python runtime or digest-pinned container for SURE Eval.
 ---
 
 # /sure_onboard
 
-Onboard or repair an audio model into a reproducible, container-delivered inference unit. The state machine lives in `hooks/state-machine.ts`; this document is what the agent reads to drive each unit.
+Onboard or repair an audio model into a reproducible inference unit. The state machine lives in `hooks/state-machine.ts`; this document is what the agent reads to drive each unit.
 
 **Prerequisite**: run `/sure_init` first to select an agent, configure auth, and validate the environment for this project.
 
-Control principle: **agent decides scope, scripts enforce format and execution.** Local validation may use a model-local environment, but a local model is Eval-ready only after Docker build, container validation, registry push, digest-pinned pull verification, and final bundle sealing. API models are the only exception.
+Control principle: **agent decides scope, scripts enforce format and execution.** A local model is Eval-ready after one selected runtime is validated and sealed: `package=none` publishes an explicit locked Python runtime, while `package=docker-registry` publishes a digest-pinned container. Python readiness is never inferred from the current shell or base Python.
 
 ## Parameters
 
@@ -25,7 +25,7 @@ Control principle: **agent decides scope, scripts enforce format and execution.*
 | `preferred_backend` | — | `uv \| pip \| conda \| pixi \| docker \| api` (overrides auto-selection). |
 | `python_version` | — | Pin a Python version. |
 | `weights_source` | — | Weights URL / local path. |
-| `package` | — | Local models default to and require `docker-registry` for success. `none` is API/local-diagnostic only; `docker-local` cannot produce an Eval-ready local bundle. |
+| `package` | — | Defaults to `none` when the site permits local Python, otherwise `docker-registry`. `none` requires a validated `uv`, `pip`, `conda`, or `pixi` runtime; `docker-registry` requires immutable registry delivery; `docker-local` is diagnostic-only. |
 | `package_profile` | — | Alias for `package`; use only one. |
 | `weights_link_policy` | — | `auto` (default), `copy`, `symlink`, `reuse-existing`, or `no-reuse`. |
 | `skip_download` | — | bool — use existing local weights only. |
@@ -65,8 +65,10 @@ Recommended first command after start, when a `MODEL_INPUT` path is available:
   --model-input-path sure/handoffs/<model>/model_input.yaml \
   --run-dir <run_dir> \
   --repo-root <repo_root> \
-  --package-profile docker-registry
+  --package-profile <resolved_package_profile>
 ```
+
+Use the package profile reported by the `pre_start` hook; do not replace a resolved `docker-registry` profile with `none`.
 
 This helper emits only `model_input_resolved.json` and `context_selection.json`. It deliberately does **not** emit `backend_choice.json` or `build_plan.json`; those must remain agent-research-first outputs based on repository evidence and documented import/load/inference paths.
 
@@ -146,11 +148,11 @@ Isolation rule: `sure/models/<model_name>/` itself must be a real harness-owned 
 
 Advance happens **only** when the current unit's `produces` is compliant. Linear units are agent self-driven; gate units additionally run a Python semantic check. Produce the current unit's artifact, then call `sure_update_state`.
 
-Default target for local models is **registry-backed container-ready**:
+The selected package profile defines the only Eval runtime published by the bundle:
 
-- `package=docker-registry`: required for local-model success; build, validate, push, resolve the immutable digest, and pull-verify that exact digest.
+- `package=none`: the default when `execution.local_runtimes` permits `python`; validate and seal the explicit Model Python, lockfile hashes, server command, and tool names. It can produce a successful local verdict without Docker.
+- `package=docker-registry`: build, validate, push, resolve the immutable digest, and pull-verify that exact digest.
 - `package=docker-local`: diagnostic only; it may prove a local image but cannot produce an Eval-ready bundle.
-- `package=none`: accepted for API deployments and explicit local diagnostics only; it cannot produce a successful local verdict.
 
 VC/HPC submission is not part of this core skill. If needed later, implement it as a separate deployment skill/command.
 
@@ -197,11 +199,11 @@ VC/HPC submission is not part of this core skill. If needed later, implement it 
 - **generate_wrapper**: Output = `wrapper_manifest.json` {wrapper_path, model_py, server_py, ...}. The wrapper set lands in `sure/models/<model_name>/` (model.py, server.py, __init__.py, validate.py). Generated `validate.py` must preserve the template CLI: `--stage import|load|infer|contract|all`, write `artifacts/<stage>_result.json`, write `artifacts/sample_output.json` during infer, and validate contract from `io_contract`. Templates live in `scripts/templates/`. `config.yaml` may enable `protocols.strict_core` only when every conservative parameter (`temperature`, `do_sample`, `num_beams`, `num_return_sequences`, `seed`) maps to a property declared by the selected MCP tool `input_schema`, or is explicitly marked `model_param: null`, `status: not_applicable` with an architecture-specific reason. Omit/disable `strict_core` when that proof is unavailable; `/sure_eval` will still use `standard_system` by default.
 - **metric enrichment reference**: Metric reports are optional enrichment, not a deployment gate. Reuse existing `sample_output.json` / generated audio whenever possible; do not rerun inference only to repair metric semantics.
 - **validate_import/load/infer/contract**: Output = `{*_passed, error, run_command|validate_py, log_path, ...}`. The gate executes `run_command` or `validate_py`; a boolean alone is not accepted. `validate_infer` is additionally Hook-guarded: `fixture_manifest.json` must exist, point to `model_dir/fixture/<task>/.../gt.jsonl`, and declare 1-5 samples before inference can run. `validate_infer` must also leave a non-empty `sample_output.json` under the run or model artifacts directory. `validate_contract` re-reads that sample output and checks it against `MODEL_INPUT.io_contract` (`required_fields`, `nonempty_fields`, `primary_field`, and audio-output evidence).
-- **package_container**: First run `"$HARNESS_PYTHON_BIN" scripts/describe_harness_runtime.py`. Add its exact named build context and `COPY --from=sure_harness_runtime` line to the model Docker build. Output `docker_registry_result.json` plus `docker_build_result.json` and `docker_validation.json`. For local models, evidence must name one target image, its registry digest, the resulting `<image>@sha256:...` reference, the Dockerfile/sample hashes, distinct `model_runtime` and `harness_runtime` bindings, both groups of passing checks, and passing push/pull verification. The gate independently executes both Python roles in the digest-pinned image.
-- **save_artifacts**: Output = `artifact_manifest.json` {model_dir, artifacts.{required,conditional,optional}}. Gate checks model-local files exist and stages the Docker evidence; it does not create runtime readiness.
-- **package_gate**: Output schema v2 = `package_gate.json` {status, package_profile, readiness, bundle_ready, model_dir, artifact_manifest_path}. A local `passed` result requires `docker-registry`, all local validations, and exact Docker tag/digest/ref agreement. `none` and `docker-local` stay non-Eval-ready.
-- **write_runtime_inventory**: Output schema v2 = `runtime_inventory.json`. Local models explicitly separate `model_runtime` and the common `harness_runtime`, and expose only `execution_mode=container_only`, the digest-pinned image, server command/tool names, and read-only model/write-separated result mount policy. Host Model Python is evidence only and is never an Eval fallback.
-- **verdict**: Output = `verdict.json` {status, instance_id, package, readiness, build, validation, artifacts}. A local success requires `package_profile=docker-registry` and `bundle_ready=true`; local-only profiles must remain `partial` or failed.
+- **package_container**: For `package=none`, emit `docker_registry_result.json` with `status=skipped` and a reason; do not call Docker or create Docker sidecars. For a Docker profile, first run `"$HARNESS_PYTHON_BIN" scripts/describe_harness_runtime.py`, then build and validate the image. `docker-registry` additionally requires push, digest resolution, and pull verification.
+- **save_artifacts**: Output = `artifact_manifest.json` {model_dir, artifacts.{required,conditional,optional}}. Gate checks model-local files exist and stages only evidence relevant to the selected package profile; it does not create runtime readiness.
+- **package_gate**: Output schema v2 = `package_gate.json` {status, package_profile, readiness, bundle_ready, model_dir, artifact_manifest_path}. `none` requires passing local validation with `local_ready=true`; `docker-registry` additionally requires exact Docker tag/digest/ref agreement and all container/registry readiness fields. `docker-local` stays non-Eval-ready.
+- **write_runtime_inventory**: Output schema v2 = `runtime_inventory.json`. `package=none` binds one approved `uv`, `pip`, `conda`, or `pixi` Model Python plus lock hashes and launch metadata. `docker-registry` binds one digest-pinned container. Neither path may fall back to an unrecorded interpreter or mutate the approved model bundle.
+- **verdict**: Output = `verdict.json` {status, instance_id, package, readiness, build, validation, artifacts}. `package=none` or `docker-registry` may succeed when its own gates pass; `docker-local` must remain `partial` or failed.
 - **finalize_model_bundle**: Copies terminal evidence to the model directory, rewrites manifest/package paths to be portable, verifies hashes, and atomically writes `deployment_ready.json`. This file is the only terminal readiness marker consumed by `/sure_eval`.
 
 ## Backend Routing Rules (Phase 1)
@@ -209,11 +211,11 @@ VC/HPC submission is not part of this core skill. If needed later, implement it 
 Rule-based backend selection (record the reason in `backend_choice.json`):
 
 1. API-only model → `api`.
-2. Repo has Dockerfile + complex deps → `docker`.
+2. Repo has Dockerfile + complex deps and `package=docker-registry` → `docker`.
 3. Repo has `environment.yml` / conda signals → `pixi` (or `conda`).
 4. Repo has only `pyproject.toml` / `requirements.txt`, pure Python → `uv`.
-5. CUDA compilation / custom C++ / k2 / complex submodules → `docker` first.
-6. High host-pollution risk → `docker` first.
+5. CUDA compilation / custom C++ / k2 / complex submodules → use `docker` with `package=docker-registry`, or stop early if the user selected `package=none`.
+6. High host-pollution risk → prefer `conda`/`pixi` for `package=none`, or use `docker-registry`.
 
 ## Model-Local Checkpoint Rule
 
@@ -233,11 +235,11 @@ sure/models/<model_name>/
 │   ├── build_plan.json
 │   ├── validation.log
 │   ├── sample_output.json
-│   ├── docker_build_result.json / docker_validation.json
-│   ├── docker_registry_result.json
+│   ├── docker_build_result.json / docker_validation.json    # container package only
+│   ├── docker_registry_result.json                          # container package only
 │   ├── package_gate.json / verdict.json
 │   ├── artifact_manifest.json
-│   ├── runtime_inventory.json                     # container-only Eval binding
+│   ├── runtime_inventory.json                     # approved Python or container binding
 │   └── deployment_ready.json                      # terminal immutable readiness marker
 ├── fixture/<task>/                                      # test audio + gt.jsonl (2–3 samples, max 5)
 ├── .runtime/ checkpoints/                               # weights convergence
@@ -246,7 +248,7 @@ sure/models/<model_name>/
 
 ## Backend
 
-The deterministic backend is bundled in `scripts/`. Gate scripts validate each unit. `stage_model_artifacts.py` stages existing run evidence; `write_runtime_inventory.py` writes runtime provenance only after the package gate; `finalize_model_bundle.py` seals the portable bundle. No helper may infer an Eval runtime from `.venv`, host Python, a Dockerfile, or an image name alone.
+The deterministic backend is bundled in `scripts/`. Gate scripts validate each unit. `stage_model_artifacts.py` stages existing run evidence; `write_runtime_inventory.py` writes runtime provenance only after the package gate; `finalize_model_bundle.py` seals the portable bundle. No helper may infer an Eval runtime from the presence of `.venv`, host Python, a Dockerfile, or an image name alone.
 
 ```bash
 "$HARNESS_PYTHON_BIN" scripts/<script>.py <args>   # cwd = skill package dir
@@ -260,4 +262,4 @@ If the same hook/gate blocks three consecutive attempts, stop and ask the user t
 
 ## Success Criteria
 
-The `pre_finish` hook enforces that the state machine reached `finalize_model_bundle` and that `deployment_ready.json` passes its hash, portability, package, and execution-policy checks. A local model cannot finish successfully without immutable registry evidence.
+The `pre_finish` hook enforces that the state machine reached `finalize_model_bundle` and that `deployment_ready.json` passes its hash, portability, package, and execution-policy checks. A local model must finish with either an explicitly approved Python identity or immutable registry evidence.

--- a/sure/skills/sure_onboard/hooks/index.ts
+++ b/sure/skills/sure_onboard/hooks/index.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { SureHookContext, SureHookResult } from "@earendil-works/pi-coding-agent/hooks";
 import { resolveHarnessPython } from "../../../runtime/harness/resolve.ts";
+import { resolveSitePolicy } from "../../../site/loader.ts";
 import {
 	advance,
 	artifactPath,
@@ -59,6 +60,14 @@ const TASK_TYPES = [
 ];
 const DEPLOYMENT_TYPES = ["local", "api"];
 const PACKAGE_PROFILES = ["none", "docker-local", "docker-registry"];
+
+function defaultPackageProfile(deploymentType: string | undefined, repositoryRoot: string): string {
+	if (deploymentType === "api") {
+		return "none";
+	}
+	const localRuntimes = resolveSitePolicy({ repositoryRoot })?.policy.execution.local_runtimes ?? ["container"];
+	return localRuntimes.includes("python") ? "none" : "docker-registry";
+}
 
 interface ResolvedOnboardArgs {
 	args: Record<string, string>;
@@ -470,7 +479,7 @@ function resolveOnboardArgs(ctx: SureHookContext): ResolvedOnboardArgs {
 			merged.weights_source = values["weights.source"];
 		}
 		if (!merged.package_profile && !merged.package) {
-			merged.package_profile = merged.deployment_type === "api" ? "none" : "docker-registry";
+			merged.package_profile = defaultPackageProfile(merged.deployment_type, ctx.cwd);
 		}
 		if (!merged.model_name && merged.model_id) {
 			merged.model_name = slugifyModelName(merged.model_id);
@@ -492,7 +501,11 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 		args.package_profile = args.package;
 	}
 	if (!args.package_profile) {
-		args.package_profile = args.deployment_type === "api" ? "none" : "docker-registry";
+		try {
+			args.package_profile = defaultPackageProfile(args.deployment_type, ctx.cwd);
+		} catch (error) {
+			return failure(error instanceof Error ? error.message : String(error), "Invalid site policy.");
+		}
 	}
 	if (!args.model_name && args.model_id) {
 		args.model_name = slugifyModelName(args.model_id);
@@ -512,7 +525,7 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (missing.length > 0) {
 		return failure(
-			`Missing required /sure_onboard parameters: ${missing.join(", ")}. Usage: /sure_onboard model=<handoff_name> OR /sure_onboard model_input_path=sure/handoffs/<handoff_name>/model_input.yaml OR /sure_onboard model_id=<owner/model> model_name=<owner__model> repo=<url|path> task_type=<${TASK_TYPES.join("|")}> deployment_type=<local|api> [preferred_backend=uv|pip|conda|pixi|docker|api] [python_version=...] [weights_source=...] [package=docker-registry] [force_repair=true] [existing_model_dir=...] [max_retries=3]`,
+			`Missing required /sure_onboard parameters: ${missing.join(", ")}. Usage: /sure_onboard model=<handoff_name> OR /sure_onboard model_input_path=sure/handoffs/<handoff_name>/model_input.yaml OR /sure_onboard model_id=<owner/model> model_name=<owner__model> repo=<url|path> task_type=<${TASK_TYPES.join("|")}> deployment_type=<local|api> [preferred_backend=uv|pip|conda|pixi|docker|api] [python_version=...] [weights_source=...] [package=none|docker-local|docker-registry] [force_repair=true] [existing_model_dir=...] [max_retries=3]`,
 			"Missing required parameters.",
 		);
 	}
@@ -533,9 +546,22 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (!PACKAGE_PROFILES.includes(args.package_profile)) {
 		return failure(
-			`package "${args.package_profile}" is not one of ${JSON.stringify(PACKAGE_PROFILES)}. Local models default to package=docker-registry; package=none is diagnostic/local-only and cannot produce an Eval-ready bundle.`,
+			`package "${args.package_profile}" is not one of ${JSON.stringify(PACKAGE_PROFILES)}. Sites that allow local Python default to package=none; choose package=docker-registry for immutable container delivery.`,
 			"Invalid package profile.",
 		);
+	}
+	if (args.deployment_type === "local" && args.package_profile === "none") {
+		try {
+			const sitePolicy = resolveSitePolicy({ repositoryRoot: ctx.cwd });
+			if (sitePolicy && !sitePolicy.policy.execution.local_runtimes.includes("python")) {
+				return failure(
+					"package=none requires python in execution.local_runtimes; enable it in the site policy or use package=docker-registry.",
+					"Local Python runtime is disabled by site policy.",
+				);
+			}
+		} catch (error) {
+			return failure(error instanceof Error ? error.message : String(error), "Invalid site policy.");
+		}
 	}
 	const runtime = resolveHarnessPython(ctx.packageDir);
 	if (!runtime.ok || !runtime.contract) {

--- a/sure/skills/sure_onboard/references/AGENTS.md
+++ b/sure/skills/sure_onboard/references/AGENTS.md
@@ -1,8 +1,8 @@
 # SURE-EVAL 模型接入 Harness 规范 (第一阶段)
 
 **版本**: v1.0  
-**目标**: 将语音模型仓库接入为**本地验证、容器交付的可复现推理单元**
-**范围**: 环境适配、最小推理验证、镜像发布与不可变运行时绑定
+**目标**: 将语音模型仓库接入为**本地验证、可复现交付的推理单元**
+**范围**: 环境适配、最小推理验证、Python 或容器运行时绑定
 
 ---
 
@@ -14,14 +14,14 @@
 
 ### 1.0 Harness 分支边界覆盖规则
 
-本 `sure_onboard` harness 版本以 **registry-backed container-ready** 为本地模型默认成功条件：
+本 `sure_onboard` harness 按 `package_profile` 发布一个主要运行时：
 
-- `package=docker-registry`：本地模型默认且唯一可成功交付的路径，要求 Docker build、容器验证、push、digest 解析与 pull verify。
+- `package=none`：当 site policy 的 `execution.local_runtimes` 允许 `python` 时为默认路径；要求显式绑定并验证 uv/pip/conda/pixi 创建的 Model Python、lock hash、server command 与 tool names，可产出 success verdict。
+- `package=docker-registry`：容器交付路径，要求 Docker build、容器验证、push、digest 解析与 pull verify。
 - `package=docker-local`：仅诊断，不能产生 Eval-ready 成功产物。
-- `package=none`：用于 API 或显式本地诊断；本地模型不得产出 success verdict。
 - VC/HPC submit/validate 不属于核心 `/sure_onboard` 成功条件；如需支持，应作为独立 deployment plugin 或独立 slash command。
 
-当本文档后续历史段落与以上边界冲突时，以本节和 `SKILL.md` 状态机为准。本地适配环境只用于验证和制作镜像，不能成为 `/sure_eval` 的 host fallback。
+当本文档后续历史段落与以上边界冲突时，以本节和 `SKILL.md` 状态机为准。Python Eval 只能使用工件中批准的 Model Python，不能回退到当前 shell 或 base Python。任务 playbook 中的 Docker 步骤仅在 Docker package profile 下适用。
 
 本文档定义第一阶段模型接入的标准 workflow，确保：
 
@@ -595,22 +595,22 @@ sure/models/{model}/checkpoints/                # 显式本地权重（如有）
 
 ---
 
-## 8. 必选 Docker 镜像制作与可选集群提交
+## 8. 可选 Docker 镜像制作与集群提交
 
-本节定义本地模型 onboarding 的必选 Docker 交付步骤。Docker registry readiness 属于 `/sure_onboard` 成功条件；VC/HPC submit 仍然是外部部署能力。
+本节只定义 Docker package profile 的交付步骤。`package=none` 必须跳过本节，不调用 Docker；VC/HPC submit 仍然是外部部署能力。
 
 ### 8.1 适用范围
 
-**本地模型需要制作独立 Docker 镜像**:
-- `/sure_onboard package=docker-registry`（默认成功路径）
+**以下情况需要制作独立 Docker 镜像**:
+- `/sure_onboard package=docker-registry`（容器成功路径）
 - `/sure_onboard package=docker-local`（仅诊断）
-- 需要本地 Python/系统依赖、模型权重、GPU/CPU runtime 的模型
 - 需要通过未来独立部署命令提交到集群容器任务运行的模型
 
 **可以跳过**:
+- `package=none` 且 uv/pip/conda/pixi Model Python 已通过全部验证
 - 纯 API 模型，且运行时只需要远程 endpoint/token
 
-本地模型无法完成 Docker registry 交付时只能记录为 partial/blocked，不能写入 Eval-ready 成功标记。
+选择 `package=docker-registry` 后无法完成 registry 交付时，只能记录为 partial/blocked，不能改用未批准的 Python 作为隐式 fallback。
 
 ### 8.2 镜像命名规则
 

--- a/sure/skills/sure_onboard/references/experience_loss_register.md
+++ b/sure/skills/sure_onboard/references/experience_loss_register.md
@@ -3,8 +3,9 @@
 This register tracks experience assets from the original
 `docs/agents/model_tool_agent` that must stay active in the harness port.
 It focuses on task, fixture, metric, environment, and failure-handling
-knowledge. Docker/registry delivery is required for local-model success; only
-VC submission remains outside this skill.
+knowledge. Local-model success requires either a locked Python runtime or
+Docker/registry delivery, according to the selected package profile. VC
+submission remains outside this skill.
 
 ## P0 Restores
 
@@ -30,5 +31,5 @@ VC submission remains outside this skill.
 
 | Source experience | Harness decision |
 | --- | --- |
-| `deployment_type == local` must finish Docker and registry pull verification before final passed/tool_ready. | Restored as the default `package=docker-registry` gate. VC/HPC remains an external deployment skill. |
+| `deployment_type == local` must finish Docker and registry pull verification before final passed/tool_ready. | Replaced by runtime-specific delivery: `package=none` seals an approved Python runtime, while `package=docker-registry` retains the image and pull-verification gates. VC/HPC remains external. |
 | Company-specific VC command examples. | Keep as external deployment notes; do not add VC submission to `/sure_onboard`. |

--- a/sure/skills/sure_onboard/references/memory/COMMON.md
+++ b/sure/skills/sure_onboard/references/memory/COMMON.md
@@ -12,8 +12,8 @@ routed files.
   explicitly requires shared harness changes. `model_name` must be the
   single-segment normalized id derived from the provider id by replacing `/`
   with `__`; never derive it from task prefixes or informal aliases.
-- Docker image tags must align with the same repo id slug; local-model success
-  requires registry push and immutable digest pull verification.
+- When container delivery is selected, Docker image tags must align with the
+  same repo id slug and success requires immutable digest pull verification.
 - Validate `model.spec.yaml` before building the runtime.
 - Keep weights and provider caches model-local by default.
 - Validate the four minimum checks: import, load, infer, output contract.
@@ -23,8 +23,8 @@ routed files.
 - Save structured artifacts: `backend_choice.json`, `build.log`,
   `validation.log`, `sample_output.json`, `verdict.json`, and
   `artifact_manifest.json`.
-- For every local model, build and validate a model-specific Docker image and
-  publish a digest-pinned container-only runtime binding.
+- Publish one explicit runtime binding: a lock-backed Model Python for
+  `package=none`, or a digest-pinned image for `package=docker-registry`.
 
 ## Context Selection Rule
 

--- a/sure/skills/sure_onboard/references/playbooks/env_ROUTING.md
+++ b/sure/skills/sure_onboard/references/playbooks/env_ROUTING.md
@@ -34,7 +34,7 @@ it. Do not load all backend playbooks as a substitute for classification.
 | `backend: pip`, `requirements.txt`, no lockfile/tooling | `playbooks/env_pip.md` | Prefer uv as the installer if available, but keep pip-specific context small. |
 | `backend: conda`, `environment.yml` | `playbooks/env_conda.md` | Record env name, channels, CUDA/PyTorch package choices. |
 | `backend: pixi`, `pixi.toml` | `playbooks/env_pixi.md` | Use pixi lockfile and `pixi run` execution pattern. |
-| `backend: docker`, complex CUDA/C++/system deps, upstream Dockerfile | `playbooks/env_docker.md` | Required for reproducible cluster-ready local models. |
+| `backend: docker`, a Docker package profile, complex CUDA/C++/system deps, upstream Dockerfile | `playbooks/env_docker.md` | Use when container delivery is selected or Python-only delivery is impractical. |
 | XForge-generated scaffold | `playbooks/xforge_sure_bridge.md` plus selected backend playbook | Only when the input comes from XForge bridge workflow. |
 
 ## Escalation Rules

--- a/sure/skills/sure_onboard/references/policies/backend_selection.md
+++ b/sure/skills/sure_onboard/references/policies/backend_selection.md
@@ -1,42 +1,41 @@
 # Backend Selection Policy
 
 **Version**: 2.0
-**Scope**: `/sure_onboard` local adaptation and container delivery
+**Scope**: `/sure_onboard` local adaptation and runtime delivery
 
 ## Two separate decisions
 
 `backend_choice.json.backend` selects the environment used to adapt and validate the model locally. It may be `uv`, `pip`, `conda`, `pixi`, or `docker`. `package_profile` selects the delivered Eval runtime.
 
-For every local model, these decisions converge as follows:
+For every local model, these decisions converge according to `package_profile`:
 
 1. Adapt with the repository-compatible backend.
 2. Run import, load, inference, and contract checks in that environment.
-3. Adapt a Dockerfile that reproduces the passing environment.
-4. Build and repeat the bounded checks inside the image.
-5. Push the image and pull-verify its immutable registry digest.
-6. Publish `runtime_inventory.json` with `execution_mode=container_only`.
+3. For `package=none`, bind the selected Python executable, lockfile hashes, server command, working directory, required imports, and tool names.
+4. For `package=docker-registry`, reproduce the passing environment in an image, repeat bounded checks, push it, and pull-verify its immutable registry digest.
+5. Publish exactly one Eval runtime identity in `runtime_inventory.json`.
 
-The local backend is evidence used to create the image. It is not an Eval fallback.
+Eval sees only `python` or `container`; `uv`, `pip`, `conda`, and `pixi` remain Onboard implementation details. The approved Python is explicit and is not a fallback to the current shell.
 
 ## Local backend routing
 
 | Evidence | Adaptation backend |
 |---|---|
 | API-only model | `api`; package profile must be `none` |
-| Upstream Dockerfile or complex OS/CUDA dependencies | `docker` |
+| Upstream Dockerfile or complex OS/CUDA dependencies with container delivery | `docker` |
 | Conda metadata or packages | `pixi` or `conda` |
 | Pure Python packaging | `uv` or `pip` |
 
-Record repository evidence, executable availability, selected version, and any fallback in `backend_choice.json`. A fallback may change the adaptation backend, but may not waive Docker registry delivery for a local model.
+Record repository evidence, executable availability, selected version, and any fallback in `backend_choice.json`. A local `package=none` plan must use `uv`, `pip`, `conda`, or `pixi`; `backend=docker` requires a Docker package profile.
 
 ## Package policy
 
-- `docker-registry`: default and only successful local-model profile.
+- `none`: default when the site permits local Python; successful only with an explicit, validated Python runtime and lock evidence.
+- `docker-registry`: successful container profile; requires build, validation, registry push, digest resolution, and digest pull verification.
 - `docker-local`: diagnostic; final verdict must not claim Eval readiness.
-- `none`: API or explicit local diagnostic; final local verdict must not be success.
 
-If Docker, registry push, digest resolution, or digest pull verification is unavailable, stop with a repairable partial/blocked result. Do not convert host `.venv`, base Python, or a locally guessed image tag into deployment readiness.
+If Docker delivery was selected and its registry closure is unavailable, stop with a repairable partial/blocked result. Do not convert base Python, an unrecorded environment, or a locally guessed image tag into deployment readiness.
 
 ## Device policy
 
-Apply CUDA-first validation rules during local adaptation. The image must then repeat the selected device-path checks. CPU fallback evidence may be retained, but the final bundle must accurately describe the validated device and must not claim unsupported GPU readiness.
+Apply CUDA-first validation rules during local adaptation. A selected image must repeat the device-path checks. CPU fallback evidence may be retained, but the final bundle must accurately describe the validated device and must not claim unsupported GPU readiness.

--- a/sure/skills/sure_onboard/schemas/build_plan.schema.json
+++ b/sure/skills/sure_onboard/schemas/build_plan.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "build_plan.schema.json",
 	"title": "SURE onboard build plan",
-	"description": "Executable local adaptation and Docker delivery plan. Local Eval-ready bundles use package_profile=docker-registry.",
+	"description": "Executable local adaptation and optional container delivery plan.",
 	"type": "object",
 	"required": ["model_id", "model_dir", "backend", "steps", "package_profile"],
 	"properties": {

--- a/sure/skills/sure_onboard/schemas/deployment_ready.schema.json
+++ b/sure/skills/sure_onboard/schemas/deployment_ready.schema.json
@@ -25,9 +25,10 @@
 		"bundle_identity_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
 		"execution_policy": {
 			"type": "object",
-			"required": ["container_only", "nfs_models_read_only", "host_python_fallback", "approved_image_override"],
+			"required": ["container_only", "eval_runtime", "nfs_models_read_only", "host_python_fallback", "approved_image_override"],
 			"properties": {
 				"container_only": { "type": "boolean" },
+				"eval_runtime": { "enum": ["python", "container", "api", "unavailable"] },
 				"nfs_models_read_only": { "const": true },
 				"host_python_fallback": { "const": false },
 				"approved_image_override": { "const": false }

--- a/sure/skills/sure_onboard/schemas/package_gate.schema.json
+++ b/sure/skills/sure_onboard/schemas/package_gate.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "package_gate.schema.json",
 	"title": "SURE onboard package gate v2",
-	"description": "Cross-checks local validation and Docker delivery readiness. Local Eval-ready bundles require docker-registry.",
+	"description": "Cross-checks local validation and the selected Python or container delivery readiness.",
 	"type": "object",
 	"required": ["schema", "status", "package_profile", "readiness", "model_dir"],
 	"properties": {

--- a/sure/skills/sure_onboard/schemas/runtime_inventory.schema.json
+++ b/sure/skills/sure_onboard/schemas/runtime_inventory.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "runtime_inventory.schema.json",
 	"title": "SURE onboard runtime inventory v2",
-	"description": "Portable model runtime contract written after the Docker package gate.",
+	"description": "Portable model runtime contract written after the package gate.",
 	"type": "object",
 	"required": ["schema", "generated_at", "status", "model", "local_runtime", "model_runtime", "harness_runtime", "container_runtime", "weights", "readiness", "evidence", "policy"],
 	"properties": {
@@ -27,11 +27,19 @@
 			"required": ["purpose", "eligible_for_eval"],
 			"properties": {
 				"purpose": { "type": "string" },
-				"eligible_for_eval": { "const": false },
+				"eligible_for_eval": { "type": "boolean" },
 				"backend": { "type": ["string", "null"] },
 				"python_executable": { "type": ["string", "null"] },
+				"path_scope": { "type": ["string", "null"], "enum": ["model_relative", "site_runtime", null] },
 				"python_version": { "type": ["string", "null"] },
-				"lockfiles": { "type": "array", "items": { "type": "string" } }
+				"lockfiles": { "type": "array", "items": { "type": "string" } },
+				"lockfile_scopes": { "type": "object", "additionalProperties": { "enum": ["model_relative", "site_runtime"] } },
+				"lockfile_sha256": { "type": "object", "additionalProperties": { "type": "string", "pattern": "^[0-9a-f]{64}$" } },
+				"working_dir": { "type": "string" },
+				"server_command": { "type": "array", "items": { "type": "string" } },
+				"tool_names": { "type": "array", "items": { "type": "string" } },
+				"required_imports": { "type": "array", "items": { "type": "string" } },
+				"gpu_required": { "type": "boolean" }
 			},
 			"additionalProperties": true
 		},
@@ -105,7 +113,7 @@
 			"type": "object",
 			"required": ["eval_runtime", "host_python_fallback", "image_override_allowed", "nfs_models_mutable_by_eval"],
 			"properties": {
-				"eval_runtime": { "enum": ["container_only", "api_only", "unavailable"] },
+				"eval_runtime": { "enum": ["python_only", "container_only", "api_only", "unavailable"] },
 				"host_python_fallback": { "const": false },
 				"image_override_allowed": { "const": false },
 				"nfs_models_mutable_by_eval": { "const": false }

--- a/sure/skills/sure_onboard/scripts/check_build_plan.py
+++ b/sure/skills/sure_onboard/scripts/check_build_plan.py
@@ -78,6 +78,13 @@ def main() -> int:
     if package_profile != resolved.get("package_profile"):
         print("BUILD_PLAN gate: package_profile disagrees with model_input_resolved.json.", file=sys.stderr)
         return 1
+    if deployment_type == "local" and package_profile == "none" and data.get("backend") not in {"uv", "pip", "conda", "pixi"}:
+        print(
+            "BUILD_PLAN gate: local package=none requires a uv, pip, conda, or pixi Python runtime; "
+            "use package=docker-registry for backend=docker.",
+            file=sys.stderr,
+        )
+        return 1
 
     steps = data.get("steps")
     if not isinstance(steps, list) or not steps:

--- a/sure/skills/sure_onboard/scripts/check_finalized_bundle.py
+++ b/sure/skills/sure_onboard/scripts/check_finalized_bundle.py
@@ -49,7 +49,11 @@ def main() -> int:
         if manifest.get("status") != "finalized" or manifest.get("model_dir") != ".":
             raise ValueError("artifact_manifest.json was not refreshed into portable finalized form")
         if resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "docker-registry":
-            if data.get("status") != "ready" or policy.get("container_only") is not True:
+            if (
+                data.get("status") != "ready"
+                or policy.get("container_only") is not True
+                or policy.get("eval_runtime") != "container"
+            ):
                 raise ValueError("local docker-registry bundle must be container-only ready")
             image, digest, image_ref = validate_image_and_digest(
                 data.get("target_image"), data.get("target_image_digest")
@@ -66,6 +70,21 @@ def main() -> int:
             harness = data.get("harness_runtime") if isinstance(data.get("harness_runtime"), dict) else {}
             if harness.get("schema") != "sure.harness.runtime.binding.v1" or not harness.get("runtime_id"):
                 raise ValueError("ready deployment must expose the common Harness Runtime binding")
+        elif resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "none":
+            if (
+                data.get("status") != "ready"
+                or policy.get("container_only") is not False
+                or policy.get("eval_runtime") != "python"
+            ):
+                raise ValueError("local package=none bundle must be Python ready")
+            inventory = read_json(model_dir / "artifacts" / "runtime_inventory.json")
+            inventory_policy = inventory.get("policy") if isinstance(inventory.get("policy"), dict) else {}
+            local = inventory.get("local_runtime") if isinstance(inventory.get("local_runtime"), dict) else {}
+            if inventory_policy.get("eval_runtime") != "python_only" or local.get("eligible_for_eval") is not True:
+                raise ValueError("Python deployment marker disagrees with runtime inventory")
+        elif resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "docker-local":
+            if data.get("status") != "local_only" or policy.get("eval_runtime") != "unavailable":
+                raise ValueError("docker-local bundle must remain diagnostic-only")
         portable = [
             read_json(model_dir / "artifacts" / name)
             for name in ("runtime_inventory.json", "package_gate.json", "artifact_manifest.json", "deployment_ready.json")

--- a/sure/skills/sure_onboard/scripts/check_runtime_inventory.py
+++ b/sure/skills/sure_onboard/scripts/check_runtime_inventory.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -12,8 +13,49 @@ from pathlib import Path
 
 from deployment_contract import read_json, resolve_model_dir, validate_image_and_digest
 
+for _parent in Path(__file__).resolve().parents:
+    if (_parent / "sure" / "site" / "loader.py").is_file():
+        sys.path.insert(0, str(_parent))
+        break
+
+from sure.site.loader import load_site_policy
+
 
 LEGACY_PATH = re.compile(r"/(?:mnt/cloudstorfs|hpc_stor\d+|hpc_\d+)/")
+PYTHON_BACKENDS = {"uv", "pip", "conda", "pixi"}
+
+
+def _inside(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _runtime_path(raw: object, scope: object, model_dir: Path, *, executable: bool = False) -> Path:
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("Python runtime path is missing")
+    if scope == "model_relative":
+        path = Path(raw)
+        if path.is_absolute():
+            raise ValueError("model_relative Python runtime path must be relative")
+        candidate = model_dir / path
+        resolved = candidate.parent.resolve() / candidate.name if executable else candidate.resolve()
+        if not _inside(resolved, model_dir.resolve()):
+            raise ValueError("model_relative Python runtime path escapes the model bundle")
+        return resolved
+    if scope == "site_runtime":
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            raise ValueError("site_runtime Python runtime path must be absolute")
+        policy = load_site_policy(required=True)["policy"]
+        runtime_root = Path(policy["storage"]["runtime_root"]).expanduser().resolve()
+        resolved = path.parent.resolve() / path.name if executable else path.resolve()
+        if not _inside(resolved, runtime_root):
+            raise ValueError(f"site_runtime path must stay below configured runtime_root: {runtime_root}")
+        return resolved
+    raise ValueError(f"unsupported Python runtime path_scope: {scope!r}")
 
 
 def main() -> int:
@@ -67,6 +109,46 @@ def main() -> int:
                 raise ValueError("inventory Harness Runtime ID differs from the active common runtime")
             if expected_lock and harness_runtime.get("lock_sha256") != expected_lock:
                 raise ValueError("inventory Harness Runtime lock differs from the active common runtime")
+        elif deployment_type == "local" and resolved.get("package_profile") == "none":
+            site_policy = load_site_policy(required=True)["policy"]
+            if "python" not in site_policy["execution"]["local_runtimes"]:
+                raise ValueError(
+                    "local Python Eval is disabled by site policy; add python to execution.local_runtimes"
+                )
+            if data.get("status") != "ready" or policy.get("eval_runtime") != "python_only":
+                raise ValueError("package=none local model must emit a Python-ready inventory")
+            local = data.get("local_runtime") if isinstance(data.get("local_runtime"), dict) else {}
+            if local.get("eligible_for_eval") is not True or local.get("backend") not in PYTHON_BACKENDS:
+                raise ValueError("Python-ready inventory must declare an eligible uv/pip/conda/pixi runtime")
+            python = _runtime_path(
+                local.get("python_executable"),
+                local.get("path_scope"),
+                model_dir,
+                executable=True,
+            )
+            if not python.is_file() or not os.access(python, os.X_OK):
+                raise ValueError(f"approved Model Python is missing or not executable: {python}")
+            lockfiles = local.get("lockfiles") if isinstance(local.get("lockfiles"), list) else []
+            lock_scopes = local.get("lockfile_scopes") if isinstance(local.get("lockfile_scopes"), dict) else {}
+            lock_hashes = local.get("lockfile_sha256") if isinstance(local.get("lockfile_sha256"), dict) else {}
+            if not lockfiles:
+                raise ValueError("Python-ready inventory must bind at least one lockfile")
+            for lockfile in lockfiles:
+                lock_path = _runtime_path(lockfile, lock_scopes.get(lockfile), model_dir)
+                if not lock_path.is_file() or lock_hashes.get(lockfile) != hashlib.sha256(lock_path.read_bytes()).hexdigest():
+                    raise ValueError(f"Python runtime lockfile hash mismatch: {lockfile}")
+            command = local.get("server_command")
+            tools = local.get("tool_names")
+            if not isinstance(command, list) or not command or command[0] != local.get("python_executable"):
+                raise ValueError("Python runtime server_command must start with the approved Model Python")
+            if not isinstance(tools, list) or not tools:
+                raise ValueError("Python runtime must declare at least one tool name")
+            model_runtime = data.get("model_runtime") if isinstance(data.get("model_runtime"), dict) else {}
+            if model_runtime.get("required") is not True or model_runtime.get("python_executable") != local.get("python_executable"):
+                raise ValueError("Python-ready inventory model_runtime disagrees with local_runtime")
+            harness_runtime = data.get("harness_runtime") if isinstance(data.get("harness_runtime"), dict) else {}
+            if harness_runtime.get("required") is not False:
+                raise ValueError("host Harness Runtime is resolved by Eval and must not be bundled with Model Python")
         elif deployment_type == "local" and data.get("status") not in {"local_only", "partial"}:
             raise ValueError("non-registry local model cannot claim Eval-ready status")
     except (OSError, ValueError) as exc:

--- a/sure/skills/sure_onboard/scripts/check_verdict.py
+++ b/sure/skills/sure_onboard/scripts/check_verdict.py
@@ -6,7 +6,8 @@ requires build.success, all four validation tests passed, and readiness that
 matches the selected package profile:
 
   - local package=docker-registry: local/docker/registry/bundle readiness
-  - local package=none or docker-local: terminal status must remain partial
+  - local package=none: local readiness is sufficient for Python Eval
+  - local package=docker-local: terminal status must remain partial
   - API package=none: local client readiness is sufficient
 
 VC/HPC readiness is intentionally not part of this core /sure_onboard gate.
@@ -234,10 +235,10 @@ def main() -> int:
         except (OSError, ValueError) as exc:
             print(f"VERDICT gate: cannot read model_input_resolved.json: {exc}", file=sys.stderr)
             return 1
-        if resolved.get("deployment_type") == "local" and profile != "docker-registry":
+        if resolved.get("deployment_type") == "local" and profile == "docker-local":
             print(
-                "VERDICT gate: local package=none/docker-local is local_only and cannot use a success status; "
-                "emit status=partial or complete docker-registry delivery.",
+                "VERDICT gate: local package=docker-local is diagnostic-only and cannot use a success status; "
+                "emit status=partial, use package=none for Python Eval, or complete docker-registry delivery.",
                 file=sys.stderr,
             )
             return 1

--- a/sure/skills/sure_onboard/scripts/finalize_model_bundle.py
+++ b/sure/skills/sure_onboard/scripts/finalize_model_bundle.py
@@ -44,8 +44,10 @@ def json_bytes(value: dict[str, Any]) -> bytes:
     return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
 
 
-def copy_terminal_artifacts(run_dir: Path, model_dir: Path) -> None:
+def copy_terminal_artifacts(run_dir: Path, model_dir: Path, package_profile: str) -> None:
     for name in TERMINAL_ARTIFACTS:
+        if package_profile == "none" and name.startswith("docker_"):
+            continue
         source = run_dir / "artifacts" / name
         if source.is_file():
             destination = model_dir / "artifacts" / name
@@ -68,7 +70,12 @@ def update_manifest(model_dir: Path, resolved: dict[str, Any]) -> dict[str, Any]
     path = model_dir / "artifacts" / "artifact_manifest.json"
     manifest = read_json(path)
     required = manifest.setdefault("artifacts", {}).setdefault("required", {})
-    for name in (*TERMINAL_ARTIFACTS, "artifact_manifest.json", "deployment_ready.json"):
+    finalized_names = [
+        name
+        for name in TERMINAL_ARTIFACTS
+        if (model_dir / "artifacts" / name).is_file()
+    ]
+    for name in (*finalized_names, "artifact_manifest.json", "deployment_ready.json"):
         key = name.replace(".", "_").replace("-", "_")
         required[key] = {"path": f"artifacts/{name}", "description": f"Finalized onboard artifact: {name}."}
     manifest.update(
@@ -94,15 +101,22 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
     if deployment_type == "local" and profile == "docker-registry" and success and inventory.get("status") == "ready":
         status = "ready"
         container_only = True
+        eval_runtime = "container"
+    elif deployment_type == "local" and profile == "none" and success and inventory.get("status") == "ready":
+        status = "ready"
+        container_only = False
+        eval_runtime = "python"
     elif deployment_type == "api" and success and inventory.get("status") == "api_ready":
         status = "api_ready"
         container_only = False
+        eval_runtime = "api"
     else:
         status = "local_only"
         container_only = False
+        eval_runtime = "unavailable"
 
     required_names = ["runtime_inventory.json", "package_gate.json", "verdict.json", "artifact_manifest.json"]
-    if status == "ready":
+    if status == "ready" and profile == "docker-registry":
         required_names.extend(["docker_build_result.json", "docker_validation.json", "docker_registry_result.json"])
     hashes = {
         f"artifacts/{name}": sha256_file(model_dir / "artifacts" / name)
@@ -146,6 +160,7 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
         "bundle_identity_sha256": bundle_identity,
         "execution_policy": {
             "container_only": container_only,
+            "eval_runtime": eval_runtime,
             "nfs_models_read_only": True,
             "host_python_fallback": False,
             "approved_image_override": False,
@@ -155,7 +170,7 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
 
 def finalize(run_dir: Path, produces: Path) -> dict[str, Any]:
     model_dir, resolved = resolve_model_dir(run_dir)
-    copy_terminal_artifacts(run_dir, model_dir)
+    copy_terminal_artifacts(run_dir, model_dir, str(resolved.get("package_profile") or "none"))
     package = update_package_gate(run_dir, model_dir)
     update_manifest(model_dir, resolved)
     deployment = build_deployment_ready(run_dir, model_dir, resolved, package)

--- a/sure/skills/sure_onboard/scripts/materialize_onboard_inputs.py
+++ b/sure/skills/sure_onboard/scripts/materialize_onboard_inputs.py
@@ -28,7 +28,6 @@ except Exception as exc:  # noqa: BLE001
 else:
     YAML_IMPORT_ERROR = None
 
-
 TASK_TYPES = {
     "asr",
     "s2tt",
@@ -247,7 +246,11 @@ def task_playbooks_for(task_type: str) -> list[str]:
     return []
 
 
-def env_playbooks_for(deployment_type: str, preferred_backend: str | None) -> list[str]:
+def env_playbooks_for(
+    deployment_type: str,
+    preferred_backend: str | None,
+    package_profile: str,
+) -> list[str]:
     if deployment_type == "api":
         return ["references/playbooks/model_api.md"]
     backend = (preferred_backend or "").strip().lower()
@@ -260,7 +263,7 @@ def env_playbooks_for(deployment_type: str, preferred_backend: str | None) -> li
         "api": "references/playbooks/model_api.md",
     }
     selected = [mapping[backend]] if backend in mapping else []
-    if "references/playbooks/env_docker.md" not in selected:
+    if package_profile in {"docker-local", "docker-registry"} and "references/playbooks/env_docker.md" not in selected:
         selected.append("references/playbooks/env_docker.md")
     return selected
 
@@ -355,8 +358,13 @@ def make_context_selection(resolved: dict[str, Any], model_input: dict[str, Any]
     task_type = str(resolved["task_type"])
     preferred_backend = get_nested(model_input, "environment_hint", "preferred_backend")
     deployment_type = str(resolved["deployment_type"])
+    package_profile = str(resolved["package_profile"])
     task_playbooks = task_playbooks_for(task_type)
-    env_playbooks = env_playbooks_for(deployment_type, str(preferred_backend) if preferred_backend else None)
+    env_playbooks = env_playbooks_for(
+        deployment_type,
+        str(preferred_backend) if preferred_backend else None,
+        package_profile,
+    )
 
     selected = {
         "default": [
@@ -435,7 +443,12 @@ def main() -> int:
     try:
         model_input = read_model_input(model_input_path)
         deployment_type = normalize_required_string(model_input.get("deployment_type"), "deployment_type")
-        package_profile = args.package_profile or ("none" if deployment_type == "api" else "docker-registry")
+        if args.package_profile:
+            package_profile = args.package_profile
+        elif deployment_type == "api":
+            package_profile = "none"
+        else:
+            package_profile = "docker-registry"
         resolved = make_model_input_resolved(
             model_input,
             model_input_path=model_input_path,

--- a/sure/skills/sure_onboard/scripts/stage_model_artifacts.py
+++ b/sure/skills/sure_onboard/scripts/stage_model_artifacts.py
@@ -196,6 +196,8 @@ def main_with_args(argv: list[str] | None = None) -> int:
             copy_artifact(source, model_artifacts / name)
             copied_required.append(name)
     for name in OPTIONAL_RUN_ARTIFACTS:
+        if resolved.get("package_profile") == "none" and name.startswith("docker_"):
+            continue
         source = run_artifacts / name
         if source.exists():
             copy_artifact(source, model_artifacts / name)

--- a/sure/skills/sure_onboard/scripts/templates/verdict.json
+++ b/sure/skills/sure_onboard/scripts/templates/verdict.json
@@ -6,7 +6,7 @@
   "model_name": "",
   "status": "pending",
   "package": {
-    "profile": "docker-registry"
+    "profile": "none"
   },
   "readiness": {
     "local_ready": false,

--- a/sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py
+++ b/sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py
@@ -223,6 +223,69 @@ class DockerDeliveryContractTests(unittest.TestCase):
         proc = self.run_script("check_finalized_bundle.py", output)
         self.assertEqual(proc.returncode, 0, proc.stderr)
 
+    def test_python_finalizer_needs_no_docker_artifacts(self) -> None:
+        self.resolved["package_profile"] = "none"
+        write_json(self.run_artifacts / "model_input_resolved.json", self.resolved)
+        for name in ("docker_build_result.json", "docker_validation.json"):
+            (self.run_artifacts / name).unlink()
+        write_json(
+            self.run_artifacts / "docker_registry_result.json",
+            {
+                "schema": "sure.onboard.docker_registry_result.v2",
+                "status": "skipped",
+                "reason": "package=none uses the approved Python runtime",
+            },
+        )
+        package = {
+            "schema": "sure.onboard.package_gate.v2",
+            "status": "passed",
+            "package_profile": "none",
+            "readiness": {
+                "local_ready": True,
+                "container_ready": False,
+                "docker_ready": False,
+                "registry_ready": False,
+                "bundle_ready": False,
+            },
+        }
+        inventory = {
+            "schema": "sure.onboard.runtime_inventory.v2",
+            "status": "ready",
+            "model": {"name": "demo__asr", "deployment_type": "local", "bundle_root": "."},
+            "local_runtime": {"purpose": "eval_runtime", "eligible_for_eval": True},
+            "container_runtime": {"required": False},
+            "policy": {
+                "eval_runtime": "python_only",
+                "host_python_fallback": False,
+                "image_override_allowed": False,
+                "nfs_models_mutable_by_eval": False,
+            },
+        }
+        manifest = {
+            "model_dir": str(self.model_dir),
+            "artifacts": {"required": {"model": {"path": "model.py"}}, "conditional": {}, "optional": {}},
+        }
+        for name, value in (
+            ("package_gate.json", package),
+            ("runtime_inventory.json", inventory),
+            ("verdict.json", {"status": "passed"}),
+        ):
+            write_json(self.run_artifacts / name, value)
+        write_json(self.model_artifacts / "artifact_manifest.json", manifest)
+
+        output = self.run_artifacts / "deployment_ready.json"
+        deployment = finalize(self.run_dir, output)
+
+        self.assertEqual(deployment["status"], "ready")
+        self.assertEqual(deployment["execution_policy"]["eval_runtime"], "python")
+        self.assertFalse(any("docker" in name for name in deployment["required_artifact_sha256"]))
+        for name in ("docker_build_result.json", "docker_validation.json", "docker_registry_result.json"):
+            self.assertFalse((self.model_artifacts / name).exists())
+        required = read_json(self.model_artifacts / "artifact_manifest.json")["artifacts"]["required"]
+        self.assertFalse(any("docker" in name for name in required))
+        proc = self.run_script("check_finalized_bundle.py", output)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
     def test_container_gate_rejects_harness_model_alias(self) -> None:
         self.validation["harness_runtime"]["python_executable"] = "python"
         write_json(self.run_artifacts / "docker_validation.json", self.validation)

--- a/sure/skills/sure_onboard/scripts/test_runtime_inventory.py
+++ b/sure/skills/sure_onboard/scripts/test_runtime_inventory.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import json
 import hashlib
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
+import check_runtime_inventory
 import stage_model_artifacts
 from write_runtime_inventory import write_inventory
 
@@ -37,7 +40,7 @@ class RuntimeInventoryTests(unittest.TestCase):
             encoding="utf-8",
         )
         (self.model_dir / ".venv" / "bin").mkdir(parents=True)
-        (self.model_dir / ".venv" / "bin" / "python").write_text("", encoding="utf-8")
+        (self.model_dir / ".venv" / "bin" / "python").symlink_to(sys.executable)
         (self.model_dir / "requirements.lock").write_text("torch\n", encoding="utf-8")
         resolved = {
             "model_id": "demo/asr",
@@ -166,6 +169,64 @@ class RuntimeInventoryTests(unittest.TestCase):
         (self.run_artifacts / "package_gate.json").unlink()
         with self.assertRaises(ValueError):
             write_inventory(self.model_dir, self.run_artifacts / "runtime_inventory.json", self.run_dir)
+
+    def test_package_none_publishes_python_eval_runtime(self) -> None:
+        resolved_path = self.run_artifacts / "model_input_resolved.json"
+        resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
+        resolved["package_profile"] = "none"
+        write_json(resolved_path, resolved)
+        write_json(
+            self.run_artifacts / "package_gate.json",
+            {
+                "schema": "sure.onboard.package_gate.v2",
+                "status": "passed",
+                "package_profile": "none",
+                "readiness": {
+                    "local_ready": True,
+                    "container_ready": False,
+                    "docker_ready": False,
+                    "registry_ready": False,
+                    "bundle_ready": False,
+                },
+            },
+        )
+
+        inventory = write_inventory(
+            self.model_dir,
+            self.run_artifacts / "runtime_inventory.json",
+            self.run_dir,
+        )
+
+        self.assertEqual(inventory["status"], "ready")
+        self.assertEqual(inventory["policy"]["eval_runtime"], "python_only")
+        self.assertTrue(inventory["local_runtime"]["eligible_for_eval"])
+        self.assertEqual(inventory["local_runtime"]["path_scope"], "model_relative")
+        self.assertEqual(inventory["local_runtime"]["python_executable"], ".venv/bin/python")
+        self.assertEqual(inventory["local_runtime"]["server_command"][0], ".venv/bin/python")
+        self.assertEqual(inventory["local_runtime"]["tool_names"], ["asr_transcribe"])
+        self.assertFalse(inventory["container_runtime"]["required"])
+        for name in ("docker_build_result.json", "docker_validation.json", "docker_registry_result.json"):
+            (self.run_artifacts / name).unlink()
+            self.assertFalse((self.artifacts / name).exists())
+        with (
+            patch.object(
+                check_runtime_inventory,
+                "load_site_policy",
+                return_value={"policy": {"execution": {"local_runtimes": ["python", "container"]}}},
+            ),
+            patch.object(
+                sys,
+                "argv",
+                [
+                    "check_runtime_inventory.py",
+                    "--run-dir",
+                    str(self.run_dir),
+                    "--produces",
+                    str(self.run_artifacts / "runtime_inventory.json"),
+                ],
+            ),
+        ):
+            self.assertEqual(check_runtime_inventory.main(), 0)
 
     def test_stage_model_artifacts_does_not_write_inventory_early(self) -> None:
         for name in stage_model_artifacts.REQUIRED_RUN_ARTIFACTS:

--- a/sure/skills/sure_onboard/scripts/write_runtime_inventory.py
+++ b/sure/skills/sure_onboard/scripts/write_runtime_inventory.py
@@ -40,15 +40,27 @@ def write_json(path: Path, value: dict[str, Any]) -> None:
     path.write_text(json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def relative_existing(raw: object, model_dir: Path) -> str | None:
+def runtime_path(
+    raw: object,
+    model_dir: Path,
+    *,
+    preserve_executable_entrypoint: bool = False,
+) -> tuple[str | None, str | None]:
     if not isinstance(raw, str) or not raw:
-        return None
+        return None, None
     path = Path(raw).expanduser()
     candidate = path if path.is_absolute() else model_dir / path
+    if not candidate.exists():
+        return None, None
+    resolved = (
+        candidate.parent.resolve() / candidate.name
+        if preserve_executable_entrypoint
+        else candidate.resolve()
+    )
     try:
-        return str(candidate.resolve().relative_to(model_dir.resolve())) if candidate.exists() else None
+        return str(resolved.relative_to(model_dir.resolve())), "model_relative"
     except ValueError:
-        return None
+        return str(resolved), "site_runtime"
 
 
 def load_config(model_dir: Path) -> dict[str, Any]:
@@ -93,15 +105,54 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
     readiness = package.get("readiness") if isinstance(package.get("readiness"), dict) else {}
     hashes, bundle_identity = core_identity(model_dir)
 
-    local_python = relative_existing(build_env.get("python_executable"), model_dir)
-    lockfile = relative_existing(build_env.get("lockfile_path"), model_dir)
+    local_python, python_scope = runtime_path(
+        build_env.get("python_executable"),
+        model_dir,
+        preserve_executable_entrypoint=True,
+    )
+    lockfile, lockfile_scope = runtime_path(build_env.get("lockfile_path"), model_dir)
+    runtime_checks = build_env.get("runtime_checks") if isinstance(build_env.get("runtime_checks"), dict) else {}
+    server = config.get("server") if isinstance(config.get("server"), dict) else {}
+    server_command = normalize_command(server.get("command"))
+    if local_python:
+        if not server_command:
+            server_command = [local_python, "server.py"]
+        elif server_command[0] in {"python", "python3"} or server_command[0].startswith((".venv/", ".pixi/")):
+            server_command[0] = local_python
+    tool_names = [
+        str(tool["name"])
+        for tool in config.get("tools", [])
+        if isinstance(tool, dict) and isinstance(tool.get("name"), str)
+    ]
+    python_ready = bool(
+        deployment_type == "local"
+        and profile == "none"
+        and readiness.get("local_ready") is True
+        and build_env.get("backend") in {"uv", "pip", "conda", "pixi"}
+        and local_python
+        and lockfile
+        and server_command
+        and tool_names
+    )
     local_runtime = {
-        "purpose": "onboard_validation_evidence_only",
-        "eligible_for_eval": False,
+        "purpose": "eval_runtime" if python_ready else "onboard_validation_evidence_only",
+        "eligible_for_eval": python_ready,
         "backend": build_env.get("backend"),
         "python_executable": local_python,
+        "path_scope": python_scope,
         "python_version": build_env.get("python_version"),
         "lockfiles": [lockfile] if lockfile else [],
+        "lockfile_scopes": {lockfile: lockfile_scope} if lockfile and lockfile_scope else {},
+        "lockfile_sha256": {lockfile: sha256_file(Path(lockfile) if Path(lockfile).is_absolute() else model_dir / lockfile)}
+        if lockfile
+        else {},
+        "working_dir": ".",
+        "server_command": server_command,
+        "tool_names": tool_names,
+        "required_imports": [str(item) for item in runtime_checks.get("required_imports", []) if isinstance(item, str)],
+        "gpu_required": bool((config.get("resources") or {}).get("gpu", True))
+        if isinstance(config.get("resources"), dict)
+        else True,
     }
 
     if deployment_type == "api":
@@ -138,10 +189,9 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
             "materialization": validated_harness_runtime.get("materialization"),
             "checks": validated_harness_runtime.get("checks"),
         }
-        server = config.get("server") if isinstance(config.get("server"), dict) else {}
-        server_command = normalize_command(runtime.get("server_command")) or normalize_command(server.get("command"))
-        if server_command and server_command[0].startswith(".venv/"):
-            server_command[0] = str(runtime.get("python_executable") or "python")
+        container_server_command = normalize_command(runtime.get("server_command")) or normalize_command(server.get("command"))
+        if container_server_command and container_server_command[0].startswith((".venv/", ".pixi/")):
+            container_server_command[0] = str(runtime.get("python_executable") or "python")
         container_runtime = {
             "required": True,
             "base_image": build.get("base_image"),
@@ -151,12 +201,8 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
             "dockerfile": {"path": str(build.get("dockerfile_path") or "Dockerfile"), "sha256": build["dockerfile_sha256"]},
             "python_executable": model_runtime["python_executable"],
             "working_dir": runtime.get("working_dir") or "/workspace/model",
-            "server_command": server_command or ["python", "server.py"],
-            "tool_names": [
-                str(tool["name"])
-                for tool in config.get("tools", [])
-                if isinstance(tool, dict) and isinstance(tool.get("name"), str)
-            ],
+            "server_command": container_server_command or ["python", "server.py"],
+            "tool_names": tool_names,
             "gpu_required": bool((config.get("resources") or {}).get("gpu", True))
             if isinstance(config.get("resources"), dict)
             else True,
@@ -168,6 +214,18 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
         }
         status = "ready"
         eval_runtime = "container_only"
+    elif python_ready:
+        status = "ready"
+        container_runtime = {"required": False}
+        model_runtime = {
+            "required": True,
+            "runtime_type": "model_python",
+            "python_executable": local_python,
+            "python_version": build_env.get("python_version"),
+            "checks": build_env.get("runtime_probe") if isinstance(build_env.get("runtime_probe"), dict) else {},
+        }
+        harness_runtime = {"required": False, "runtime_type": "harness_python"}
+        eval_runtime = "python_only"
     else:
         status = "local_only" if readiness.get("local_ready") is True else "partial"
         container_runtime = {"required": profile != "none"}
@@ -200,9 +258,9 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
         "readiness": readiness,
         "evidence": {
             "package_gate": "artifacts/package_gate.json",
-            "docker_build": "artifacts/docker_build_result.json" if deployment_type == "local" else None,
-            "docker_validation": "artifacts/docker_validation.json" if deployment_type == "local" else None,
-            "docker_registry": "artifacts/docker_registry_result.json" if deployment_type == "local" else None,
+            "docker_build": "artifacts/docker_build_result.json" if profile in {"docker-local", "docker-registry"} else None,
+            "docker_validation": "artifacts/docker_validation.json" if profile in {"docker-local", "docker-registry"} else None,
+            "docker_registry": "artifacts/docker_registry_result.json" if profile == "docker-registry" else None,
             "core_sha256": hashes,
         },
         "policy": {

--- a/sure/skills/sure_onboard/sure.skill.json
+++ b/sure/skills/sure_onboard/sure.skill.json
@@ -1,7 +1,7 @@
 {
 	"name": "sure_onboard",
 	"command": "/sure_onboard",
-	"description": "Onboard or repair an audio model, validate it locally and in Docker, publish a digest-pinned image, and seal a container-only Eval deployment bundle.",
+	"description": "Onboard or repair an audio model, validate it, and seal either an approved Python runtime or a digest-pinned container for Eval.",
 	"prompt": "SKILL.md",
 	"hooks": {
 		"pre_start": [{ "module": "hooks/index.ts", "handler": "preStart" }],
@@ -44,19 +44,19 @@
 			"type": "package_gate",
 			"path": "artifacts/package_gate.json",
 			"required": false,
-			"description": "Docker registry package readiness gate result."
+			"description": "Selected Python or container package readiness gate result."
 		},
 		{
 			"type": "runtime_inventory",
 			"path": "artifacts/runtime_inventory.json",
 			"required": true,
-			"description": "Container-only Eval runtime binding."
+			"description": "Approved Python or container Eval runtime binding."
 		},
 		{
 			"type": "deployment_ready",
 			"path": "artifacts/deployment_ready.json",
 			"required": true,
-			"description": "Terminal portable bundle and immutable image readiness marker."
+			"description": "Terminal portable bundle and approved runtime readiness marker."
 		}
 	],
 	"ui": {


### PR DESCRIPTION
## Summary

- add site-policy permissions for approved local Python and container runtimes, preserving container-only behavior for existing policies
- make package=none produce a Python-ready onboard bundle with an explicit interpreter, lock hashes, server command, tools, and no Docker sidecars
- add local_python execution to sure_eval while retaining digest-pinned container execution and VC restrictions
- align runtime gates, schemas, agent contracts, examples, and README guidance with the selected runtime

## Validation

- Onboard Python tests: 14/14 passed
- Eval Python tests: 181/182 passed; one pre-existing group-write mode assertion fails under this root/umask environment
- Site loader tests: 2/2 passed
- Eval Vitest suites: 38/38 passed
- Onboard Vitest suite: 72/74 passed; two failures depend on local ignored handoff fixtures whose backend/content differs or is missing
- npm run check: 10/11 passed; only the pre-existing import ordering issue in packages/coding-agent/src/core/sure/output-dir.ts remains
- check:sure-hooks, check:site-boundary, sure:site-check, Python compilation, JSON parsing, and git diff --check passed