### PR TITLE
chore(public): sync GitLab projection through 338f7a7

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -80,10 +80,6 @@ jobs:
   public-smoke:
     name: Public export and startup
     runs-on: ubuntu-24.04
-    env:
-      PUBLIC_TREE: ${{ runner.temp }}/sure-public-one
-      PUBLIC_TREE_SECOND: ${{ runner.temp }}/sure-public-two
-      PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-agent
     steps:
       - name: Check out the public tree
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -101,6 +97,9 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Export the public tree twice
+        env:
+          PUBLIC_TREE: ${{ runner.temp }}/sure-public-one
+          PUBLIC_TREE_SECOND: ${{ runner.temp }}/sure-public-two
         run: |
           npm run public:export -- --output "$PUBLIC_TREE"
           npm run public:export -- --output "$PUBLIC_TREE_SECOND"
@@ -127,6 +126,8 @@ jobs:
 
       - name: Validate configured public startup
         working-directory: ${{ runner.temp }}/sure-public-two
+        env:
+          PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-agent
         run: |
           cp config/site.example.yaml config/site.local.yaml
           npm run sure:site-check

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -1,0 +1,134 @@
+name: Public CI
+
+on:
+  pull_request:
+    branches: [harness-tui-agent]
+  push:
+    branches: [harness-tui-agent]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: public-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality and contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out the public tree
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.19.0
+          cache: npm
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.11"
+
+      - name: Install system and Node dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ripgrep
+          npm ci --ignore-scripts
+
+      - name: Install the locked Harness Runtime
+        run: |
+          python -m venv "$RUNNER_TEMP/sure-harness-venv"
+          "$RUNNER_TEMP/sure-harness-venv/bin/pip" install --require-hashes -r sure/runtime/harness/requirements.lock.txt
+          echo "$RUNNER_TEMP/sure-harness-venv/bin" >> "$GITHUB_PATH"
+
+      - name: Configure the public CI fixture
+        run: |
+          cp config/site.example.yaml config/site.local.yaml
+          npm run sure:site-check
+
+      - name: Run repository checks
+        run: npm run check
+
+      - name: Check public compatibility rules
+        run: |
+          npm run check:site-compatibility -- --report "$RUNNER_TEMP/site-compatibility-report.json"
+          npm run test:site-compatibility-rules
+
+      - name: Run Python tests
+        run: |
+          python -m unittest discover -s sure/skills/sure_eval/scripts -p "test_*.py"
+          python -m unittest discover -s sure/skills/sure_trans/scripts -p "test_*.py"
+          python -m unittest discover -s sure/skills/sure_onboard/scripts -p "test_*.py"
+          python -m unittest discover -s sure/skills/sure_feed/scripts -p "test_*.py"
+          python -m unittest discover -s sure/site -p "test_*.py"
+
+      - name: Run coding-agent SURE tests
+        working-directory: packages/coding-agent
+        run: |
+          node node_modules/vitest/dist/cli.js --run \
+            test/suite/sure-*.test.ts \
+            test/sure/*.test.ts \
+            --exclude test/suite/sure-extension.test.ts
+
+  public-smoke:
+    name: Public export and startup
+    runs-on: ubuntu-24.04
+    env:
+      PUBLIC_TREE: ${{ runner.temp }}/sure-public-one
+      PUBLIC_TREE_SECOND: ${{ runner.temp }}/sure-public-two
+      PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-agent
+    steps:
+      - name: Check out the public tree
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 22.19.0
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Export the public tree twice
+        run: |
+          npm run public:export -- --output "$PUBLIC_TREE"
+          npm run public:export -- --output "$PUBLIC_TREE_SECOND"
+          test ! -e "$PUBLIC_TREE/config/site.bundled.yaml"
+          test ! -e "$PUBLIC_TREE/private/aispeech"
+          test ! -e "$PUBLIC_TREE/.gitlab-ci.yml"
+          test -f "$PUBLIC_TREE/public-export-manifest.json"
+          diff -ru "$PUBLIC_TREE" "$PUBLIC_TREE_SECOND"
+
+      - name: Install the exported tree
+        working-directory: ${{ runner.temp }}/sure-public-two
+        run: npm ci --ignore-scripts
+
+      - name: Require fail-closed public defaults
+        working-directory: ${{ runner.temp }}/sure-public-two
+        run: |
+          npm run sure:site-info | tee "$RUNNER_TEMP/sure-site-info.txt"
+          grep -F "configured: false" "$RUNNER_TEMP/sure-site-info.txt"
+          if npm run sure:site-check > "$RUNNER_TEMP/sure-site-check-missing.txt" 2>&1; then
+            echo "site check unexpectedly accepted an unconfigured public tree" >&2
+            exit 1
+          fi
+          grep -F "site policy is not configured" "$RUNNER_TEMP/sure-site-check-missing.txt"
+
+      - name: Validate configured public startup
+        working-directory: ${{ runner.temp }}/sure-public-two
+        run: |
+          cp config/site.example.yaml config/site.local.yaml
+          npm run sure:site-check
+          npm run sure:doctor
+          PI_OFFLINE=1 ./pi-test.sh --help > /dev/null

--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Install the locked Harness Runtime
         run: |
           python -m venv "$RUNNER_TEMP/sure-harness-venv"
+          "$RUNNER_TEMP/sure-harness-venv/bin/pip" install "uv==0.7.13"
           "$RUNNER_TEMP/sure-harness-venv/bin/pip" install --require-hashes -r sure/runtime/harness/requirements.lock.txt
           echo "$RUNNER_TEMP/sure-harness-venv/bin" >> "$GITHUB_PATH"
 

--- a/config/site.example.yaml
+++ b/config/site.example.yaml
@@ -14,6 +14,7 @@ storage:
 datasets:
   allowed_source_roots:
     - /srv/sure/datasets
+  projection_root: /var/lib/sure/dataset-projections
 
 execution:
   surfaces:

--- a/docs/evaluation_engine.md
+++ b/docs/evaluation_engine.md
@@ -82,11 +82,18 @@ data/datasets/sure_benchmark/jsonl
 
 它**不是** `datasets=` 参数该填的东西。`datasets=` 传活动站点策略允许的数据源路径，详见 [`/sure_eval` skill 契约](../sure/skills/sure_eval/SKILL.md)。
 
-`SURE_EVAL_DATASETS_ROOT` 可以指向另一个包含 `sure_benchmark/jsonl` 的数据根,但它**只挪 JSONL 的查找位置**:
+投影根目录是独立的可写工作区。首次运行会创建
+`sure_benchmark/jsonl` 以及索引和元数据；原始音频仍从站点策略允许的源目录读取，
+不会复制或迁移。优先级是 `/sure_eval datasets_root=`、
+`SURE_EVAL_DATASETS_ROOT`、站点策略 `datasets.projection_root`、显式配置的
+`data.datasets`，最后才是仓库内开发默认值。环境变量示例:
 
 ```bash
 export SURE_EVAL_DATASETS_ROOT=/path/to/data/datasets
 ```
+
+投影根必须是绝对路径，不能落在 `forbidden_output_roots` 下，也不能与
+`allowed_source_roots` 重叠。容器只读挂载原始数据和模型，只对投影根与本次结果目录开放写入。
 
 音频路径先看数据集 JSONL 里写的值:绝对路径直接用;相对路径依次试这五处,取第一个存在的:
 

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -45,6 +45,7 @@ The machine-readable contract is [sure/site/policy.schema.json](../sure/site/pol
 | `storage.forbidden_output_roots` | yes | Roots where automated `output_dir` writes are forbidden |
 | `storage.runtime_root` | yes | Declared site-owned cache root for adapters and future runtime placement |
 | `datasets.allowed_source_roots` | yes | Roots accepted by the strict dataset source resolver |
+| `datasets.projection_root` | optional | Writable root for generated dataset JSONL indexes and metadata; raw data remains in the allowed source root |
 | `execution.surfaces` | yes | Enabled execution surfaces: `local`, `vc`, or both |
 | `execution.vc_partitions` | when needed | Declared VC partitions for adapters and deployment documentation |
 | `execution.vc_partition_priority` | optional | Numeric priority map used by automatic VC selection |
@@ -61,6 +62,7 @@ Policy v1 accepts exactly one path in each root list. The list shape leaves room
 - Every configured root is absolute.
 - Approved model and result roots must be protected by a configured forbidden output root.
 - The declared runtime root must stay outside forbidden output roots.
+- A configured dataset projection root must stay outside forbidden output roots and must not overlap an allowed source root.
 - Path authorization resolves existing symlinks before comparison, so alternate names cannot bypass a protected root.
 - The policy validator does not create directories and does not require network access. Runtime commands perform their existing availability and permission checks at the same stages as before.
 - This compatibility phase does not redirect the locked Harness Runtime or Evaluation Runtime. They continue to materialize in their pre-existing repository-local locations; changing that behavior requires a separate differential migration.
@@ -85,13 +87,14 @@ storage:
 datasets:
   allowed_source_roots:
     - /srv/datasets
+  projection_root: /var/lib/sure/dataset-projections
 
 execution:
   surfaces:
     - local
 ```
 
-For shared storage, replace these placeholders with roots visible to every host and container that executes a workflow. For a local-only fixture, create temporary model, result, dataset, and runtime roots and point the local policy at them.
+For shared storage, replace these placeholders with roots visible to every host and container that executes a workflow. The projection root is the only writable dataset workspace; source roots are mounted read-only. For a local-only fixture, create temporary model, result, dataset, projection, and runtime roots and point the local policy at them.
 
 ## Diagnostics
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"check:repository-hygiene": "node scripts/check-repository-hygiene.mjs",
 		"check:site-boundary": "node scripts/check-site-boundary.mjs",
 		"check:site-compatibility": "node scripts/check-site-compatibility.mjs",
+		"test:site-compatibility-rules": "node --test scripts/site-compatibility-rules.test.mjs",
 		"public:export": "node scripts/export-public.mjs",
 		"sure:site-info": "node --import tsx scripts/sure-site-info.ts",
 		"sure:site-check": "node --import tsx scripts/sure-site-check.ts",

--- a/packages/coding-agent/test/suite/sure-eval-red-lines.test.ts
+++ b/packages/coding-agent/test/suite/sure-eval-red-lines.test.ts
@@ -171,6 +171,21 @@ describe("sure_eval execution policy gate", () => {
 		expect(blocked.stderr).toContain("execution=vc");
 	});
 
+	it("blocks vc_submit artifacts that cannot be correlated by the wait gate", () => {
+		const runDir = freshRunDir("execution-vc-missing-control-fields");
+		writeArtifact(runDir, "submit_result.json", {
+			execution_path: "vc_submit",
+			execution_requested: "auto",
+			vc_available: VC_AVAILABLE,
+		});
+
+		const blocked = runGate("vc_check.py", runDir, "submit_result.json");
+		expect(blocked.ok).toBe(false);
+		expect(blocked.stderr).toContain("vc_job_id");
+		expect(blocked.stderr).toContain("submission_token");
+		expect(blocked.stderr).toContain("terminal_status_path");
+	});
+
 	it("blocks execution=auto local_bash when vc is available unless fallback is approved", () => {
 		if (!VC_AVAILABLE) {
 			return;
@@ -300,6 +315,8 @@ submission = r._resolved_submission(
     run_evaluation_path="/host/repo/.sure/runs/r/artifacts/run_evaluation.sh",
     log_path=Path("/host/repo/.sure/runs/r/vc_logs/job.log"),
     command="vc submit ...",
+    submission_token="a" * 32,
+    terminal_status_path="artifacts/vc_terminal_status." + "a" * 32 + ".json",
     harness_runtime={"runtime_id": "sure-harness-test"},
     model_runtime={"runtime_type": "model_python", "python_executable": "python"},
 )

--- a/packages/coding-agent/test/suite/sure-eval-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-eval-state-machine.test.ts
@@ -410,7 +410,7 @@ describe("sure_eval tool_readiness_routing handoff gate", () => {
 	});
 });
 
-// Gate-with-script units (submit_vc_run, smoke_test, assessment, run_report,
+// Gate-with-script units (submit_vc_run, execute_wait, smoke_test, assessment, run_report,
 // script_routing) must have NO in-process gateCheck — the python gateScript is
 // the single authoritative semantic checker. This is the redundancy-removal
 // contract: no duplicated === true vs truthy logic, no duplicated constant lists.
@@ -420,6 +420,7 @@ describe("sure_eval gate-with-script units have no in-process gateCheck (python 
 		["execution_readiness", "check_execution_surface_compliance.py"],
 		["smoke_test", "run_smoke.py"],
 		["submit_vc_run", "vc_check.py"],
+		["execute_wait", "wait_vc_execution.py"],
 		["assessment", "check_assessment.py"],
 		["run_report", "check_run_report.py"],
 	])("%s delegates semantics to its python gateScript (no in-process gateCheck)", (unitId, script) => {
@@ -434,8 +435,8 @@ describe("sure_eval gate-with-script units have no in-process gateCheck (python 
 	it("execution_readiness keeps its in-process gateCheck (disjoint from python)", () => {
 		expect(findUnit("execution_readiness")!.gateCheck).toBeDefined();
 	});
-	it("script_routing/smoke_test/submit_vc_run/assessment/run_report drop in-process gateCheck", () => {
-		for (const id of ["script_routing", "smoke_test", "submit_vc_run", "assessment", "run_report"]) {
+	it("script_routing/smoke_test/submit_vc_run/execute_wait/assessment/run_report drop in-process gateCheck", () => {
+		for (const id of ["script_routing", "smoke_test", "submit_vc_run", "execute_wait", "assessment", "run_report"]) {
 			expect(findUnit(id)!.gateCheck).toBeUndefined();
 		}
 	});

--- a/packages/coding-agent/test/sure/site-loader.test.ts
+++ b/packages/coding-agent/test/sure/site-loader.test.ts
@@ -52,6 +52,31 @@ describe("validateSitePolicy absolute paths", () => {
 			),
 		).toThrow(/storage\.approved_models_roots\[0\]/);
 	});
+
+	it("returns an absolute dataset projection root", () => {
+		const result = validateSitePolicy(
+			policy({
+				datasets: {
+					allowed_source_roots: [`${ROOT}/datasets`],
+					projection_root: "/var/lib/sure/dataset-projections",
+				},
+			}),
+		);
+		expect(result.datasets.projection_root).toBe("/var/lib/sure/dataset-projections");
+	});
+
+	it("rejects a relative dataset projection root", () => {
+		expect(() =>
+			validateSitePolicy(
+				policy({
+					datasets: {
+						allowed_source_roots: [`${ROOT}/datasets`],
+						projection_root: "data/projections",
+					},
+				}),
+			),
+		).toThrow(/datasets\.projection_root/);
+	});
 });
 
 describe("validateSitePolicy network.container_registry", () => {

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,13 +1,13 @@
 {
   "schema": "sure.public_export_manifest.v1",
-  "source_commit": "de911243be230c6259a406377b5323fb36971236",
+  "source_commit": "338f7a700563007e2ab6f7b0f9cff0d1ed099fd4",
   "source_dirty": false,
-  "tree_sha256": "d3400040af9427d3db7518a733aa104ff16235872c55ecbdd5af91f6a86c0122",
+  "tree_sha256": "ddb7a97e72957c0ca209d3dafd200e3c40e9e4501d9baaa7a3155b7fae6f729a",
   "files": [
     {
       "path": ".github/workflows/public-ci.yml",
       "type": "file",
-      "sha256": "0a6a7debbb183c518488b1d6b2f9a0cf82f82e703a8c21dfe7becf0035ca70ee"
+      "sha256": "07b1e79d9f6e9f9b75b9c7ff0314aba70b475456e2d0b63a1b557b551afed338"
     },
     {
       "path": ".gitignore",

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,9 +1,14 @@
 {
   "schema": "sure.public_export_manifest.v1",
-  "source_commit": "4502c590d92b2e1e6a1e5f5f862428635163f60b",
+  "source_commit": "fd79083c217e434bf2d7608bbdd8723d0cba7b06",
   "source_dirty": false,
-  "tree_sha256": "29f263bc27f544158e0851eb81333683718c1c74ba8dcb1ecb33b0878d0740dc",
+  "tree_sha256": "74d6612c191c775e0b25da3706e54fb5dbb87c35673d42fe810c78f3fe673695",
   "files": [
+    {
+      "path": ".github/workflows/public-ci.yml",
+      "type": "file",
+      "sha256": "cca9230a5d4c861811298b31e206507317272b8367763af580f924603bf0f9fe"
+    },
     {
       "path": ".gitignore",
       "type": "file",
@@ -57,17 +62,17 @@
     {
       "path": "config/site.example.yaml",
       "type": "file",
-      "sha256": "755c874030c0d1b000fd7d643031bb7afe26e0c18fac4eaefb4fa8f67963af9b"
+      "sha256": "b473b676724abef89ed4d7a50c87825be521d7e287883bcdb27ba5d67a2bf4bb"
     },
     {
       "path": "docs/evaluation_engine.md",
       "type": "file",
-      "sha256": "bcb3240d529b0b8fd1dae4591dd0fbe7b7840ac364937dd94f81cd24e8179328"
+      "sha256": "b58902c015a688d7db273db137052c3409320d6b294d19736aa7c62e95ed42bb"
     },
     {
       "path": "docs/site-configuration.md",
       "type": "file",
-      "sha256": "651d609e99ce25b9e71a77eaa49ab0b6ea1e50abf23c9ca1185e6016bd41d192"
+      "sha256": "8bf5ca23c2e8137019877dd2f397866c2e3ae6118293d62fd713eeef0cba0a3d"
     },
     {
       "path": "fixtures/README.md",
@@ -367,7 +372,7 @@
     {
       "path": "package.json",
       "type": "file",
-      "sha256": "521b349dd534f830abcb3a9a935fc0850f87216618ee4f60046f908876c9bb6d"
+      "sha256": "8a7bc0d23a3a6310e22ccdcd80e05e1163e06539c1f4c68c3bbcd9cc4e1cf123"
     },
     {
       "path": "packages/agent/CHANGELOG.md",
@@ -4612,7 +4617,7 @@
     {
       "path": "packages/coding-agent/test/suite/sure-eval-red-lines.test.ts",
       "type": "file",
-      "sha256": "1bd818c754072a3535e9f3225a78083415a8531adbe5b9d45c10653113051de5"
+      "sha256": "f9b7c9a97089246a741e3887b9a31fb3ef6d6048f56ef3c045111038d6ea2459"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-eval-runbackend.test.ts",
@@ -4622,7 +4627,7 @@
     {
       "path": "packages/coding-agent/test/suite/sure-eval-state-machine.test.ts",
       "type": "file",
-      "sha256": "bb830ae59a8e8c3fc8411706a9ba22e62cd4f77812a88825ffa5da0dc18ac674"
+      "sha256": "c26dd84e22baa020da028c42fdf30aad51e46bccedfe752c2ace84202f6966b5"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-extension.test.ts",
@@ -4732,7 +4737,7 @@
     {
       "path": "packages/coding-agent/test/sure/site-loader.test.ts",
       "type": "file",
-      "sha256": "8c2ae641713aa1cc9826f624841b03cf2701172cf35b6152303c4ad625134e85"
+      "sha256": "bdf32a5b6f69c054f42cc74e302280a5c908db3abc38d45dba760fb8b461d5f4"
     },
     {
       "path": "packages/coding-agent/test/syntax-highlight.test.ts",
@@ -5352,7 +5357,7 @@
     {
       "path": "scripts/check-site-compatibility.mjs",
       "type": "file",
-      "sha256": "82d1f580564a5086814308fb7feb33fed74ecf21811cbf7677d69bd08d186c48"
+      "sha256": "f25c876b25be3416fa516fb92aacf389d5d9e271484f8829a70e9cad0d543895"
     },
     {
       "path": "scripts/check-ts-relative-imports.mjs",
@@ -5440,6 +5445,16 @@
       "sha256": "e914220044303236caa06018123f1ceac8f8f2acf5279d6b1ce716cab5af6bb4"
     },
     {
+      "path": "scripts/site-compatibility-rules.mjs",
+      "type": "file",
+      "sha256": "73c4cbe0e573d3ce9c20e6ddff4903c92ab427ae54091faf5045c3bbd1c20b05"
+    },
+    {
+      "path": "scripts/site-compatibility-rules.test.mjs",
+      "type": "file",
+      "sha256": "d582a250e57b37f32d7071a60a4d8c1fedaa4d998502aeea92a38524f9f9ec57"
+    },
+    {
       "path": "scripts/stats.ts",
       "type": "file",
       "sha256": "742549c85ba794bc790a2f49b16044adfaa60e5ada96aab2878858d4baff6f77"
@@ -5452,7 +5467,7 @@
     {
       "path": "scripts/sure-site-check.ts",
       "type": "file",
-      "sha256": "d997967abb43c9c6e9ccfcbcf21706bdaa85fa22a95a031c3dd6724159a0ef0c"
+      "sha256": "9c053a6677a86eeaae293a7a1c7982ca4b2aa13baed01fdbbfb1ec74c066807e"
     },
     {
       "path": "scripts/sure-site-info.ts",
@@ -5592,27 +5607,27 @@
     {
       "path": "sure/site/loader.py",
       "type": "file",
-      "sha256": "d1bb43a3605d40208b07147749b0095be089395f262d66be06246c31d3c79696"
+      "sha256": "eafb7eeb31a8f326f51563264e6091bcf0865a82166689c86d815ba237aef21c"
     },
     {
       "path": "sure/site/loader.ts",
       "type": "file",
-      "sha256": "11a73ddc53f842e8ec4f99b87a84cc6b02f8993a885621d38d503833095965bd"
+      "sha256": "ab704b6fed3a91a306398433d36361c9cee6cdcfc5c970de4173ab727f0ab19e"
     },
     {
       "path": "sure/site/policy.schema.json",
       "type": "file",
-      "sha256": "43d698c7625b3f72ebf644b0b96e88d860c0e7d185d23a898507dcb33a0ea62d"
+      "sha256": "1c8678d4a12cac7e73a10d910073b52f01e2d43c95e8368bfab78848d86edc26"
     },
     {
       "path": "sure/site/public.example.yaml",
       "type": "file",
-      "sha256": "755c874030c0d1b000fd7d643031bb7afe26e0c18fac4eaefb4fa8f67963af9b"
+      "sha256": "b473b676724abef89ed4d7a50c87825be521d7e287883bcdb27ba5d67a2bf4bb"
     },
     {
       "path": "sure/site/test_loader.py",
       "type": "file",
-      "sha256": "66b58ad6ed49ee0026dc9092d6ac038423573b13ccb5af47a2a5cd1c4c0e8543"
+      "sha256": "e9cd231fe17896a9777cef6c8b7dc8fd5b37b693ce62c042a640eaf5440e7c8b"
     },
     {
       "path": "sure/skills/README.md",
@@ -5622,7 +5637,7 @@
     {
       "path": "sure/skills/sure_eval/SKILL.md",
       "type": "file",
-      "sha256": "105018ab0e87f8bd833eacf124f20e95b7d05d2ab41106a4885e85208cf1101b"
+      "sha256": "3e74294e80267774f6aed3d27e28aa7090bd380aa00e9a6afd28b3a090e3f705"
     },
     {
       "path": "sure/skills/sure_eval/config/protocols.yaml",
@@ -5642,12 +5657,12 @@
     {
       "path": "sure/skills/sure_eval/hooks/index.ts",
       "type": "file",
-      "sha256": "687108b100ec0300a00211f91b0852275d731727e554c86ff9317bb226f1c389"
+      "sha256": "1e6c50da97cb6b4a9731c09d1a94100ba3bfa74c42a5f188bc0ea61e235881ce"
     },
     {
       "path": "sure/skills/sure_eval/hooks/state-machine.ts",
       "type": "file",
-      "sha256": "4ab19b66ee63dd6e52481c3d3a8b611414d0bf81f7efc5905ccef6678743317b"
+      "sha256": "7ec00303576f01e75514ab35331086d9fd9b0d163da7e9ac1d5e63ea09e9e52c"
     },
     {
       "path": "sure/skills/sure_eval/hooks/validate.ts",
@@ -5792,7 +5807,7 @@
     {
       "path": "sure/skills/sure_eval/schemas/execution_result.schema.json",
       "type": "file",
-      "sha256": "3db4e7eed1ffb0c9b94d179cc75859bdfcfb4b7d55f074ed56a60996ff04db2b"
+      "sha256": "4b8980c3bb2b968614edc2a3a9208487abb72be8fb534fb23f1bf6cc55a4fea6"
     },
     {
       "path": "sure/skills/sure_eval/schemas/execution_surface.schema.json",
@@ -5837,7 +5852,7 @@
     {
       "path": "sure/skills/sure_eval/schemas/submit_result.schema.json",
       "type": "file",
-      "sha256": "72e6a2da00b18400b98cfba359927deec941723215b7db178d672ddad2b701fb"
+      "sha256": "dc920f09b94eaf01b66fae244a5dce75e1fbe459db018e9c9b15bbcd2040eed8"
     },
     {
       "path": "sure/skills/sure_eval/schemas/task_classification.schema.json",
@@ -5857,7 +5872,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/check_execution_surface_compliance.py",
       "type": "file",
-      "sha256": "c933a38b00a53db6d034129d540a9c10f918095b4c95394c3b92bc955b8fa7cd"
+      "sha256": "d03bf40ae5ce55a3138e35ed7613748d4feff002225fcd1b7377e33c3a3c1926"
     },
     {
       "path": "sure/skills/sure_eval/scripts/check_main_flow_reference.py",
@@ -5887,7 +5902,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/container_execution.py",
       "type": "file",
-      "sha256": "0460a62972e2df392b4bec43ac1cf71ed4fb7598c1e31d055f4b54a8849561fc"
+      "sha256": "5c98ba7468d1f0e70f0ed38931da4da753613ed6ccdf32776685d89005dd6dfc"
     },
     {
       "path": "sure/skills/sure_eval/scripts/convert_sure_to_jsonl.py",
@@ -5912,7 +5927,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/evaluate_predictions.py",
       "type": "file",
-      "sha256": "82c54a1f39960d5deb76ac0a0f43b5585242c3489ccacfde716220809fb9fbda"
+      "sha256": "0802f480f0e198d5664c7aad6d8f6207376e31aab180cdbd921258c48ba85c3b"
     },
     {
       "path": "sure/skills/sure_eval/scripts/evaluation_capabilities.py",
@@ -5922,7 +5937,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/evaluation_runtime.py",
       "type": "file",
-      "sha256": "b7ce4193c9e44df3b4c8a6ac4ac831c4cfb0bff6f1efee0f43e815a030368535"
+      "sha256": "30980bdf354945b224bb7048d15b800f8d75298356951a6db5ecf854bf0eb04d"
     },
     {
       "path": "sure/skills/sure_eval/scripts/extract_test_samples.py",
@@ -5937,7 +5952,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/generate_predictions_via_server.py",
       "type": "file",
-      "sha256": "f65da02f309596c101d4992e1fc9d221fa699ed7ad54c0377946b4c5d2e1cea8"
+      "sha256": "ed0740cc8d4a014f37be55356353c792ff388749bb724e8b3765b3435a59082e"
     },
     {
       "path": "sure/skills/sure_eval/scripts/generate_report_snapshot.py",
@@ -5997,7 +6012,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/resolve_eval_input.py",
       "type": "file",
-      "sha256": "4d79da726ff161915d5693a311b56ca2d6b585f62d2fca73e355405877280bac"
+      "sha256": "b7dd377d95d1e32a47158131477029a3de195556004b8188b1c440e970065244"
     },
     {
       "path": "sure/skills/sure_eval/scripts/resolve_evaluation_engine.py",
@@ -6012,12 +6027,12 @@
     {
       "path": "sure/skills/sure_eval/scripts/resolve_model_dir.py",
       "type": "file",
-      "sha256": "c52bbd28755c8fe70ca8427eb9737f1e4813b61f366a72b3ae216610e0ff4361"
+      "sha256": "9728e9544939732d3678f3170db573d97851bb4485fc3d8e7b422681a69c2cad"
     },
     {
       "path": "sure/skills/sure_eval/scripts/resolve_prediction_source.py",
       "type": "file",
-      "sha256": "fc48332ddd363af22347df068b18ee826583c9a6118f12b055fa16cc693b0295"
+      "sha256": "fa1a53a715b59f9d454a74fb3cdabf3b081ab59d0285d4be3b5fed9faa6eb8a4"
     },
     {
       "path": "sure/skills/sure_eval/scripts/run_local_execution.py",
@@ -6052,7 +6067,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/run_vc_execution.py",
       "type": "file",
-      "sha256": "c0c01556b493a6277ec8db5936b65c4a18fabc30f7d55bb009208ee270ea7683"
+      "sha256": "9ff2ffe065a85dfee2b6534ab72570eadaa3f1c94639af8f1f65372f3c77f593"
     },
     {
       "path": "sure/skills/sure_eval/scripts/sure_eval/__init__.py",
@@ -6457,7 +6472,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/sure_eval/models/registry.py",
       "type": "file",
-      "sha256": "efc2d5f5318ba48675eda91abf74c5e066e1c5b05e2477c80203c993fd9f0bc6"
+      "sha256": "5bae98b76f97a2130b2af00ed870030991ac8fc8ffe85312790c52e9d6d5b9e9"
     },
     {
       "path": "sure/skills/sure_eval/scripts/sure_eval/protocols/__init__.py",
@@ -6612,7 +6627,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/test_deployment_binding.py",
       "type": "file",
-      "sha256": "9e19d0e716545a0d5546c92bfea9d660a43d0c11ac924e794b125087f3b16ce1"
+      "sha256": "2a1b3329023b5dee5e9b2f8d207f99fe07374f5604eb5df2f8f2fe2ec654f525"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_eval_input_policy.py",
@@ -6622,17 +6637,17 @@
     {
       "path": "sure/skills/sure_eval/scripts/test_evaluation_runtime.py",
       "type": "file",
-      "sha256": "668cc4ddcafcb56b4aa64d765157c137f6dd3003ab31860c745c0e813b9d0fa0"
+      "sha256": "9e8fd2cc270747fe1720e1047c2d86c6a969d31246adbd6ab346735028e0476d"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_execution_surface_checks.py",
       "type": "file",
-      "sha256": "fa9e6338235744259e49b70b8196db940fdeeb0e7ea2ca728c9a57725dee4161"
+      "sha256": "84fae27a6883aa36fd202a0dfc112bf2d4e581d545af26902e516ff4a8ce381a"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_external_bridge.py",
       "type": "file",
-      "sha256": "53975207c4c81c474a50bacc70a16ddcab51fee47e0f8e2020fed76186e61b7e"
+      "sha256": "54811a8d5e0421485bb0ec1d69cd0b555de48ed883f45270341418cbc8494b20"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_failed_run_report.py",
@@ -6647,7 +6662,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/test_harness_config_bootstrap.py",
       "type": "file",
-      "sha256": "0bfd8de286e3b17a18f95c4659b85c380791ad4bc193f5afe5e15a8d0e781267"
+      "sha256": "3ebd05a7dd80fa5bc16d24bc24c92a7d2b03045651cae5816e6dcd95307aff95"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_harness_runtime.py",
@@ -6660,9 +6675,19 @@
       "sha256": "d19d3a3213f6667f915d405020a08dd4ed5816efc7cb8214dff3f2bf741349dc"
     },
     {
+      "path": "sure/skills/sure_eval/scripts/test_model_registry.py",
+      "type": "file",
+      "sha256": "6644c717c175df502988f0d3de6b5dca551731c23161799448b63fb887ec89fb"
+    },
+    {
       "path": "sure/skills/sure_eval/scripts/test_payload_artifact_paths.py",
       "type": "file",
-      "sha256": "b0d6c2848066b564fd5136b2b813a9d5754a0bfdf026120f08e08d9cda62c85d"
+      "sha256": "e79b2fd3ac916ba2b8c5332bf1712ab4b5a9fd6e23aad14a0ea17621212c3956"
+    },
+    {
+      "path": "sure/skills/sure_eval/scripts/test_prediction_payload.py",
+      "type": "file",
+      "sha256": "72172ad29f40b3b67a42d066a01a5811781f0dbded6f453b2cef647c1ceca1cd"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_preflight_evaluation_support.py",
@@ -6690,6 +6715,11 @@
       "sha256": "7a4014414bc182ab0bf40d00b68e03734c4fbb9e0c7c4509e3c9553382c86769"
     },
     {
+      "path": "sure/skills/sure_eval/scripts/test_reval_prediction_source.py",
+      "type": "file",
+      "sha256": "09c7626388f87e72ec30f6072ea4ff4b84e27c438c31d58dcfef7f627a35e97d"
+    },
+    {
       "path": "sure/skills/sure_eval/scripts/test_smoke_dataset_version_guard.py",
       "type": "file",
       "sha256": "7a87fb5f98eb6d6ad65bb9d30cb2afcbbf4d651f29b661405d7722cb40465cc3"
@@ -6697,7 +6727,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/test_source_conversion.py",
       "type": "file",
-      "sha256": "9c44c416804f4ad1d60685dd73c022ee61858eb527e7f01be374086942631495"
+      "sha256": "78ee57a010810ff5fecd0232b9bb059fe0a96500252b3ddbff0a2431a04f8842"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_source_naming_flow.py",
@@ -6720,6 +6750,11 @@
       "sha256": "d28311e52b4c04d14c883b38266ea0899adc82dcf5176feebc68b6cce8065e16"
     },
     {
+      "path": "sure/skills/sure_eval/scripts/test_wait_vc_execution.py",
+      "type": "file",
+      "sha256": "34ef07681414563e2500d40bc93edc4392ac1e2f65e5d3162b550ed2cfe61dcc"
+    },
+    {
       "path": "sure/skills/sure_eval/scripts/validate_prediction_files.py",
       "type": "file",
       "sha256": "cf9130f82f9f83a78586a20e6da08405d4ca04d5de362b68e97e27b8ab075083"
@@ -6727,7 +6762,12 @@
     {
       "path": "sure/skills/sure_eval/scripts/vc_check.py",
       "type": "file",
-      "sha256": "eb3824014b7920df5a7763b227f6fd5dd142e2f2521d7a66c5fafc0f427b4fea"
+      "sha256": "4c02b757436bc6ace9b4eeab082148ac465fad1fff1ff90a6bc7c3f192c54e1c"
+    },
+    {
+      "path": "sure/skills/sure_eval/scripts/wait_vc_execution.py",
+      "type": "file",
+      "sha256": "2601ab0e1dfbcb0ab219e945797a0c16812f1eb60a6a7d659a6572755ac90f63"
     },
     {
       "path": "sure/skills/sure_eval/sure.skill.json",
@@ -7617,7 +7657,7 @@
     {
       "path": "sure/skills/sure_reval/SKILL.md",
       "type": "file",
-      "sha256": "e1ff56123462a25106bbf313f31889add07ee43bed25043b8ad8badd175a02ff"
+      "sha256": "b38cada9d44abcecc03bfdd54a9d2a9d3f5e025102e210d2eb4c2efd52f7731f"
     },
     {
       "path": "sure/skills/sure_reval/hooks/index.ts",
@@ -7852,7 +7892,7 @@
     {
       "path": "sure/skills/sure_trans/scripts/templates/__init__.py",
       "type": "file",
-      "sha256": "83ef73204d0ffeb03f339f0265aa854b5ec724dbc7d2087cb67c5e3012aff27f"
+      "sha256": "95c9175e612f3dab43d53548afc0ec536b16eaa50595a5fc3f65bab616fe1079"
     },
     {
       "path": "sure/skills/sure_trans/scripts/templates/config.yaml",

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,13 +1,13 @@
 {
   "schema": "sure.public_export_manifest.v1",
-  "source_commit": "fd79083c217e434bf2d7608bbdd8723d0cba7b06",
+  "source_commit": "de911243be230c6259a406377b5323fb36971236",
   "source_dirty": false,
-  "tree_sha256": "74d6612c191c775e0b25da3706e54fb5dbb87c35673d42fe810c78f3fe673695",
+  "tree_sha256": "d3400040af9427d3db7518a733aa104ff16235872c55ecbdd5af91f6a86c0122",
   "files": [
     {
       "path": ".github/workflows/public-ci.yml",
       "type": "file",
-      "sha256": "cca9230a5d4c861811298b31e206507317272b8367763af580f924603bf0f9fe"
+      "sha256": "0a6a7debbb183c518488b1d6b2f9a0cf82f82e703a8c21dfe7becf0035ca70ee"
     },
     {
       "path": ".gitignore",

--- a/scripts/check-site-compatibility.mjs
+++ b/scripts/check-site-compatibility.mjs
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
+import { legacyValueDifferences, schemaCompatibilityDifferences } from "./site-compatibility-rules.mjs";
 
 function run(command, args, options = {}) {
 	return spawnSync(command, args, { encoding: "utf8", ...options });
@@ -70,28 +71,11 @@ const expectedPolicy = JSON.parse(readFileSync(policySnapshotPath, "utf8"));
 const checks = [];
 const failures = [];
 let policySha256 = null;
+let candidateEvaluationSubmoduleCommit = null;
 
 function record(id, category, ok, detail, input = undefined) {
 	checks.push({ id, category, status: ok ? "pass" : "fail", detail, ...(input === undefined ? {} : { input }) });
 	if (!ok) failures.push(`${id}: ${detail}`);
-}
-
-function compareExactTree(id, prefix) {
-	const before = listedAt(baseline.baseline_commit, prefix);
-	const after = listedNow(prefix);
-	if (JSON.stringify(before) !== JSON.stringify(after)) {
-		record(id, "runtime", false, `${prefix} file set changed`);
-		return;
-	}
-	const changed = before.filter((path) => !readFileSync(path).equals(baselineFile(baseline.baseline_commit, path)));
-	record(id, "runtime", changed.length === 0, changed.length === 0 ? `${before.length} files are byte-identical` : `changed: ${changed.join(", ")}`);
-}
-
-function compareExactFiles(id, paths, category) {
-	const changed = paths.filter(
-		(path) => !existsSync(path) || !readFileSync(path).equals(baselineFile(baseline.baseline_commit, path)),
-	);
-	record(id, category, changed.length === 0, changed.length === 0 ? `${paths.length} files are byte-identical` : `changed: ${changed.join(", ")}`);
 }
 
 try {
@@ -102,44 +86,59 @@ try {
 }
 
 if (failures.length === 0) {
-	compareExactFiles(
+	const manifestPaths = [
+		"sure/skills/sure_feed/sure.skill.json",
+		"sure/skills/sure_onboard/sure.skill.json",
+		"sure/skills/sure_eval/sure.skill.json",
+		"sure/skills/sure_reval/sure.skill.json",
+	];
+	const manifestDifferences = manifestPaths.flatMap((path) => {
+		if (!existsSync(path)) return [`${path} is missing`];
+		const before = normalized(JSON.parse(baselineFile(baseline.baseline_commit, path).toString("utf8")), true);
+		const after = normalized(JSON.parse(readFileSync(path, "utf8")), true);
+		return legacyValueDifferences(before, after, "$", {
+			orderedArray: (valuePath) => valuePath.startsWith("$.hooks.") || valuePath.startsWith("$.ui."),
+		}).map((difference) => `${path}: ${difference}`);
+	});
+	record(
 		"command-state-manifests",
-		["sure/skills/sure_feed/sure.skill.json", "sure/skills/sure_onboard/sure.skill.json", "sure/skills/sure_eval/sure.skill.json", "sure/skills/sure_reval/sure.skill.json"],
 		"state",
+		manifestDifferences.length === 0,
+		manifestDifferences.length === 0 ? `${manifestPaths.length} legacy manifests remain compatible` : manifestDifferences.join("; "),
 	);
-	compareExactTree("runtime-boundary", "sure/runtime");
-	compareExactFiles("dependency-locks", ["package-lock.json", "packages/coding-agent/npm-shrinkwrap.json"], "runtime");
 
 	const beforeSchemas = listedAt(baseline.baseline_commit, "sure/skills").filter((path) => path.includes("/schemas/") && path.endsWith(".json"));
 	const afterSchemas = listedNow("sure/skills").filter((path) => path.includes("/schemas/") && path.endsWith(".json"));
-	let schemaDetail = `${beforeSchemas.length} artifact schemas are structurally identical`;
-	let schemasMatch = JSON.stringify(beforeSchemas) === JSON.stringify(afterSchemas);
-	if (schemasMatch) {
-		for (const path of beforeSchemas) {
-			const before = normalized(JSON.parse(baselineFile(baseline.baseline_commit, path).toString("utf8")), true);
-			const after = normalized(JSON.parse(readFileSync(path, "utf8")), true);
-			if (JSON.stringify(before) !== JSON.stringify(after)) {
-				schemasMatch = false;
-				schemaDetail = `${path} changed beyond description text`;
-				break;
-			}
+	const schemaDifferences = [];
+	for (const path of beforeSchemas) {
+		if (!afterSchemas.includes(path)) {
+			schemaDifferences.push(`${path} is missing`);
+			continue;
 		}
-	} else {
-		schemaDetail = "artifact schema file set changed";
+		const before = JSON.parse(baselineFile(baseline.baseline_commit, path).toString("utf8"));
+		const after = JSON.parse(readFileSync(path, "utf8"));
+		for (const difference of schemaCompatibilityDifferences(before, after)) {
+			schemaDifferences.push(`${path}: ${difference}`);
+		}
 	}
-	record("artifact-schemas", "artifact", schemasMatch, schemaDetail);
-
-	const baselineGitlink = git(["rev-parse", `${baseline.baseline_commit}:sure/external/sure-evaluation`]).trim();
-	const candidateGitlink = git(["rev-parse", "HEAD:sure/external/sure-evaluation"]).trim();
-	const checkoutGitlink = git(["-C", "sure/external/sure-evaluation", "rev-parse", "HEAD"]).trim();
-	const gitlinkMatches = [baselineGitlink, candidateGitlink, checkoutGitlink].every(
-		(commit) => commit === baseline.evaluation_submodule_commit,
+	record(
+		"artifact-schemas",
+		"artifact",
+		schemaDifferences.length === 0,
+		schemaDifferences.length === 0
+			? `${beforeSchemas.length} legacy schemas remain compatible; ${afterSchemas.length - beforeSchemas.length} additions allowed`
+			: schemaDifferences.join("; "),
 	);
+
+	const candidateGitlink = git(["rev-parse", "HEAD:sure/external/sure-evaluation"]).trim();
+	candidateEvaluationSubmoduleCommit = candidateGitlink;
+	const checkoutGitlink = git(["-C", "sure/external/sure-evaluation", "rev-parse", "HEAD"]).trim();
+	const gitlinkMatches = candidateGitlink === checkoutGitlink;
 	record(
 		"evaluation-submodule",
 		"runtime",
 		gitlinkMatches,
-		gitlinkMatches ? baseline.evaluation_submodule_commit : `baseline=${baselineGitlink} candidate=${candidateGitlink} checkout=${checkoutGitlink}`,
+		gitlinkMatches ? `checkout matches candidate gitlink ${candidateGitlink}` : `candidate=${candidateGitlink} checkout=${checkoutGitlink}`,
 	);
 }
 
@@ -155,8 +154,13 @@ if (siteInfo.status !== 0) {
 	try {
 		const actual = JSON.parse(siteInfo.stdout);
 		policySha256 = actual?.sha256 ?? null;
-		const matches = actual?.source === "bundled" && JSON.stringify(normalized(actual.policy)) === JSON.stringify(normalized(expectedPolicy));
-		record("bundled-policy", "policy", matches, matches ? `exact legacy values, sha256 ${policySha256}` : "bundled policy differs from the legacy snapshot");
+		const policyDifferences = actual?.source === "bundled" ? legacyValueDifferences(expectedPolicy, actual.policy) : ["bundled policy is not selected"];
+		record(
+			"bundled-policy",
+			"policy",
+			policyDifferences.length === 0,
+			policyDifferences.length === 0 ? `legacy values retained, sha256 ${policySha256}` : policyDifferences.join("; "),
+		);
 	} catch (error) {
 		record("bundled-policy", "policy", false, error instanceof Error ? error.message : String(error));
 	}
@@ -209,7 +213,8 @@ try {
 		actualExecution = null;
 	}
 	const executionMatches =
-		executionProbe.status === 0 && JSON.stringify(normalized(actualExecution)) === JSON.stringify(normalized(expectedExecution));
+		executionProbe.status === 0 &&
+		JSON.stringify(normalized(actualExecution)) === JSON.stringify(normalized(expectedExecution));
 	record("execution-selection", "command", executionMatches, executionMatches ? "five legacy execution decisions match" : executionProbe.stderr.trim() || executionProbe.stdout.trim(), expectedExecution.map((item) => item.case));
 
 	const explicitConfig = join(testRoot, "explicit.yaml");
@@ -248,7 +253,8 @@ const report = {
 	baseline_commit: baseline.baseline_commit,
 	candidate_commit: git(["rev-parse", "HEAD"]).trim(),
 	candidate_dirty: git(["status", "--porcelain", "--untracked-files=all"]).trim().length > 0,
-	evaluation_submodule_commit: baseline.evaluation_submodule_commit,
+	evaluation_submodule_commit: candidateEvaluationSubmoduleCommit,
+	baseline_evaluation_submodule_commit: baseline.evaluation_submodule_commit,
 	aispeech_policy_sha256: policySha256,
 	normalization_rules: baseline.normalization_rules,
 	checks,

--- a/scripts/site-compatibility-rules.mjs
+++ b/scripts/site-compatibility-rules.mjs
@@ -1,0 +1,91 @@
+function isObject(value) {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function sameValue(left, right) {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function legacyValueDifferences(expected, actual, path = "$", options = {}) {
+	if (Array.isArray(expected)) {
+		if (!Array.isArray(actual)) return [`${path} must remain an array`];
+		if (options.orderedArray?.(path)) {
+			return expected.flatMap((expectedItem, index) =>
+				index < actual.length
+					? legacyValueDifferences(expectedItem, actual[index], `${path}[${index}]`, options)
+					: [`${path}[${index}] is missing`],
+			);
+		}
+		const unmatched = new Set(actual.map((_, index) => index));
+		const differences = [];
+		for (const expectedItem of expected) {
+			const match = [...unmatched].find(
+				(index) => legacyValueDifferences(expectedItem, actual[index], `${path}[]`, options).length === 0,
+			);
+			if (match === undefined) differences.push(`${path} no longer contains ${JSON.stringify(expectedItem)}`);
+			else unmatched.delete(match);
+		}
+		return differences;
+	}
+	if (isObject(expected)) {
+		if (!isObject(actual)) return [`${path} must remain an object`];
+		return Object.entries(expected).flatMap(([key, value]) =>
+			Object.hasOwn(actual, key)
+				? legacyValueDifferences(value, actual[key], `${path}.${key}`, options)
+				: [`${path}.${key} is missing`],
+		);
+	}
+	return Object.is(expected, actual) ? [] : [`${path} changed from ${JSON.stringify(expected)} to ${JSON.stringify(actual)}`];
+}
+
+function sameSet(left, right) {
+	return left.length === right.length && left.every((value) => right.some((candidate) => sameValue(value, candidate)));
+}
+
+export function schemaCompatibilityDifferences(expected, actual, path = "$") {
+	if (Array.isArray(expected)) {
+		if (!Array.isArray(actual)) return [`${path} must remain an array`];
+		if (path.endsWith(".enum")) {
+			return expected.every((value) => actual.some((candidate) => sameValue(value, candidate)))
+				? []
+				: [`${path} removed a legacy value`];
+		}
+		if (path.endsWith(".required") || path.endsWith(".type")) {
+			return sameSet(expected, actual) ? [] : [`${path} changed`];
+		}
+		return sameValue(expected, actual) ? [] : [`${path} changed`];
+	}
+	if (!isObject(expected)) {
+		return Object.is(expected, actual)
+			? []
+			: [`${path} changed from ${JSON.stringify(expected)} to ${JSON.stringify(actual)}`];
+	}
+	if (!isObject(actual)) return [`${path} must remain an object`];
+
+	const differences = [];
+	for (const [key, value] of Object.entries(expected)) {
+		if (key === "description") continue;
+		if (!Object.hasOwn(actual, key)) {
+			differences.push(`${path}.${key} is missing`);
+			continue;
+		}
+		if ((key === "properties" || key === "$defs" || key === "definitions") && isObject(value)) {
+			if (!isObject(actual[key])) {
+				differences.push(`${path}.${key} must remain an object`);
+				continue;
+			}
+			for (const [name, definition] of Object.entries(value)) {
+				if (!Object.hasOwn(actual[key], name)) differences.push(`${path}.${key}.${name} is missing`);
+				else differences.push(...schemaCompatibilityDifferences(definition, actual[key][name], `${path}.${key}.${name}`));
+			}
+			continue;
+		}
+		differences.push(...schemaCompatibilityDifferences(value, actual[key], `${path}.${key}`));
+	}
+
+	for (const key of Object.keys(actual)) {
+		if (key === "description" || Object.hasOwn(expected, key)) continue;
+		differences.push(`${path}.${key} added a new constraint`);
+	}
+	return differences;
+}

--- a/scripts/site-compatibility-rules.test.mjs
+++ b/scripts/site-compatibility-rules.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { legacyValueDifferences, schemaCompatibilityDifferences } from "./site-compatibility-rules.mjs";
+
+test("legacy policy allows additive configuration", () => {
+	const expected = {
+		datasets: { allowed_source_roots: ["/datasets"] },
+		execution: { surfaces: ["local", "vc"] },
+	};
+	const actual = {
+		datasets: { allowed_source_roots: ["/datasets", "/datasets-secondary"] },
+		execution: { surfaces: ["local", "vc", "native"], default_surface: "native" },
+	};
+	assert.deepEqual(legacyValueDifferences(expected, actual), []);
+});
+
+test("legacy policy rejects changed values", () => {
+	const differences = legacyValueDifferences(
+		{ datasets: { allowed_source_roots: ["/datasets"] } },
+		{ datasets: { allowed_source_roots: ["/other"] } },
+	);
+	assert.deepEqual(differences, ['$.datasets.allowed_source_roots no longer contains "/datasets"']);
+});
+
+test("legacy manifests preserve ordered hook and UI entries", () => {
+	const options = { orderedArray: (path) => path.startsWith("$.hooks.") || path.startsWith("$.ui.") };
+	const expected = {
+		hooks: { pre_start: [{ handler: "first" }, { handler: "second" }] },
+		ui: { primaryCounters: ["completed", "total"] },
+	};
+	const actual = {
+		hooks: { pre_start: [{ handler: "second" }, { handler: "first" }] },
+		ui: { primaryCounters: ["total", "completed"] },
+	};
+	assert.deepEqual(legacyValueDifferences(expected, actual, "$", options), [
+		'$.hooks.pre_start[0].handler changed from "first" to "second"',
+		'$.hooks.pre_start[1].handler changed from "second" to "first"',
+		'$.ui.primaryCounters[0] changed from "completed" to "total"',
+		'$.ui.primaryCounters[1] changed from "total" to "completed"',
+	]);
+});
+
+test("legacy manifests allow appended ordered entries and unordered artifacts", () => {
+	const options = { orderedArray: (path) => path.startsWith("$.hooks.") || path.startsWith("$.ui.") };
+	const expected = {
+		hooks: { pre_start: [{ handler: "legacy" }] },
+		artifacts: [{ type: "report" }, { type: "manifest" }],
+	};
+	const actual = {
+		hooks: { pre_start: [{ handler: "legacy" }, { handler: "new" }] },
+		artifacts: [{ type: "new" }, { type: "manifest" }, { type: "report" }],
+	};
+	assert.deepEqual(legacyValueDifferences(expected, actual, "$", options), []);
+});
+
+test("schema compatibility allows optional properties and enum extensions", () => {
+	const expected = {
+		type: "object",
+		required: ["status"],
+		properties: {
+			status: { type: "string", enum: ["ready", "blocked"] },
+		},
+		additionalProperties: false,
+	};
+	const actual = {
+		type: "object",
+		required: ["status"],
+		properties: {
+			status: { type: "string", enum: ["ready", "blocked", "pending"] },
+			reason: { type: "string" },
+		},
+		additionalProperties: false,
+	};
+	assert.deepEqual(schemaCompatibilityDifferences(expected, actual), []);
+});
+
+test("schema compatibility rejects property removal", () => {
+	const expected = { type: "object", properties: { status: { type: "string" } } };
+	const actual = { type: "object", properties: {} };
+	assert.deepEqual(schemaCompatibilityDifferences(expected, actual), ["$.properties.status is missing"]);
+});
+
+test("schema compatibility rejects changed types and required fields", () => {
+	const expected = {
+		type: "object",
+		required: ["status"],
+		properties: { status: { type: "string" } },
+	};
+	const actual = {
+		type: "object",
+		required: ["status", "reason"],
+		properties: { status: { type: "number" }, reason: { type: "string" } },
+	};
+	assert.deepEqual(schemaCompatibilityDifferences(expected, actual), [
+		"$.required changed",
+		'$.properties.status.type changed from "string" to "number"',
+	]);
+});

--- a/scripts/sure-site-check.ts
+++ b/scripts/sure-site-check.ts
@@ -10,6 +10,7 @@ function isWithin(path: string, root: string): boolean {
 try {
 	const resolved = requireSitePolicy();
 	const { datasets, execution, storage } = resolved.policy;
+	const projectionRoot = datasets.projection_root;
 	const failures: string[] = [];
 	for (const [kind, roots] of [
 		["approved model", storage.approved_models_roots],
@@ -23,6 +24,20 @@ try {
 	}
 	if (storage.forbidden_output_roots.some((forbidden) => isWithin(storage.runtime_root, forbidden))) {
 		failures.push(`runtime root must stay outside forbidden output roots: ${storage.runtime_root}`);
+	}
+	if (
+		projectionRoot &&
+		storage.forbidden_output_roots.some((forbidden) => isWithin(projectionRoot, forbidden))
+	) {
+		failures.push(`dataset projection root must stay outside forbidden output roots: ${projectionRoot}`);
+	}
+	if (
+		projectionRoot &&
+		datasets.allowed_source_roots.some(
+			(source) => isWithin(projectionRoot, source) || isWithin(source, projectionRoot),
+		)
+	) {
+		failures.push(`dataset projection root must not overlap an allowed source root: ${projectionRoot}`);
 	}
 	if (execution.surfaces.includes("vc") && !execution.vc_partitions?.length) {
 		failures.push("execution.vc_partitions is required when the vc surface is enabled");

--- a/sure/site/loader.py
+++ b/sure/site/loader.py
@@ -80,7 +80,7 @@ def validate_site_policy(value: Any) -> dict[str, Any]:
     storage = _mapping(root.get("storage"), "storage")
     _reject_unknown(storage, {"approved_models_roots", "approved_results_roots", "forbidden_output_roots", "runtime_root"}, "storage")
     datasets = _mapping(root.get("datasets"), "datasets")
-    _reject_unknown(datasets, {"allowed_source_roots"}, "datasets")
+    _reject_unknown(datasets, {"allowed_source_roots", "projection_root"}, "datasets")
     execution = _mapping(root.get("execution"), "execution")
     _reject_unknown(execution, {"surfaces", "vc_partitions", "vc_partition_priority", "vc_default_partition"}, "execution")
     surfaces = _unique_strings(execution.get("surfaces"), "execution.surfaces", absolute=False)
@@ -102,6 +102,10 @@ def validate_site_policy(value: Any) -> dict[str, Any]:
         },
         "execution": {"surfaces": surfaces},
     }
+    if "projection_root" in datasets:
+        policy["datasets"]["projection_root"] = _absolute_path(
+            datasets["projection_root"], "datasets.projection_root"
+        )
     if "vc_partitions" in execution:
         policy["execution"]["vc_partitions"] = _unique_strings(execution["vc_partitions"], "execution.vc_partitions", absolute=False)
     if "vc_partition_priority" in execution:

--- a/sure/site/loader.ts
+++ b/sure/site/loader.ts
@@ -22,6 +22,7 @@ export interface SitePolicy {
 	};
 	datasets: {
 		allowed_source_roots: string[];
+		projection_root?: string;
 	};
 	execution: {
 		surfaces: ExecutionSurface[];
@@ -102,7 +103,7 @@ export function validateSitePolicy(value: unknown): SitePolicy {
 	const storage = expectRecord(root.storage, "storage");
 	rejectUnknown(storage, ["approved_models_roots", "approved_results_roots", "forbidden_output_roots", "runtime_root"], "storage");
 	const datasets = expectRecord(root.datasets, "datasets");
-	rejectUnknown(datasets, ["allowed_source_roots"], "datasets");
+	rejectUnknown(datasets, ["allowed_source_roots", "projection_root"], "datasets");
 	const execution = expectRecord(root.execution, "execution");
 	rejectUnknown(execution, ["surfaces", "vc_partitions", "vc_partition_priority", "vc_default_partition"], "execution");
 	const surfaces = expectUniqueStrings(execution.surfaces, "execution.surfaces", false);
@@ -149,6 +150,9 @@ export function validateSitePolicy(value: unknown): SitePolicy {
 			surfaces: surfaces as ExecutionSurface[],
 		},
 	};
+	if (datasets.projection_root !== undefined) {
+		policy.datasets.projection_root = expectAbsolutePath(datasets.projection_root, "datasets.projection_root");
+	}
 	if (execution.vc_partitions !== undefined) {
 		policy.execution.vc_partitions = expectUniqueStrings(execution.vc_partitions, "execution.vc_partitions", false);
 	}

--- a/sure/site/policy.schema.json
+++ b/sure/site/policy.schema.json
@@ -25,7 +25,8 @@
 			"additionalProperties": false,
 			"required": ["allowed_source_roots"],
 			"properties": {
-				"allowed_source_roots": { "$ref": "#/$defs/absolutePaths" }
+				"allowed_source_roots": { "$ref": "#/$defs/absolutePaths" },
+				"projection_root": { "$ref": "#/$defs/absolutePath" }
 			}
 		},
 		"execution": {

--- a/sure/site/public.example.yaml
+++ b/sure/site/public.example.yaml
@@ -14,6 +14,7 @@ storage:
 datasets:
   allowed_source_roots:
     - /srv/sure/datasets
+  projection_root: /var/lib/sure/dataset-projections
 
 execution:
   surfaces:

--- a/sure/site/test_loader.py
+++ b/sure/site/test_loader.py
@@ -72,6 +72,32 @@ class AbsolutePathTest(unittest.TestCase):
             validate_site_policy(_policy(storage=storage))
         self.assertIn("storage.approved_models_roots[0]", str(raised.exception))
 
+    def test_accepts_an_absolute_dataset_projection_root(self) -> None:
+        policy = validate_site_policy(
+            _policy(
+                datasets={
+                    "allowed_source_roots": [f"{_ROOT}/datasets"],
+                    "projection_root": "/var/lib/sure/dataset-projections",
+                }
+            )
+        )
+        self.assertEqual(
+            policy["datasets"]["projection_root"],
+            "/var/lib/sure/dataset-projections",
+        )
+
+    def test_rejects_a_relative_dataset_projection_root(self) -> None:
+        with self.assertRaises(SitePolicyError) as raised:
+            validate_site_policy(
+                _policy(
+                    datasets={
+                        "allowed_source_roots": [f"{_ROOT}/datasets"],
+                        "projection_root": "data/projections",
+                    }
+                )
+            )
+        self.assertIn("datasets.projection_root", str(raised.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/sure/skills/sure_eval/SKILL.md
+++ b/sure/skills/sure_eval/SKILL.md
@@ -19,6 +19,7 @@ Control principle: **agent decides scope, scripts enforce format and execution.*
 |-----------|----------|---------|
 | `model` | ✅ | Exact approved directory name below a configured `approved_models_roots` entry. No path, alias, environment-root, or local-model fallback is accepted. |
 | `datasets` | ✅ | Comma-separated source paths below a configured `allowed_source_roots` entry, e.g. `datasets=/srv/sure/datasets/group/store/ds_pool/example@v1.0.2`. The strict main flow rejects legacy dataset names and short aliases; multi-version sources require the trailing `@<version_id>` (single-version sources may omit it). Dataset metadata, not a user-supplied task flag, determines ASR/TTS/VC/etc. |
+| `datasets_root` | — | Absolute writable projection root for generated JSONL indexes and metadata. Resolution precedence is this parameter, `SURE_EVAL_DATASETS_ROOT`, `datasets.projection_root` in site policy, an explicit config's `data.datasets`, then the repository development default. It must stay outside forbidden output roots and must not overlap a source root. Raw data is referenced in place and is never copied or moved. |
 | `protocol` | — | `standard_system` (default) follows the approved model's upstream configuration. `strict_core` requires every conservative parameter to be mapped to an MCP argument or explicitly proven not applicable. |
 | `device` | — | `auto \| cpu \| cuda \| cuda:<index>`. Default `auto`; resolved by `scripts/resolve_eval_input.py` and passed through inference/evaluation templates when materialized. For `execution=local`, `cuda:<index>` selects the local host GPU by setting `CUDA_VISIBLE_DEVICES=<index>`. For `execution=vc`, the allocated container GPU is addressed as `cuda:0`; choose hardware with `vc_partition`/`vc_gpu`, not a host CUDA ordinal. |
 | `target` | — | Target metric or paper to compare against. |
@@ -92,7 +93,7 @@ Advance happens **only** when the current unit's `produces` artifact is complian
 | 7 | `execution_readiness` | **gate** | `execution_readiness_report.json` | `scripts/check_execution_surface_compliance.py` |
 | 8 | `smoke_test` | **gate** | `smoke_test_result.json` | `scripts/run_smoke.py` |
 | 9 | `submit_vc_run` | **gate** | `submit_result.json` | `scripts/vc_check.py` |
-| 10 | `execute_wait` | linear | `execution_result.json` | — |
+| 10 | `execute_wait` | **gate** | `execution_result.json` | `scripts/wait_vc_execution.py` |
 | 11 | `assessment` | **gate** | `assessment_report.json` | `scripts/check_assessment.py` |
 | 12 | `run_report` | **gate** | `main_agent_run_report.json` | `scripts/check_run_report.py` |
 
@@ -110,6 +111,7 @@ Each unit must satisfy: **Inputs** (previous unit's produces + evidence sources 
 - **execution_readiness**: `check_execution_surface_compliance.py` compares the surface binding with the approved input, rejects `local_bash`, `.venv`, `/usr/bin/python3`, image changes, writable NFS models, and tool mismatches. It also preserves template isolation and validates the standalone evaluation route plan.
 - **smoke_test**: bounded smoke on a tiny slice using local Docker and the approved digest-pinned image; `smoke_passed` true.
 - **submit_vc_run**: `execution=vc` uses the same approved image through `vc_submit`; `execution=local` uses `local_docker`; `auto` prefers VC when available. VC precheck verifies the immutable image, partition, mounts, and resources. It does not infer or rewrite a model `.venv`.
+- **execute_wait**: For VC, run `scripts/wait_vc_execution.py --run-dir <sure_run_dir> --wait` once. The waiter matches the current submission token, prefers the atomic terminal sentinel, and uses `vc info`/`vc describe` only to classify missing-container and timeout cases. Do not hand-author polling or a terminal result. Local Docker already writes its own result, which this gate validates.
 - **assessment**: {anomaly_detected, user_confirmed}. Anomaly (e.g. WER/CER > 50%, Accuracy < 20%) requires user confirmation.
 - **run_report**: {report_persisted, execution_path_actual}. Record `execution_path_requested`, `execution_path_actual`, `device_request`, `device_actual`, `max_samples`, total dataset samples, and evaluated samples. Non-vc paths are valid for explicit `execution=local`; auto local fallback requires a reason and, if vc was available, explicit fallback approval.
 
@@ -183,6 +185,7 @@ standalone `sure-evaluation` engine when it is available. Flat scripts under
 `materialize_predictions_template.py`, `generate_predictions_via_server.py`,
 `validate_prediction_files.py`, `evaluate_predictions.py`,
 `refresh_report_snapshot.py`, `run_local_execution.py`, `run_vc_execution.py`,
+`wait_vc_execution.py`,
 `check_execution_surface_compliance.py`) are the routing targets. Templates live
 in `scripts/templates/`. Run them as:
 
@@ -196,7 +199,10 @@ both `submit_result.json` and `execution_result.json`. For `execution=vc`, use
 `scripts/run_vc_execution.py --run-dir <sure_run_dir>` from the submit unit. It
 writes `submit_result.json`, includes the exact `vc submit` command and a
 persistent `<sure_run_dir>/vc_logs/job.log`, and leaves final
-`execution_result.json` to the following `execute_wait` unit. When vc resources
+`execution_result.json` to `scripts/wait_vc_execution.py --run-dir <sure_run_dir> --wait`
+in the following `execute_wait` unit. The generated VC entrypoint atomically
+writes a tokenized terminal sentinel on exit, so pod cleanup cannot erase the
+authoritative exit code. When vc resources
 are selected at submit time, the effective digest-pinned image, partition, CPU,
 GPU, memory, entrypoint, and log snapshot is recorded in both `submit_result.vc_submission`
 and `execution_surface.vc_runtime.resolved_submission`.
@@ -227,15 +233,14 @@ default. In a GitHub-backed harness worktree, this path should be a Git
 submodule that points at the independent `sure-evaluation` repository. Use
 `SURE_EVALUATION_HOME` or `--evaluation-engine-root` only as an explicit local
 override; the workspace checkout is not an implicit fallback.
-If `SURE_EVAL_CONFIG` is not supplied, harness runtime templates materialize
-`<run_dir>/_harness_config.yaml` from the submodule's `config/default.yaml` and
-rewrite results/cache paths to harness-local absolute paths. The default dataset
-entry is `data/datasets` under the harness repository; deployments either
-download and convert benchmark data with the repository scripts (see the user
-guide's Benchmark Data section) or symlink an existing
-`sure_benchmark/jsonl` tree into `data/datasets/sure_benchmark/jsonl`.
-Override `SURE_EVAL_DATASETS_ROOT` only when pointing at another directory that
-contains `sure_benchmark/jsonl`.
+Input resolution always materializes `<run_dir>/_harness_config.yaml` from the
+selected config and binds its dataset entry to the resolved writable projection
+root. The first run creates `sure_benchmark/jsonl` plus generated indexes and
+metadata there. Source `sample.jsonl`, `ds.jsonl`, and raw audio remain under the
+configured `allowed_source_roots`; execution mounts those source roots and the
+approved model read-only. Configure the projection with `datasets_root`,
+`SURE_EVAL_DATASETS_ROOT`, or site policy `datasets.projection_root`. The
+repository-local `data/datasets` path is only the development fallback.
 
 `evaluate_predictions.py` accepts `--evaluation-backend auto|external|legacy`
 and `--strict-main-flow`. Harness main-flow templates default to
@@ -262,6 +267,7 @@ inside that container; it never starts a host model runtime.
 - `execution_readiness`: `execution_ready && isolation_audit.audit_passed`; `check_execution_surface_compliance.py` (red line 1) also prepares/verifies the locked Evaluation Python, writes `evaluation_route_plan.json`, and blocks when standalone `sure-evaluation` reports root or selected node environment issues. The plan must include engine commit, Evaluation Runtime ID/lock, supported/default metrics, selected metrics, route choices, selected routes, and setup commands for blocking node-local environments. Bounded smoke is enforced by the next `smoke_test` gate.
 - `smoke_test`: `smoke_passed` true; entrypoint exists.
 - `submit_vc_run`: `vc_check.py` enforces `execution=local|vc|auto` semantics against real `which vc && vc info` availability.
+- `execute_wait`: `wait_vc_execution.py` rejects `running` as incomplete, validates the current submission token, and accepts terminal success or failure for downstream assessment.
 - `assessment`: anomaly → `user_confirmed` true.
 - `run_report`: `report_persisted` true, `execution_path_actual` declared, and execution/device/sample provenance recorded. Completed runs should index `eval_input_resolved.json` and `evaluation_route_plan.json`, and must contain model-local `evaluation_payload.json`, `protocol.yaml`, `report.jsonl`, `metrics/<dataset>/<metric_slug>/{report.json,pipeline_description.json}`, `sample_reports/<dataset>/<metric_slug>.jsonl`, and `predictions/<dataset>.txt/.jsonl`.
 

--- a/sure/skills/sure_eval/hooks/index.ts
+++ b/sure/skills/sure_eval/hooks/index.ts
@@ -100,7 +100,7 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (missing.length > 0) {
 		return failure(
-			`Missing required /sure_eval parameters: ${missing.join(", ")}. Usage: /sure_eval model=<name> datasets=<dataset__version[,dataset__version...]> [protocol=standard_system|strict_core] [execution=auto|local|vc] [device=auto|cpu|cuda[:index]] [max_samples=...]`,
+			`Missing required /sure_eval parameters: ${missing.join(", ")}. Usage: /sure_eval model=<name> datasets=<source_root[,source_root...]> [datasets_root=<writable_projection_root>] [protocol=standard_system|strict_core] [execution=auto|local|vc] [device=auto|cpu|cuda[:index]] [max_samples=...]`,
 			"Missing required parameters.",
 		);
 	}
@@ -195,6 +195,9 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (typeof args.config === "string") {
 		resolveArgs.push("--config", args.config);
+	}
+	if (typeof args.datasets_root === "string") {
+		resolveArgs.push("--datasets-root", args.datasets_root);
 	}
 	const resolvedInput = spawnSync(runtime.contract.python_executable, resolveArgs, {
 		cwd: ctx.packageDir,

--- a/sure/skills/sure_eval/hooks/state-machine.ts
+++ b/sure/skills/sure_eval/hooks/state-machine.ts
@@ -249,12 +249,13 @@ export const MAIN_FLOW_UNITS: Unit[] = [
 	{
 		id: "execute_wait",
 		label: "Execute & wait for completion",
-		kind: "linear",
+		kind: "gate",
 		produces: "execution_result.json",
 		schemaRef: "execution_result.schema.json",
 		requiredFields: ["job_status"],
 		allowedValues: { job_status: ["succeeded", "running", "failed", "partial"] },
 		forbiddenFields: ["report_persisted"],
+		gateScript: "wait_vc_execution.py",
 	},
 	{
 		id: "assessment",

--- a/sure/skills/sure_eval/schemas/execution_result.schema.json
+++ b/sure/skills/sure_eval/schemas/execution_result.schema.json
@@ -27,7 +27,17 @@
 		"stderr_log": { "type": "string" },
 		"device_request": { "type": "string" },
 		"device_actual": { "type": "string" },
-		"cuda_visible_devices": { "type": "string" }
+		"cuda_visible_devices": { "type": "string" },
+		"completion_source": {
+			"type": "string",
+			"enum": ["terminal_sentinel", "vc_terminal_without_sentinel", "wait_timeout", "local_process"]
+		},
+		"submission_token": { "type": "string" },
+		"terminal_sentinel": { "type": "string" },
+		"timed_out": { "type": "boolean" },
+		"poll_count": { "type": "integer", "minimum": 0 },
+		"vc_info_excerpt": { "type": "string" },
+		"vc_describe_excerpt": { "type": "string" }
 	},
 	"additionalProperties": false
 }

--- a/sure/skills/sure_eval/schemas/submit_result.schema.json
+++ b/sure/skills/sure_eval/schemas/submit_result.schema.json
@@ -21,6 +21,8 @@
 		"fallback_approved": { "type": "boolean" },
 		"local_fallback_reason": { "type": "string" },
 		"submitted_at": { "type": "string" },
+		"submission_token": { "type": "string" },
+		"terminal_status_path": { "type": "string" },
 		"host": { "type": "string" },
 		"pid": { "type": "number" },
 		"command": { "type": "string" },

--- a/sure/skills/sure_eval/scripts/check_execution_surface_compliance.py
+++ b/sure/skills/sure_eval/scripts/check_execution_surface_compliance.py
@@ -276,6 +276,10 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
         env.get("PYTHON_BIN"),
     }:
         issues.append("Harness Python and Model Python must be separate execution roles")
+    declared_node_python = env.get("SURE_EVAL_NODE_LOCAL_PYTHON")
+    if isinstance(declared_node_python, str) and declared_node_python:
+        if declared_node_python != approved_harness.get("python_executable"):
+            issues.append("SURE_EVAL_NODE_LOCAL_PYTHON differs from the approved common Harness Runtime")
 
     declared_tool = next(
         (value for value in (env.get("TOOL_NAME"), resolved_inputs.get("tool_name")) if isinstance(value, str) and value),
@@ -321,6 +325,11 @@ def _live_runtime_probe(
     container = binding.get("container") if isinstance(binding.get("container"), dict) else {}
     model_python = str(container.get("python_executable") or "python")
     harness_python = str(harness["python_executable"])
+    node_probe = (
+        "import os,subprocess;"
+        "python=os.environ['SURE_EVAL_NODE_LOCAL_PYTHON'];"
+        "subprocess.run([python,'-S','-c','import sys'],check=True)"
+    )
     script = (
         f"test {shlex.quote(harness_python)} != {shlex.quote(model_python)} || exit 40; "
         f"{shlex.quote(harness_python)} -s -c "
@@ -328,7 +337,9 @@ def _live_runtime_probe(
         + " || exit 41; "
         + f"{shlex.quote(model_python)} -c "
         + shlex.quote("import sys; print(sys.executable)")
-        + " || exit 42"
+        + " || exit 42; "
+        + f"export SURE_EVAL_NODE_LOCAL_PYTHON={shlex.quote(harness_python)}; "
+        + f"{shlex.quote(harness_python)} -s -c {shlex.quote(node_probe)} || exit 43"
     )
     command = ["docker", "run", "--rm", "--entrypoint", "bash"]
     if mounted:
@@ -347,6 +358,7 @@ def _live_runtime_probe(
         40: "HARNESS_MODEL_RUNTIME_ALIAS",
         41: "HARNESS_RUNTIME_NOT_READY",
         42: "MODEL_RUNTIME_NEEDS_REPAIR",
+        43: "EVALUATION_NODE_RUNTIME_NOT_READY",
     }
     failure_class = categories.get(completed.returncode, "CONTAINER_RUNTIME_UNAVAILABLE")
     detail = (completed.stderr or completed.stdout or "").strip()
@@ -358,9 +370,10 @@ def _live_runtime_probe(
         "harness_runtime_id": harness.get("runtime_id"),
         "harness_lock_sha256": harness.get("lock_sha256"),
         "harness_python": harness_python,
+        "node_local_python": harness_python,
         "model_python": model_python,
         "harness_runtime_source": harness.get("execution_source"),
-        "evidence": "exact-image Harness/Model runtime probe passed"
+        "evidence": "exact-image Harness/Model/Node runtime probe passed"
         if completed.returncode == 0
         else f"{failure_class}: {detail or f'exit {completed.returncode}'}",
     }

--- a/sure/skills/sure_eval/scripts/container_execution.py
+++ b/sure/skills/sure_eval/scripts/container_execution.py
@@ -51,6 +51,26 @@ def surface_env(surface: dict[str, Any]) -> dict[str, str]:
     }
 
 
+def dataset_projection_root_from_eval_input(eval_input: dict[str, Any]) -> Path | None:
+    runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+    projection = runtime.get("dataset_projection")
+    if projection is None:
+        return None
+    if not isinstance(projection, dict):
+        raise ValueError("eval input dataset_projection must be an object")
+    raw_root = str(projection.get("host_root") or "")
+    root = Path(raw_root).expanduser()
+    if not raw_root or not root.is_absolute():
+        raise ValueError("eval input dataset_projection.host_root must be absolute")
+    root = root.resolve()
+    if not (root / "sure_benchmark" / "jsonl").is_dir():
+        raise ValueError(
+            "eval input dataset projection must contain sure_benchmark/jsonl: "
+            f"{root}"
+        )
+    return root
+
+
 def _mount(
     command: list[str],
     mounted_targets: dict[str, tuple[Path, bool]],
@@ -147,6 +167,7 @@ def build_local_container_command(
     harness_python = str(harness_runtime["python_executable"])
     harness_manifest = str(harness_runtime["manifest_path"])
     evaluation_runtime = evaluation_runtime_from_eval_input(eval_input, prepare=False)
+    dataset_projection_root = dataset_projection_root_from_eval_input(eval_input)
 
     command = ["docker", "run", "--rm", "--init", "--entrypoint", "bash"]
     mounted_targets: dict[str, tuple[Path, bool]] = {}
@@ -163,6 +184,14 @@ def build_local_container_command(
     _mount(command, mounted_targets, model_source, str(model_source), read_only=True)
     if model_target != str(model_source):
         _mount(command, mounted_targets, model_source, model_target, read_only=True)
+    if dataset_projection_root is not None:
+        _mount(
+            command,
+            mounted_targets,
+            dataset_projection_root,
+            str(dataset_projection_root),
+            read_only=False,
+        )
 
     for item in eval_input.get("datasets", []):
         if not isinstance(item, dict):
@@ -173,6 +202,13 @@ def build_local_container_command(
                 continue
             declared_path = Path(raw).expanduser()
             path = declared_path.resolve()
+            if key == "jsonl_path" and dataset_projection_root is not None:
+                try:
+                    path.relative_to(dataset_projection_root)
+                except ValueError:
+                    pass
+                else:
+                    continue
             mount_source = path if path.is_dir() else path.parent
             mount_target = declared_path if path.is_dir() else declared_path.parent
             if mount_source.exists():
@@ -194,6 +230,7 @@ def build_local_container_command(
             "MODEL_PYTHON": str(container.get("python_executable") or "python"),
             "PYTHON_BIN": str(container.get("python_executable") or "python"),
             "HARNESS_PYTHON_BIN": harness_python,
+            "SURE_EVAL_NODE_LOCAL_PYTHON": harness_python,
             "SURE_HARNESS_RUNTIME_ID": str(harness_runtime["runtime_id"]),
             "SURE_HARNESS_LOCK_SHA256": str(harness_runtime["lock_sha256"]),
             "SURE_HARNESS_MANIFEST_PATH": harness_manifest,
@@ -216,6 +253,8 @@ def build_local_container_command(
             "XDG_CACHE_HOME": f"{output_target}/.runtime/cache/xdg",
         }
     )
+    if dataset_projection_root is not None:
+        env["SURE_EVAL_DATASETS_ROOT"] = str(dataset_projection_root)
     if evaluation_runtime is not None:
         env.update(
             {
@@ -235,8 +274,22 @@ def build_local_container_command(
         "image_ref": binding["target_image_ref"],
         "model_mount": {"source": str(model_source), "target": model_target, "read_only": True},
         "result_mount": {"source": str(output_source), "target": output_target, "read_only": False},
+        "dataset_projection_mount": (
+            {
+                "source": str(dataset_projection_root),
+                "target": str(dataset_projection_root),
+                "read_only": False,
+            }
+            if dataset_projection_root is not None
+            else None
+        ),
         "harness_runtime": harness_runtime,
         "evaluation_runtime": evaluation_runtime,
+        "evaluation_node_runtime": {
+            "runtime_type": "evaluation_node_python",
+            "python_executable": harness_python,
+            "source": "approved_common_harness_runtime",
+        },
         "harness_runtime_mounted_from_repo": harness_mounted_from_repo,
         "model_runtime": {
             "runtime_type": "model_python",

--- a/sure/skills/sure_eval/scripts/evaluate_predictions.py
+++ b/sure/skills/sure_eval/scripts/evaluate_predictions.py
@@ -34,7 +34,11 @@ from sure_eval.evaluation.sure_evaluator import SUREEvaluator
 from sure_eval.reports import SOTAManager
 
 from resolve_evaluation_engine import resolve_engine_root
-from evaluation_runtime import ensure_evaluation_runtime, evaluation_child_environment
+from evaluation_runtime import (
+    EvaluationRuntimeError,
+    ensure_evaluation_runtime,
+    evaluation_child_environment,
+)
 
 configure_logging(level="INFO")
 logger = get_logger(__name__)
@@ -995,6 +999,16 @@ def _to_strict_jsonable(value: Any) -> Any:
 def _metric_slug(metric: str) -> str:
     slug = "".join(ch if ch.isalnum() or ch in "._=-" else "_" for ch in str(metric).lower())
     return slug or "metric"
+
+
+def _run_relative_artifact_path(path: str | Path, run_dir: Path) -> str:
+    """Return a portable artifact path, rejecting references outside the run."""
+    resolved_run_dir = run_dir.resolve()
+    resolved_path = Path(path).resolve()
+    try:
+        return resolved_path.relative_to(resolved_run_dir).as_posix()
+    except ValueError as exc:
+        raise ValueError(f"artifact path must stay under the run root: {resolved_path}") from exc
 
 
 def _primary_result(metric: str, score: Any, report: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -2056,6 +2070,12 @@ def _external_metric_applies_to_task_language(
             pipeline_id=pipeline_id,
             timeout=timeout,
         )
+    except (OSError, EvaluationRuntimeError):
+        # The engine never got asked: a missing binary or an unusable evaluation
+        # runtime says nothing about whether it supports this metric. Recording
+        # it as "not applicable" turns a broken environment into a silent
+        # "no metric is supported" at the end of the run.
+        raise
     except Exception as exc:
         if failures is not None:
             failures.append(f"{pipeline_id or metric or 'default'}: {_summarize_bridge_error(exc)}")
@@ -2127,24 +2147,25 @@ def _write_run_artifacts(
         row = payload_rows[index] if index < len(payload_rows) and isinstance(payload_rows[index], dict) else _dataset_metric_row(result)
         row = dict(row)
         artifacts = dict(row.get("artifacts") or {})
-        # check_run_report resolves relative payload paths against the run
-        # root, so record absolute paths even when --run-dir was relative.
         artifacts.update(
             {
-                "metric_artifact_dir": str(metric_dir.resolve()),
-                "report": str(report_path.resolve()),
-                "pipeline_description": str(pipeline_path.resolve()),
-                "sample_report": str(sample_report_path.resolve()),
-                "prediction_file": str(Path(result["prediction_path"]).resolve()),
+                "metric_artifact_dir": _run_relative_artifact_path(metric_dir, run_dir),
+                "report": _run_relative_artifact_path(report_path, run_dir),
+                "pipeline_description": _run_relative_artifact_path(pipeline_path, run_dir),
+                "sample_report": _run_relative_artifact_path(sample_report_path, run_dir),
+                "prediction_file": _run_relative_artifact_path(result["prediction_path"], run_dir),
             }
         )
         row["artifacts"] = artifacts
+        inputs = dict(row.get("inputs") or {})
+        inputs["prediction_path"] = artifacts["prediction_file"]
+        row["inputs"] = inputs
         pipeline_payload = dict(row.get("pipeline") or {})
         pipeline_payload.update(
             {
                 "pipeline_id": row.get("pipeline_id") or result.get("pipeline_id"),
-                "report_path": str(report_path.resolve()),
-                "description_path": str(pipeline_path.resolve()),
+                "report_path": artifacts["report"],
+                "description_path": artifacts["pipeline_description"],
             }
         )
         row["pipeline"] = pipeline_payload

--- a/sure/skills/sure_eval/scripts/evaluation_runtime.py
+++ b/sure/skills/sure_eval/scripts/evaluation_runtime.py
@@ -100,14 +100,22 @@ def evaluation_child_environment(parent: dict[str, str] | None = None) -> dict[s
 
 
 def _engine_commit(engine_root: Path) -> str:
-    completed = subprocess.run(
-        ["git", "-c", f"safe.directory={engine_root}", "rev-parse", "HEAD"],
-        cwd=engine_root,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=evaluation_child_environment(),
-    )
+    try:
+        completed = subprocess.run(
+            ["git", "-c", f"safe.directory={engine_root}", "rev-parse", "HEAD"],
+            cwd=engine_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=evaluation_child_environment(),
+        )
+    except OSError as exc:
+        # An empty commit means "git looked and found nothing pinned here"; a git
+        # that will not run at all is a broken environment and has to say so,
+        # otherwise the caller reports it as a commit mismatch against "".
+        raise EvaluationRuntimeError(
+            f"cannot read the evaluation engine commit: git is unavailable ({exc})"
+        ) from exc
     return completed.stdout.strip() if completed.returncode == 0 else ""
 
 

--- a/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
+++ b/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
@@ -653,6 +653,11 @@ def _normalize_prediction_payload(payload: Any, *, task: str) -> tuple[str, dict
             prediction = dict(payload)
         if task_name in {"ASR", "S2TT"}:
             value = prediction.get("text") or prediction.get("transcript") or payload.get("text") or ""
+            if isinstance(value, (list, tuple)) and len(value) == 1:
+                # A wrapper that hands back {"text": ["…"]} is a normal MCP shape;
+                # str() on the list would write the Python literal, brackets and
+                # quotes included, straight into the prediction file.
+                value = value[0]
             return str(value), {"text": str(value)}
         if task_name in {"TTS", "VC"}:
             value = (

--- a/sure/skills/sure_eval/scripts/resolve_eval_input.py
+++ b/sure/skills/sure_eval/scripts/resolve_eval_input.py
@@ -51,6 +51,7 @@ MAIN_FLOW_SCRIPTS = [
     "scripts/refresh_report_snapshot.py",
     "scripts/run_local_execution.py",
     "scripts/run_vc_execution.py",
+    "scripts/wait_vc_execution.py",
 ]
 
 TEXT_DEFAULT_METRICS = {
@@ -241,50 +242,140 @@ def _check_dataset_input_policy(datasets: list[dict[str, Any]]) -> None:
     )
 
 
-def _write_harness_config(*, run_dir: Path, config_path: str | None) -> Path:
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _select_harness_config(config_path: str | None, harness_root: Path) -> tuple[Path, str]:
     if config_path:
         path = Path(config_path).expanduser()
-        if not path.exists():
-            raise FileNotFoundError(f"Config file not found: {path}")
-        return path.resolve()
+        label = "--config"
+    else:
+        env_config = os.environ.get("SURE_EVAL_CONFIG", "").strip()
+        if env_config:
+            path = Path(env_config).expanduser()
+            label = "SURE_EVAL_CONFIG"
+        else:
+            path = harness_root / "sure" / "external" / "sure-evaluation" / "config" / "default.yaml"
+            label = "submodule config"
+    if not path.is_file():
+        raise FileNotFoundError(f"{label} file not found: {path}")
+    return path.resolve(), label
 
-    env_config = os.environ.get("SURE_EVAL_CONFIG")
-    if env_config:
-        path = Path(env_config).expanduser()
-        if not path.exists():
-            raise FileNotFoundError(f"SURE_EVAL_CONFIG file not found: {path}")
-        return path.resolve()
 
-    harness_root = _repo_root_from_script()
-    base_config = harness_root / "sure" / "external" / "sure-evaluation" / "config" / "default.yaml"
+def _resolve_dataset_projection(
+    *,
+    explicit_root: str | None,
+    configured_root: object,
+    harness_root: Path,
+    site_policy: dict[str, Any],
+    reserved_write_roots: tuple[Path, ...] = (),
+) -> dict[str, str]:
     env_root = os.environ.get("SURE_EVAL_DATASETS_ROOT", "").strip()
-    datasets_root = Path(env_root) if env_root else harness_root / "data" / "datasets"
-    if not base_config.exists():
-        raise FileNotFoundError(f"Submodule config not found: {base_config}")
-    jsonl_dir = datasets_root / "sure_benchmark" / "jsonl"
-    if not jsonl_dir.is_dir():
-        # An explicit env root must already exist so a mistyped path fails fast;
-        # the in-repo default is scaffolding that source prepare fills on demand.
-        if env_root:
-            raise FileNotFoundError(f"SURE_EVAL_DATASETS_ROOT must contain sure_benchmark/jsonl: {datasets_root}")
-        jsonl_dir.mkdir(parents=True, exist_ok=True)
+    policy = site_policy["policy"]
+    policy_root = str((policy.get("datasets") or {}).get("projection_root") or "").strip()
+    config_root = str(configured_root or "").strip()
+    candidates = (
+        (str(explicit_root or "").strip(), "command"),
+        (env_root, "environment"),
+        (policy_root, "site_policy"),
+        (config_root, "config"),
+        (str(harness_root / "data" / "datasets"), "development_default"),
+    )
+    raw_root, source = next((value, origin) for value, origin in candidates if value)
+    candidate = Path(raw_root).expanduser()
+    if not candidate.is_absolute():
+        raise EvalInputError(f"dataset projection root from {source} must be absolute: {candidate}")
+    projection_root = candidate.resolve()
 
+    for raw_forbidden in policy["storage"]["forbidden_output_roots"]:
+        forbidden = Path(str(raw_forbidden)).resolve()
+        if _is_within(projection_root, forbidden):
+            raise EvalInputError(
+                f"dataset projection root is under a forbidden output root: {projection_root}"
+            )
+    for raw_source in policy["datasets"]["allowed_source_roots"]:
+        source_root = Path(str(raw_source)).resolve()
+        if _is_within(projection_root, source_root) or _is_within(source_root, projection_root):
+            raise EvalInputError(
+                "dataset projection root must not overlap an allowed source root: "
+                f"{projection_root} vs {source_root}"
+            )
+    for reserved_root in reserved_write_roots:
+        reserved = reserved_root.resolve()
+        if _is_within(projection_root, reserved) or _is_within(reserved, projection_root):
+            raise EvalInputError(
+                "dataset projection root must not overlap the evaluation output directory: "
+                f"{projection_root} vs {reserved}"
+            )
+
+    jsonl_root = projection_root / "sure_benchmark" / "jsonl"
+    try:
+        jsonl_root.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise EvalInputError(f"cannot create dataset projection root {projection_root}: {exc}") from exc
+    if not os.access(projection_root, os.W_OK) or not os.access(jsonl_root, os.W_OK):
+        raise EvalInputError(f"dataset projection root is not writable: {projection_root}")
+    return {
+        "host_root": str(projection_root),
+        "jsonl_root": str(jsonl_root),
+        "source": source,
+        "content": "generated_jsonl_indexes_and_metadata",
+        "raw_data_policy": "reference_only_no_copy_or_move",
+    }
+
+
+def _materialize_harness_config(
+    *,
+    run_dir: Path,
+    config_path: str | None,
+    datasets_root: str | None = None,
+    site_policy: dict[str, Any] | None = None,
+) -> tuple[Path, dict[str, str]]:
+    harness_root = _repo_root_from_script()
+    base_config, config_source = _select_harness_config(config_path, harness_root)
     config = yaml.safe_load(base_config.read_text(encoding="utf-8")) or {}
+    if not isinstance(config, dict):
+        raise EvalInputError(f"evaluation config must be a mapping: {base_config}")
     data = dict(config.get("data") or {})
-    data.update(
-        {
+    active_site_policy = site_policy or load_site_policy(repository_root=harness_root, required=True)
+    projection = _resolve_dataset_projection(
+        explicit_root=datasets_root,
+        configured_root=data.get("datasets") if config_source != "submodule config" else None,
+        harness_root=harness_root,
+        site_policy=active_site_policy,
+        reserved_write_roots=(run_dir,),
+    )
+    if config_source == "submodule config":
+        data.update({
             "root": str(harness_root / "data"),
             "cache": str(harness_root / "data" / "cache"),
             "models": str(harness_root / "data" / "models"),
-            "datasets": str(datasets_root),
             "results": str(run_dir / "results"),
-        }
-    )
+        })
+    data["datasets"] = projection["host_root"]
     config["data"] = data
     output = run_dir / "_harness_config.yaml"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(yaml.safe_dump(config, sort_keys=False, allow_unicode=True), encoding="utf-8")
-    return output.resolve()
+    return output.resolve(), projection
+
+
+def _write_harness_config(*, run_dir: Path, config_path: str | None) -> Path:
+    """Compatibility helper preserving the historical config selection contract."""
+    harness_root = _repo_root_from_script()
+    selected, source = _select_harness_config(config_path, harness_root)
+    if source != "submodule config":
+        return selected
+    output, _ = _materialize_harness_config(
+        run_dir=run_dir,
+        config_path=None,
+    )
+    return output
 
 
 def _nvidia_smi_available() -> bool:
@@ -688,7 +779,12 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         getattr(args, "output_dir", ""),
         _stage_output_dir(results_root, args.model, protocol, run_id),
     )
-    config_path = _write_harness_config(run_dir=output_dir, config_path=args.config)
+    config_path, dataset_projection = _materialize_harness_config(
+        run_dir=output_dir,
+        config_path=args.config,
+        datasets_root=getattr(args, "datasets_root", None),
+        site_policy=active_site_policy,
+    )
     cfg = Config.from_yaml(config_path)
     manager = DatasetManager(cfg)
     requested_datasets = _split_values(args.datasets)
@@ -752,6 +848,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "max_samples": args.max_samples,
             "deployment_binding": model["deployment_binding"],
             "harness_runtime": harness_runtime,
+            "dataset_projection": dataset_projection,
         },
     }
 
@@ -769,6 +866,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "execution_path": args.execution_path or "auto",
             "user_goal": args.user_goal,
             "vc": vc_request,
+            "datasets_root": getattr(args, "datasets_root", None),
         },
         "model": model,
         "datasets": datasets,
@@ -791,6 +889,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "vc": vc_request,
             "deployment_binding": model["deployment_binding"],
             "harness_runtime": harness_runtime,
+            "dataset_projection": dataset_projection,
         },
         "evaluation": {
             "backend": args.evaluation_backend,
@@ -840,6 +939,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--run-id")
     parser.add_argument("--config")
+    parser.add_argument("--datasets-root")
     parser.add_argument("--output")
     parser.add_argument("--output-dir", default="")
     return parser

--- a/sure/skills/sure_eval/scripts/resolve_model_dir.py
+++ b/sure/skills/sure_eval/scripts/resolve_model_dir.py
@@ -26,6 +26,7 @@ APPROVED_MODELS_ROOT = (
     else None
 )
 MODEL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+SUCCESSFUL_VERDICT_STATUSES = frozenset({"pass", "passed", "success"})
 
 
 def configured_approved_models_root() -> Path:
@@ -44,13 +45,10 @@ def _is_relative_to(path: Path, root: Path) -> bool:
 def _verdict_path(model_dir: Path | None) -> Path | None:
     if model_dir is None:
         return None
-    for path in (model_dir / "verdict.json", model_dir / "artifacts" / "verdict.json"):
+    for path in (model_dir / "artifacts" / "verdict.json", model_dir / "verdict.json"):
         if path.is_file() and _is_relative_to(path.resolve(), model_dir):
             return path
     return None
-
-
-TERMINAL_VERDICT_STATUSES = {"success", "passed", "pass"}
 
 
 def verdict_is_ready(model_dir: Path | None) -> bool:
@@ -59,14 +57,8 @@ def verdict_is_ready(model_dir: Path | None) -> bool:
     The file existing proves a transformation ran, not that it succeeded; a
     bundle sealed alongside a failed verdict would otherwise resolve as ready.
     """
-    path = _verdict_path(model_dir)
-    if path is None:
-        return False
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return False
-    return isinstance(value, dict) and str(value.get("status", "")).lower() in TERMINAL_VERDICT_STATUSES
+    ready, _, _ = _successful_verdict(_verdict_path(model_dir))
+    return ready
 
 
 def _checks(model_dir: Path | None) -> dict[str, bool]:
@@ -101,7 +93,28 @@ def _checks(model_dir: Path | None) -> dict[str, bool]:
     }
 
 
-def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_MODELS_ROOT) -> dict[str, Any]:
+def _successful_verdict(path: Path | None) -> tuple[bool, str | None, str | None]:
+    if path is None:
+        return False, None, "approved model verdict is missing"
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return False, None, f"approved model verdict is invalid: {exc}"
+    if not isinstance(value, dict):
+        return False, None, "approved model verdict must be a JSON object"
+    status = str(value.get("status") or "")
+    if status.lower() not in SUCCESSFUL_VERDICT_STATUSES:
+        return False, status or None, f"approved model verdict status is not successful: {status!r}"
+    return True, status, None
+
+
+def resolve_approved_model_identity(
+    model: str,
+    *,
+    approved_root: Path | None = APPROVED_MODELS_ROOT,
+) -> dict[str, Any]:
+    """Resolve approved model identity without requiring an inference runtime."""
+
     if not MODEL_ID_RE.fullmatch(model):
         raise ValueError(f"invalid model id {model!r}; path separators and aliases are not allowed")
     root = (approved_root or configured_approved_models_root()).expanduser().resolve()
@@ -114,6 +127,30 @@ def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_
     selected = model_dir if model_dir.is_dir() else None
     verdict = _verdict_path(selected)
     checks = _checks(selected)
+    verdict_ready, verdict_status, verdict_error = _successful_verdict(verdict)
+    config_ready = checks["config_yaml"]
+    identity_error = verdict_error
+    if selected is not None and not config_ready:
+        identity_error = "approved model config.yaml is missing"
+    return {
+        "schema": "sure.approved_model.identity.v1",
+        "ok": bool(selected and config_ready and verdict_ready),
+        "model": model,
+        "model_dir": str(selected) if selected else None,
+        "source": "approved_nfs_models",
+        "approved_models_root": str(root),
+        "config_path": str((selected / "config.yaml").resolve()) if selected and config_ready else None,
+        "verdict_path": str(verdict.resolve()) if verdict else None,
+        "verdict_status": verdict_status,
+        "verdict_ready": verdict_ready,
+        "identity_error": identity_error,
+        "checks": checks,
+    }
+
+
+def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_MODELS_ROOT) -> dict[str, Any]:
+    identity = resolve_approved_model_identity(model, approved_root=approved_root)
+    selected = Path(identity["model_dir"]) if identity["model_dir"] else None
     deployment_binding = None
     deployment_error = None
     if selected is not None:
@@ -122,20 +159,22 @@ def resolve_approved_model(model: str, *, approved_root: Path | None = APPROVED_
         except DeploymentBindingError as exc:
             deployment_error = str(exc)
     runtime_ready = deployment_binding is not None
-    verdict_ready = verdict_is_ready(selected)
+    verdict_ready = bool(identity["verdict_ready"])
     return {
         "schema": "sure.eval.approved_model_resolution.v1",
-        "ok": bool(selected and runtime_ready and verdict_ready),
+        "ok": bool(identity["ok"] and runtime_ready),
         "model": model,
-        "model_dir": str(selected) if selected else None,
-        "source": "approved_nfs_models",
-        "approved_models_root": str(root),
-        "verdict_path": str(verdict.resolve()) if verdict else None,
+        "model_dir": identity["model_dir"],
+        "source": identity["source"],
+        "approved_models_root": identity["approved_models_root"],
+        "verdict_path": identity["verdict_path"],
+        "verdict_status": identity["verdict_status"],
         "runtime_ready": runtime_ready,
         "verdict_ready": verdict_ready,
         "deployment_binding": deployment_binding,
         "deployment_error": deployment_error,
-        "checks": checks,
+        "identity_error": identity["identity_error"],
+        "checks": identity["checks"],
     }
 
 

--- a/sure/skills/sure_eval/scripts/resolve_prediction_source.py
+++ b/sure/skills/sure_eval/scripts/resolve_prediction_source.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import yaml
 
-from resolve_model_dir import APPROVED_MODELS_ROOT, resolve_approved_model
+from resolve_model_dir import APPROVED_MODELS_ROOT, resolve_approved_model_identity
 
 for _parent in Path(__file__).resolve().parents:
     if (_parent / "sure" / "site" / "loader.py").is_file():
@@ -160,9 +160,10 @@ def build_payload(
     if len(requested) != len(set(requested)):
         raise ValueError("requested datasets contain duplicate canonical identities")
 
-    model_resolution = resolve_approved_model(model, approved_root=approved_models_root)
+    model_resolution = resolve_approved_model_identity(model, approved_root=approved_models_root)
     if not model_resolution["ok"]:
-        raise ValueError(f"model {model!r} is not approved and runtime-ready in NFS")
+        detail = model_resolution.get("identity_error") or "approved model identity is incomplete"
+        raise ValueError(f"model {model!r} is not approved with a successful verdict in NFS: {detail}")
     model_dir = Path(str(model_resolution["model_dir"]))
 
     if approved_results_root is None:

--- a/sure/skills/sure_eval/scripts/run_vc_execution.py
+++ b/sure/skills/sure_eval/scripts/run_vc_execution.py
@@ -17,20 +17,24 @@ import shlex
 import shutil
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 import yaml
 
-from container_execution import deployment_binding, resolve_container_harness_runtime
+from container_execution import (
+    dataset_projection_root_from_eval_input,
+    deployment_binding,
+    resolve_container_harness_runtime,
+)
 from evaluation_runtime import evaluation_runtime_from_eval_input
 from harness_runtime import harness_runtime_from_eval_input
 from sure_eval.agent import vc_precheck
 from sure_eval.agent.vc_submitter import (
     _infer_default_volume_mount,
     _infer_repo_root,
-    _merge_volume_mounts,
     _translate_to_container_path,
     select_best_partition,
 )
@@ -80,6 +84,78 @@ def _dataset_source_roots(eval_input: dict) -> list[str]:
             if root not in roots:
                 roots.append(root)
     return roots
+
+
+def _append_vc_mount(
+    volume_mount: str,
+    *,
+    source: Path,
+    target: str,
+    read_only: bool,
+) -> str:
+    source_text = str(source.expanduser())
+    source_identity = str(source.resolve())
+    target_path = Path(target)
+    if not target_path.is_absolute():
+        raise ValueError(f"vc mount target must be absolute: {target}")
+    mode = "ro" if read_only else "rw"
+    for raw_mount in volume_mount.split(","):
+        parts = raw_mount.split(":")
+        if len(parts) < 2 or parts[1] != target:
+            continue
+        existing_source = str(Path(parts[0]).resolve())
+        existing_mode = parts[2] if len(parts) > 2 else "rw"
+        if existing_source == source_identity and existing_mode == mode:
+            return volume_mount
+        raise ValueError(f"conflicting vc mount target: {target}")
+    suffix = ":ro" if read_only else ""
+    return f"{volume_mount},{source_text}:{target}{suffix}"
+
+
+def _build_vc_volume_mounts(
+    *,
+    primary: str,
+    model_dir: Path,
+    model_target: str,
+    result_source: Path,
+    result_target: str,
+    dataset_source_roots: list[str],
+    dataset_projection_root: Path | None,
+) -> str:
+    volume_mount = primary
+    if dataset_projection_root is not None:
+        volume_mount = _append_vc_mount(
+            volume_mount,
+            source=dataset_projection_root,
+            target=str(dataset_projection_root),
+            read_only=False,
+        )
+    for dataset_source_root in dataset_source_roots:
+        declared_source = Path(dataset_source_root).expanduser()
+        volume_mount = _append_vc_mount(
+            volume_mount,
+            source=declared_source,
+            target=str(declared_source),
+            read_only=True,
+        )
+    volume_mount = _append_vc_mount(
+        volume_mount,
+        source=model_dir,
+        target=str(model_dir),
+        read_only=True,
+    )
+    volume_mount = _append_vc_mount(
+        volume_mount,
+        source=model_dir,
+        target=model_target,
+        read_only=True,
+    )
+    return _append_vc_mount(
+        volume_mount,
+        source=result_source,
+        target=result_target,
+        read_only=False,
+    )
 
 
 def _execution_from_surface(surface: dict[str, Any], eval_input: dict[str, Any]) -> dict[str, Any]:
@@ -260,6 +336,8 @@ def _resolved_submission(
     run_evaluation_path: str,
     log_path: Path,
     command: str,
+    submission_token: str,
+    terminal_status_path: str,
     harness_runtime: dict[str, Any],
     model_runtime: dict[str, Any],
 ) -> dict[str, Any]:
@@ -279,6 +357,8 @@ def _resolved_submission(
         "run_evaluation_host": run_evaluation_path,
         "log_path": str(log_path),
         "command": command,
+        "submission_token": submission_token,
+        "terminal_status_path": terminal_status_path,
         "harness_runtime": harness_runtime,
         "model_runtime": model_runtime,
     }
@@ -318,16 +398,41 @@ def _write_entrypoint(
     harness_library_paths: list[str],
     harness_python_home: str,
     entrypoint_env: dict[str, str],
+    submission_token: str,
+    terminal_status_path: Path,
 ) -> None:
     run_evaluation_container = _translate_to_container_path(Path(run_evaluation_path), volume_mount)
     log_path_container = _translate_to_container_path(log_path, volume_mount)
     harness_python_container = (
         _translate_to_container_path(Path(harness_python_bin), volume_mount) if harness_python_bin else ""
     )
+    terminal_status_container = _translate_to_container_path(terminal_status_path, volume_mount)
     q = shlex.quote
     lines = [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
+        f"_SURE_EVAL_TERMINAL_STATUS={q(terminal_status_container)}",
+        f"_SURE_EVAL_SUBMISSION_TOKEN={q(submission_token)}",
+        '_SURE_EVAL_STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+        '_SURE_EVAL_STARTED_EPOCH="$(date +%s)"',
+        "_sure_eval_write_terminal() {",
+        "  local exit_code=$?",
+        "  trap - EXIT INT TERM",
+        '  local ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"',
+        '  local ended_epoch="$(date +%s)"',
+        '  local job_status="failed"',
+        '  if [[ "$exit_code" -eq 0 ]]; then job_status="succeeded"; fi',
+        '  local terminal_tmp="${_SURE_EVAL_TERMINAL_STATUS}.tmp.$$"',
+        '  mkdir -p "$(dirname "$_SURE_EVAL_TERMINAL_STATUS")"',
+        "  printf '%s\\n' \"{\\\"schema\\\":\\\"sure.eval.vc_terminal_status.v1\\\",\\\"submission_token\\\":\\\"${_SURE_EVAL_SUBMISSION_TOKEN}\\\",\\\"job_status\\\":\\\"${job_status}\\\",\\\"exit_code\\\":${exit_code},\\\"started_at\\\":\\\"${_SURE_EVAL_STARTED_AT}\\\",\\\"ended_at\\\":\\\"${ended_at}\\\",\\\"duration_seconds\\\":$((ended_epoch - _SURE_EVAL_STARTED_EPOCH))}\" > \"$terminal_tmp\"",
+        '  mv -f -- "$terminal_tmp" "$_SURE_EVAL_TERMINAL_STATUS"',
+        '  exit "$exit_code"',
+        "}",
+        "_sure_eval_handle_int() { exit 130; }",
+        "_sure_eval_handle_term() { exit 143; }",
+        "trap _sure_eval_handle_int INT",
+        "trap _sure_eval_handle_term TERM",
+        "trap _sure_eval_write_terminal EXIT",
         f"export PYTHON_BIN={q(model_python_bin)}",
         f"export MODEL_PYTHON={q(model_python_bin)}",
         "export SURE_EVAL_EXECUTION_PATH=vc_submit",
@@ -350,11 +455,14 @@ def _write_entrypoint(
         lines.append(f"export PYTHONPATH={q(':'.join(model_pythonpath))}:${{PYTHONPATH:-}}")
     if harness_python_container:
         lines.append(f"export HARNESS_PYTHON_BIN={q(harness_python_container)}")
+        lines.append(f"export SURE_EVAL_NODE_LOCAL_PYTHON={q(harness_python_container)}")
     if harness_library_paths:
         lines.append(f"export LD_LIBRARY_PATH={q(':'.join(harness_library_paths))}:${{LD_LIBRARY_PATH:-}}")
     if harness_python_home:
         lines.append(f"export PYTHONHOME={q(harness_python_home)}")
     for key in sorted(entrypoint_env):
+        if key == "SURE_EVAL_NODE_LOCAL_PYTHON":
+            continue
         lines.append(f"export {key}={q(entrypoint_env[key])}")
     lines.extend(
         [
@@ -420,6 +528,12 @@ def main() -> int:
     device_request, device_actual = _device(eval_input, surface)
     log_path = run_dir / "vc_logs" / "job.log"
     entrypoint_path = artifacts_dir / "vc_entrypoint.sh"
+    submitted_at = _utc_now()
+    submission_token = hashlib.sha256(
+        f"{run_dir}:{submitted_at}:{os.getpid()}:{time.time_ns()}".encode("utf-8")
+    ).hexdigest()[:32]
+    terminal_status_path = artifacts_dir / f"vc_terminal_status.{submission_token}.json"
+    terminal_status_relative = terminal_status_path.relative_to(run_dir).as_posix()
     submit_output = Path(args.submit_output).expanduser().resolve() if args.submit_output else artifacts_dir / "submit_result.json"
     cwd = Path(args.cwd).expanduser().resolve() if args.cwd else Path.cwd()
     repo_root = _infer_repo_root()
@@ -432,7 +546,7 @@ def main() -> int:
     )
     harness_root = Path(str(harness_runtime["runtime_root"]))
     evaluation_runtime = evaluation_runtime_from_eval_input(eval_input, prepare=False)
-    volume_mount = _merge_volume_mounts(volume_mount, [str(model_dir), *dataset_source_roots])
+    dataset_projection_root = dataset_projection_root_from_eval_input(eval_input)
     model_mount = container.get("model_mount") if isinstance(container.get("model_mount"), dict) else {}
     model_target = str(model_mount.get("target") or "")
     result_mount = container.get("result_mount") if isinstance(container.get("result_mount"), dict) else {}
@@ -441,7 +555,15 @@ def main() -> int:
     if not Path(model_target).is_absolute() or not Path(result_target).is_absolute():
         raise RuntimeError("approved deployment container mount targets must be absolute")
     result_source.mkdir(parents=True, exist_ok=True)
-    volume_mount = f"{volume_mount},{model_dir}:{model_target}:ro,{result_source}:{result_target}"
+    volume_mount = _build_vc_volume_mounts(
+        primary=volume_mount,
+        model_dir=model_dir,
+        model_target=model_target,
+        result_source=result_source,
+        result_target=result_target,
+        dataset_source_roots=dataset_source_roots,
+        dataset_projection_root=dataset_projection_root,
+    )
     entrypoint_container = _translate_to_container_path(entrypoint_path, volume_mount)
     model_python_bin = str(container.get("python_executable") or "python")
     harness_python_bin = str(harness_runtime["python_executable"])
@@ -454,6 +576,7 @@ def main() -> int:
         "MODEL_PYTHON",
         "PYTHON_BIN",
         "HARNESS_PYTHON_BIN",
+        "SURE_EVAL_NODE_LOCAL_PYTHON",
         "MODEL_DIR",
         "SURE_EVAL_APPROVED_MODEL_DIR",
         "RUN_DIR",
@@ -496,6 +619,8 @@ def main() -> int:
             "XDG_CACHE_HOME": f"{result_target}/.runtime/cache/xdg",
         }
     )
+    if dataset_projection_root is not None:
+        entrypoint_env["SURE_EVAL_DATASETS_ROOT"] = str(dataset_projection_root)
     if evaluation_runtime is not None:
         entrypoint_env.update(
             {
@@ -538,6 +663,8 @@ def main() -> int:
         harness_library_paths=harness_library_paths,
         harness_python_home=harness_python_home,
         entrypoint_env=entrypoint_env,
+        submission_token=submission_token,
+        terminal_status_path=terminal_status_path,
     )
     cmd = [
         "vc",
@@ -577,6 +704,8 @@ def main() -> int:
         run_evaluation_path=str(_entrypoint(surface)),
         log_path=log_path,
         command=command,
+        submission_token=submission_token,
+        terminal_status_path=terminal_status_relative,
         harness_runtime=harness_runtime,
         model_runtime={
             "runtime_type": "model_python",
@@ -594,6 +723,8 @@ def main() -> int:
     if model_dir is not None:
         precheck_paths.append(str(model_dir))
     precheck_paths.extend(dataset_source_roots)
+    if dataset_projection_root is not None:
+        precheck_paths.append(str(dataset_projection_root))
     identity_check = vc_precheck.check_image(image_identity_ref, image_source)
     identity_check.name = "image_identity"
     precheck_results = vc_precheck.run_precheck(
@@ -636,7 +767,9 @@ def main() -> int:
         },
         "fallback_approved": False,
         "local_fallback_reason": "",
-        "submitted_at": _utc_now(),
+        "submitted_at": submitted_at,
+        "submission_token": submission_token,
+        "terminal_status_path": terminal_status_relative,
         "host": job_id,
         "command": "bash " + str(_entrypoint(surface)),
         "cwd": str(cwd),

--- a/sure/skills/sure_eval/scripts/sure_eval/models/registry.py
+++ b/sure/skills/sure_eval/scripts/sure_eval/models/registry.py
@@ -188,7 +188,14 @@ class ModelRegistry:
                     )
                 except Exception as e:
                     print(f"Error loading model config {item}: {e}")
-    
+
+        # Callers hold a directory, not a declared name: the container mounts the
+        # bundle at /workspace/model and looks it up as "model". Register the
+        # directory name too, in a second pass so a name some config.yaml really
+        # declares is never shadowed by another directory that shares it.
+        for info in list(self._models.values()):
+            self._models.setdefault(info.path.name, info)
+
     def list_models(self) -> list[str]:
         """List all model names."""
         return list(self._models.keys())

--- a/sure/skills/sure_eval/scripts/test_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_deployment_binding.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -11,7 +13,13 @@ from unittest.mock import patch
 from container_execution import build_local_container_command
 from deployment_binding import DeploymentBindingError, load_deployment_binding
 from check_run_report import _submitted_image_error
-from run_vc_execution import _approved_memory_gb, _job_name, _normalize_job_name, _write_entrypoint
+from run_vc_execution import (
+    _approved_memory_gb,
+    _build_vc_volume_mounts,
+    _job_name,
+    _normalize_job_name,
+    _write_entrypoint,
+)
 
 
 def write_json(path: Path, payload: dict) -> None:
@@ -95,6 +103,8 @@ class DeploymentBindingTests(unittest.TestCase):
         self.image_ref = "registry.example.com/sure/demo@" + self.digest
         self.output = self.root / "results" / "run"
         self.output.mkdir(parents=True)
+        self.projection = self.root / "dataset-projection"
+        (self.projection / "sure_benchmark" / "jsonl").mkdir(parents=True)
         self.control = self.root / "control"
         self.control.mkdir()
         self.entrypoint = self.control / "run_evaluation.sh"
@@ -273,12 +283,18 @@ class DeploymentBindingTests(unittest.TestCase):
     def test_local_command_uses_digest_and_read_only_model(self) -> None:
         binding = load_deployment_binding(self.model, "demo")
         command, provenance = build_local_container_command(
-            surface={"env": {"TOOL_NAME": "transcribe_audio"}},
+            surface={
+                "env": {
+                    "TOOL_NAME": "transcribe_audio",
+                    "SURE_EVAL_NODE_LOCAL_PYTHON": "/usr/bin/python3.11",
+                }
+            },
             eval_input={
                 "model": {"deployment_binding": binding},
                 "runtime": {
                     "run_dir": str(self.output),
                     "harness_runtime": self._runtime_binding(),
+                    "dataset_projection": {"host_root": str(self.projection)},
                 },
                 "datasets": [],
             },
@@ -291,11 +307,26 @@ class DeploymentBindingTests(unittest.TestCase):
         self.assertIn("device=2", command)
         self.assertTrue(any("src=" + str(self.model) in item and "readonly" in item for item in command))
         self.assertIn(f"HARNESS_PYTHON_BIN={self.harness_python}", command)
+        self.assertIn(f"SURE_EVAL_NODE_LOCAL_PYTHON={self.harness_python}", command)
+        self.assertNotIn("SURE_EVAL_NODE_LOCAL_PYTHON=/usr/bin/python3.11", command)
         self.assertIn("MODEL_PYTHON=python", command)
         self.assertIn("SURE_EVAL_APPROVED_MODEL_DIR=/workspace/model", command)
         self.assertIn("SURE_EVAL_APPROVED_RESULT_DIR=/sure-output", command)
         self.assertIn("SURE_EVAL_CACHE_DIR=/sure-output/.runtime/cache/sure-eval", command)
+        self.assertIn(f"SURE_EVAL_DATASETS_ROOT={self.projection}", command)
+        self.assertIn(
+            f"type=bind,src={self.projection},dst={self.projection}",
+            command,
+        )
+        self.assertEqual(
+            provenance["dataset_projection_mount"],
+            {"source": str(self.projection), "target": str(self.projection), "read_only": False},
+        )
         self.assertNotEqual(provenance["harness_runtime"]["python_executable"], "python")
+        self.assertEqual(
+            provenance["evaluation_node_runtime"]["python_executable"],
+            str(self.harness_python),
+        )
         self.assertFalse(provenance["host_python_fallback"])
 
     def test_local_command_preserves_declared_dataset_mount_target(self) -> None:
@@ -323,6 +354,56 @@ class DeploymentBindingTests(unittest.TestCase):
             f"type=bind,src={real_dataset},dst={dataset_alias},readonly",
             command,
         )
+
+    def test_local_command_does_not_remount_projection_jsonl_read_only(self) -> None:
+        binding = load_deployment_binding(self.model, "demo")
+        jsonl_path = self.projection / "sure_benchmark" / "jsonl" / "demo.jsonl"
+        command, _ = build_local_container_command(
+            surface={"env": {}},
+            eval_input={
+                "model": {"deployment_binding": binding},
+                "runtime": {
+                    "run_dir": str(self.output),
+                    "harness_runtime": self._runtime_binding(),
+                    "dataset_projection": {"host_root": str(self.projection)},
+                },
+                "datasets": [{"jsonl_path": str(jsonl_path)}],
+            },
+            control_run_dir=self.control,
+            entrypoint=self.entrypoint,
+            repo_root=self.repo,
+            device_request="cpu",
+        )
+        projection_mounts = [
+            command[index + 1]
+            for index, value in enumerate(command[:-1])
+            if value == "--mount" and str(self.projection) in command[index + 1]
+        ]
+        self.assertEqual(
+            projection_mounts,
+            [f"type=bind,src={self.projection},dst={self.projection}"],
+        )
+
+    def test_vc_mounts_keep_models_and_sources_read_only(self) -> None:
+        dataset_source = self.root / "source-dataset"
+        dataset_source.mkdir()
+        dataset_alias = self.root / "source-dataset-alias"
+        dataset_alias.symlink_to(dataset_source, target_is_directory=True)
+        volume = _build_vc_volume_mounts(
+            primary=f"{self.repo}:{self.repo}",
+            model_dir=self.model,
+            model_target="/workspace/model",
+            result_source=self.output,
+            result_target="/sure-output",
+            dataset_source_roots=[str(dataset_alias)],
+            dataset_projection_root=self.projection,
+        )
+        self.assertIn(f"{self.model}:{self.model}:ro", volume)
+        self.assertIn(f"{self.model}:/workspace/model:ro", volume)
+        self.assertIn(f"{dataset_alias}:{dataset_alias}:ro", volume)
+        self.assertIn(f"{self.projection}:{self.projection}", volume)
+        self.assertNotIn(f"{self.projection}:{self.projection}:ro", volume)
+        self.assertIn(f"{self.output}:/sure-output", volume)
 
     def test_local_command_injects_separate_evaluation_runtime(self) -> None:
         binding = load_deployment_binding(self.model, "demo")
@@ -356,6 +437,7 @@ class DeploymentBindingTests(unittest.TestCase):
 
     def test_vc_entrypoint_never_rewrites_model_runtime(self) -> None:
         path = self.control / "vc_entrypoint.sh"
+        terminal_status = self.control / "vc_terminal_status.json"
         _write_entrypoint(
             path=path,
             volume_mount=f"{self.root}:{self.root}",
@@ -381,7 +463,10 @@ class DeploymentBindingTests(unittest.TestCase):
                 "RUN_DIR": "/sure-output",
                 "SURE_EVAL_APPROVED_RESULT_DIR": "/sure-output",
                 "SURE_EVAL_CACHE_DIR": "/sure-output/.runtime/cache/sure-eval",
+                "SURE_EVAL_NODE_LOCAL_PYTHON": "/usr/bin/python3.11",
             },
+            submission_token="d" * 32,
+            terminal_status_path=terminal_status,
         )
         text = path.read_text(encoding="utf-8")
         self.assertIn(self.image_ref, text)
@@ -389,11 +474,37 @@ class DeploymentBindingTests(unittest.TestCase):
         self.assertNotIn(".venv", text)
         self.assertNotIn("/usr/bin/python3", text)
         self.assertIn(f"export HARNESS_PYTHON_BIN={self.harness_python}", text)
+        self.assertIn(f"export SURE_EVAL_NODE_LOCAL_PYTHON={self.harness_python}", text)
+        self.assertNotIn("export SURE_EVAL_NODE_LOCAL_PYTHON=/usr/bin/python3.11", text)
         self.assertIn("export MODEL_PYTHON=python", text)
         self.assertIn("export SURE_EVAL_APPROVED_MODEL_DIR=/workspace/model", text)
         self.assertIn("export SURE_EVAL_APPROVED_RESULT_DIR=/sure-output", text)
         self.assertIn("export SURE_EVAL_CACHE_DIR=/sure-output/.runtime/cache/sure-eval", text)
-        self.assertNotRegex(text, r"(?m)^\s*(mv|ln|rm)\b")
+        self.assertIn("sure.eval.vc_terminal_status.v1", text)
+        self.assertIn("trap _sure_eval_write_terminal EXIT", text)
+        mutation_lines = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().split(" ", 1)[0] in {"mv", "ln", "rm"}
+        ]
+        self.assertEqual(
+            mutation_lines,
+            ['mv -f -- "$terminal_tmp" "$_SURE_EVAL_TERMINAL_STATUS"'],
+        )
+        syntax = subprocess.run(["bash", "-n", str(path)], capture_output=True, text=True, check=False)
+        self.assertEqual(syntax.returncode, 0, syntax.stderr)
+        completed = subprocess.run(
+            ["bash", str(path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, "VC_JOB_ID": "job-test"},
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        sentinel = json.loads(terminal_status.read_text(encoding="utf-8"))
+        self.assertEqual(sentinel["submission_token"], "d" * 32)
+        self.assertEqual(sentinel["job_status"], "succeeded")
+        self.assertEqual(sentinel["exit_code"], 0)
 
     def test_local_command_prefers_matching_image_harness_runtime(self) -> None:
         binding = load_deployment_binding(self.model, "demo")

--- a/sure/skills/sure_eval/scripts/test_evaluation_runtime.py
+++ b/sure/skills/sure_eval/scripts/test_evaluation_runtime.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import os
 import stat
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from evaluation_runtime import (
+    EvaluationRuntimeError,
+    _engine_commit,
     _make_group_writable,
     _wrapper,
     evaluation_child_environment,
@@ -72,6 +76,20 @@ class EvaluationRuntimeTests(unittest.TestCase):
                 prepare=False,
             )
         )
+
+
+class EngineCommitTests(unittest.TestCase):
+    def test_absent_git_binary_is_reported_as_an_evaluation_runtime_error(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            empty_bin = root / "bin"
+            empty_bin.mkdir()
+            engine_root = root / "engine"
+            engine_root.mkdir()
+            with mock.patch.dict(os.environ, {"PATH": str(empty_bin)}):
+                with self.assertRaises(EvaluationRuntimeError) as caught:
+                    _engine_commit(engine_root)
+        self.assertIn("git", str(caught.exception))
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_eval/scripts/test_execution_surface_checks.py
+++ b/sure/skills/sure_eval/scripts/test_execution_surface_checks.py
@@ -5,12 +5,14 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import check_execution_surface_compliance as checks
 
 
 IMAGE_REF = "registry.example.com/sure/demo@sha256:" + "a" * 64
+LIVE_RUNTIME_PROBE = checks._live_runtime_probe
 
 
 class InferenceRuntimeCheckTests(unittest.TestCase):
@@ -150,6 +152,49 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
         )
         self.assertFalse(result["passed"])
         self.assertIn("separate execution roles", result["evidence"])
+
+    def test_declared_node_python_must_match_harness_runtime(self) -> None:
+        result = checks.check_inference_runtime(
+            self.write_surface(
+                env={
+                    "TOOL_NAME": "transcribe_audio",
+                    "SURE_EVAL_NODE_LOCAL_PYTHON": "/usr/bin/python3.11",
+                }
+            )
+        )
+        self.assertFalse(result["passed"])
+        self.assertIn("approved common Harness Runtime", result["evidence"])
+
+
+class LiveRuntimeProbeTests(unittest.TestCase):
+    def test_exact_image_probe_executes_node_override(self) -> None:
+        commands: list[list[str]] = []
+
+        def run(command: list[str], **_kwargs: object) -> SimpleNamespace:
+            commands.append(command)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        harness = {
+            "runtime_id": "sure-harness-test",
+            "lock_sha256": "c" * 64,
+            "python_executable": "/opt/sure-harness/bin/python",
+            "manifest_path": "/opt/sure-harness/runtime-manifest.json",
+            "runtime_root": "/opt/sure-harness",
+        }
+        binding = {
+            "target_image_ref": IMAGE_REF,
+            "container": {
+                "python_executable": "python",
+                "harness_runtime": harness,
+            },
+        }
+
+        result = LIVE_RUNTIME_PROBE(binding, harness, run=run)
+
+        self.assertTrue(result["passed"])
+        self.assertEqual(result["node_local_python"], harness["python_executable"])
+        self.assertIn("SURE_EVAL_NODE_LOCAL_PYTHON", commands[0][-1])
+        self.assertIn("subprocess.run", commands[0][-1])
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_eval/scripts/test_external_bridge.py
+++ b/sure/skills/sure_eval/scripts/test_external_bridge.py
@@ -8,6 +8,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import evaluate_predictions as ep  # noqa: E402
+from evaluation_runtime import EvaluationRuntimeError  # noqa: E402
 
 
 class BridgeFailureReportingTests(unittest.TestCase):
@@ -54,6 +55,26 @@ class BridgeFailureReportingTests(unittest.TestCase):
         failures: list[str] = []
         self.assertFalse(self._applies(failures, metric=None, pipeline_id="asr.zh.cer.v1"))
         self.assertIn("asr.zh.cer.v1", failures[0])
+
+    def test_a_broken_environment_is_raised_instead_of_recorded_as_unsupported(self) -> None:
+        def boom(**_: object) -> dict[str, object]:
+            raise FileNotFoundError(2, "No such file or directory", "git")
+
+        ep._describe_external_pipeline = boom
+        failures: list[str] = []
+        with self.assertRaises(FileNotFoundError):
+            self._applies(failures)
+        self.assertEqual(failures, [])
+
+    def test_an_unusable_evaluation_runtime_is_raised_instead_of_recorded(self) -> None:
+        def boom(**_: object) -> dict[str, object]:
+            raise EvaluationRuntimeError("evaluation engine commit is unavailable: git is not installed")
+
+        ep._describe_external_pipeline = boom
+        failures: list[str] = []
+        with self.assertRaises(EvaluationRuntimeError):
+            self._applies(failures)
+        self.assertEqual(failures, [])
 
     def test_supported_request_records_nothing(self) -> None:
         ep._describe_external_pipeline = lambda **_: {"pipeline_id": "asr.zh.cer.v1"}

--- a/sure/skills/sure_eval/scripts/test_harness_config_bootstrap.py
+++ b/sure/skills/sure_eval/scripts/test_harness_config_bootstrap.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests: default datasets root bootstraps itself; explicit env root still fails fast.
+"""Tests for the writable dataset projection root contract.
 
 Run directly:
     cd sure/skills/sure_eval/scripts && python test_harness_config_bootstrap.py
@@ -28,6 +28,16 @@ class WriteHarnessConfigBootstrapTests(unittest.TestCase):
         base_config.parent.mkdir(parents=True)
         base_config.write_text("data: {}\n", encoding="utf-8")
         self.run_dir = self.root / "run"
+        self.site_policy = {
+            "policy": {
+                "storage": {
+                    "forbidden_output_roots": [str(self.root / "forbidden")],
+                },
+                "datasets": {
+                    "allowed_source_roots": [str(self.root / "sources")],
+                },
+            }
+        }
         self._repo_root = mock.patch.object(
             resolve_eval_input, "_repo_root_from_script", return_value=self.root
         )
@@ -43,18 +53,122 @@ class WriteHarnessConfigBootstrapTests(unittest.TestCase):
         self._tmp.cleanup()
 
     def test_default_root_is_created_on_fresh_checkout(self) -> None:
-        config_path = resolve_eval_input._write_harness_config(run_dir=self.run_dir, config_path=None)
+        config_path, projection = resolve_eval_input._materialize_harness_config(
+            run_dir=self.run_dir,
+            config_path=None,
+            site_policy=self.site_policy,
+        )
         jsonl_dir = self.root / "data" / "datasets" / "sure_benchmark" / "jsonl"
         self.assertTrue(jsonl_dir.is_dir())
         config = yaml.safe_load(Path(config_path).read_text(encoding="utf-8"))
         self.assertEqual(config["data"]["datasets"], str(self.root / "data" / "datasets"))
+        self.assertEqual(projection["source"], "development_default")
+        self.assertEqual(projection["raw_data_policy"], "reference_only_no_copy_or_move")
 
-    def test_explicit_env_root_must_exist(self) -> None:
+    def test_explicit_env_root_is_created_on_first_use(self) -> None:
         missing = self.root / "elsewhere"
         os.environ["SURE_EVAL_DATASETS_ROOT"] = str(missing)
-        with self.assertRaises(FileNotFoundError):
-            resolve_eval_input._write_harness_config(run_dir=self.run_dir, config_path=None)
-        self.assertFalse((missing / "sure_benchmark" / "jsonl").exists())
+        _, projection = resolve_eval_input._materialize_harness_config(
+            run_dir=self.run_dir,
+            config_path=None,
+            site_policy=self.site_policy,
+        )
+        self.assertTrue((missing / "sure_benchmark" / "jsonl").is_dir())
+        self.assertEqual(projection["source"], "environment")
+
+    def test_command_root_wins_over_environment_and_site_policy(self) -> None:
+        command_root = self.root / "command-projection"
+        os.environ["SURE_EVAL_DATASETS_ROOT"] = str(self.root / "environment-projection")
+        self.site_policy["policy"]["datasets"]["projection_root"] = str(
+            self.root / "policy-projection"
+        )
+        _, projection = resolve_eval_input._materialize_harness_config(
+            run_dir=self.run_dir,
+            config_path=None,
+            datasets_root=str(command_root),
+            site_policy=self.site_policy,
+        )
+        self.assertEqual(projection["host_root"], str(command_root))
+        self.assertEqual(projection["source"], "command")
+
+    def test_site_policy_root_is_used_without_an_override(self) -> None:
+        policy_root = self.root / "policy-projection"
+        self.site_policy["policy"]["datasets"]["projection_root"] = str(policy_root)
+        _, projection = resolve_eval_input._materialize_harness_config(
+            run_dir=self.run_dir,
+            config_path=None,
+            site_policy=self.site_policy,
+        )
+        self.assertEqual(projection["host_root"], str(policy_root))
+        self.assertEqual(projection["source"], "site_policy")
+
+    def test_custom_config_root_is_the_compatibility_fallback(self) -> None:
+        configured_root = self.root / "configured-projection"
+        custom = self.root / "configured.yaml"
+        custom.write_text(
+            f"data:\n  datasets: {configured_root}\n",
+            encoding="utf-8",
+        )
+        _, projection = resolve_eval_input._materialize_harness_config(
+            run_dir=self.run_dir,
+            config_path=str(custom),
+            site_policy=self.site_policy,
+        )
+        self.assertEqual(projection["host_root"], str(configured_root))
+        self.assertEqual(projection["source"], "config")
+
+    def test_rejects_projection_under_forbidden_output_root(self) -> None:
+        forbidden_projection = self.root / "forbidden" / "projection"
+        with self.assertRaisesRegex(resolve_eval_input.EvalInputError, "forbidden output root"):
+            resolve_eval_input._materialize_harness_config(
+                run_dir=self.run_dir,
+                config_path=None,
+                datasets_root=str(forbidden_projection),
+                site_policy=self.site_policy,
+            )
+        self.assertFalse(forbidden_projection.exists())
+
+    def test_rejects_projection_overlapping_source_root(self) -> None:
+        source_projection = self.root / "sources" / "projection"
+        with self.assertRaisesRegex(resolve_eval_input.EvalInputError, "must not overlap"):
+            resolve_eval_input._materialize_harness_config(
+                run_dir=self.run_dir,
+                config_path=None,
+                datasets_root=str(source_projection),
+                site_policy=self.site_policy,
+            )
+        self.assertFalse(source_projection.exists())
+
+    def test_rejects_projection_overlapping_run_output(self) -> None:
+        with self.assertRaisesRegex(resolve_eval_input.EvalInputError, "evaluation output"):
+            resolve_eval_input._materialize_harness_config(
+                run_dir=self.run_dir,
+                config_path=None,
+                datasets_root=str(self.run_dir / "datasets"),
+                site_policy=self.site_policy,
+            )
+        self.assertFalse((self.run_dir / "datasets").exists())
+
+    def test_custom_config_is_copied_and_only_dataset_root_is_overridden(self) -> None:
+        custom = self.root / "custom.yaml"
+        custom.write_text(
+            "data:\n  cache: /custom/cache\n  datasets: /custom/projection\n",
+            encoding="utf-8",
+        )
+        projection_root = self.root / "explicit-projection"
+        config_path, _ = resolve_eval_input._materialize_harness_config(
+            run_dir=self.run_dir,
+            config_path=str(custom),
+            datasets_root=str(projection_root),
+            site_policy=self.site_policy,
+        )
+        materialized = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(materialized["data"]["cache"], "/custom/cache")
+        self.assertEqual(materialized["data"]["datasets"], str(projection_root))
+        self.assertEqual(
+            yaml.safe_load(custom.read_text(encoding="utf-8"))["data"]["datasets"],
+            "/custom/projection",
+        )
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_eval/scripts/test_model_registry.py
+++ b/sure/skills/sure_eval/scripts/test_model_registry.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sure_eval.models.registry import ModelRegistry  # noqa: E402
+
+
+def _plant(root: Path, dir_name: str, declared_name: str, task: str = "ASR") -> Path:
+    model_dir = root / dir_name
+    model_dir.mkdir(parents=True)
+    (model_dir / "config.yaml").write_text(
+        f"name: {declared_name}\ntask: {task}\n", encoding="utf-8"
+    )
+    return model_dir
+
+
+class RegistryLookupTests(unittest.TestCase):
+    def test_model_is_findable_by_the_directory_it_was_mounted_as(self) -> None:
+        """The container mounts the bundle at /workspace/model, so callers look it
+        up by the basename "model" while config.yaml declares the canonical name."""
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            _plant(root, "model", "CohereLabs__cohere-transcribe-03-2026")
+            registry = ModelRegistry(root)
+
+            self.assertIsNotNone(registry.get_model("CohereLabs__cohere-transcribe-03-2026"))
+            found = registry.get_model("model")
+            self.assertIsNotNone(found)
+            self.assertEqual(found.name, "CohereLabs__cohere-transcribe-03-2026")
+
+    def test_a_declared_name_is_never_shadowed_by_another_directorys_basename(self) -> None:
+        """Whichever order the directories are walked in, the name config.yaml
+        declares must win over a directory that merely happens to be called that."""
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            _plant(root, "spare", "aispeech14.1")
+            _plant(root, "aispeech14.1", "aispeech14.1-v2")
+            registry = ModelRegistry(root)
+
+            found = registry.get_model("aispeech14.1")
+            self.assertIsNotNone(found)
+            self.assertEqual(found.path.name, "spare")
+            self.assertIsNotNone(registry.get_model("aispeech14.1-v2"))
+
+    def test_unknown_name_still_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            _plant(root, "model", "CohereLabs__cohere-transcribe-03-2026")
+            registry = ModelRegistry(root)
+
+            self.assertIsNone(registry.get_model("no-such-model"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/scripts/test_payload_artifact_paths.py
+++ b/sure/skills/sure_eval/scripts/test_payload_artifact_paths.py
@@ -12,10 +12,7 @@ import evaluate_predictions
 
 
 class PayloadArtifactPathTests(unittest.TestCase):
-    """The vc runner invokes evaluate_predictions.py with a repo-relative
-    --run-dir, so payload artifact paths must never depend on the cwd the
-    writer happened to run from (check_run_report resolves relative paths
-    against the run root)."""
+    """Run artifact references must remain valid across mount namespaces."""
 
     def setUp(self) -> None:
         self._previous_cwd = Path.cwd()
@@ -31,8 +28,13 @@ class PayloadArtifactPathTests(unittest.TestCase):
         external.mkdir(parents=True, exist_ok=True)
         sample_source = external / "sample.jsonl"
         sample_source.write_text('{"key": "utt1"}\n', encoding="utf-8")
-        prediction_source = external / "ds__v1.txt"
+        prediction_source = run_dir / "predictions" / "ds__v1.txt"
+        prediction_source.parent.mkdir(parents=True, exist_ok=True)
         prediction_source.write_text("utt1\thello\n", encoding="utf-8")
+        prediction_source.with_suffix(".jsonl").write_text(
+            '{"key": "utt1", "normalized_prediction": "hello"}\n',
+            encoding="utf-8",
+        )
         result = {
             "schema": "sure.eval.payload.dataset_metric.v2",
             "dataset": "ds__v1",
@@ -56,23 +58,27 @@ class PayloadArtifactPathTests(unittest.TestCase):
         run_dir = Path("sure/results/model/standard_system/run-1")
         payload = self._write_artifacts(run_dir)
         artifacts = payload["results"][0]["artifacts"]
-        metric_dir = run_dir.resolve() / "metrics" / "ds__v1" / "cer"
+        metric_dir = Path("metrics/ds__v1/cer")
         self.assertEqual(Path(artifacts["metric_artifact_dir"]), metric_dir)
         self.assertEqual(Path(artifacts["report"]), metric_dir / "report.json")
         self.assertEqual(Path(artifacts["pipeline_description"]), metric_dir / "pipeline_description.json")
         self.assertEqual(
             Path(artifacts["sample_report"]),
-            run_dir.resolve() / "sample_reports" / "ds__v1" / "cer.jsonl",
+            Path("sample_reports/ds__v1/cer.jsonl"),
         )
-        self.assertTrue(Path(artifacts["prediction_file"]).is_absolute())
+        self.assertEqual(Path(artifacts["prediction_file"]), Path("predictions/ds__v1.txt"))
+        self.assertEqual(Path(payload["results"][0]["inputs"]["prediction_path"]), Path("predictions/ds__v1.txt"))
         pipeline = payload["results"][0]["pipeline"]
         self.assertEqual(Path(pipeline["report_path"]), metric_dir / "report.json")
         self.assertEqual(Path(pipeline["description_path"]), metric_dir / "pipeline_description.json")
 
-    def test_gate_locates_metric_artifacts_written_from_relative_run_dir(self) -> None:
-        run_dir = Path("sure/results/model/standard_system/run-1")
-        self._write_artifacts(run_dir)
-        errors = check_run_report._validate_completed_artifacts(run_dir.resolve())
+    def test_gate_locates_metric_artifacts_after_run_directory_moves(self) -> None:
+        container_run_dir = Path("container/sure-output")
+        self._write_artifacts(container_run_dir)
+        host_run_dir = Path("host/results/model/standard_system/run-1")
+        host_run_dir.parent.mkdir(parents=True, exist_ok=True)
+        container_run_dir.rename(host_run_dir)
+        errors = check_run_report._validate_completed_artifacts(host_run_dir.resolve())
         missing = [
             error
             for error in errors

--- a/sure/skills/sure_eval/scripts/test_prediction_payload.py
+++ b/sure/skills/sure_eval/scripts/test_prediction_payload.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import generate_predictions_via_server as gp  # noqa: E402
+
+
+class AsrPayloadNormalizationTests(unittest.TestCase):
+    def test_single_element_text_list_is_unwrapped(self) -> None:
+        prediction, normalized = gp._normalize_prediction_payload(
+            {"text": [" 二零二二年冬奥会在北京举行"]}, task="ASR"
+        )
+        self.assertEqual(prediction, " 二零二二年冬奥会在北京举行")
+        self.assertEqual(normalized, {"text": " 二零二二年冬奥会在北京举行"})
+
+    def test_single_element_text_tuple_is_unwrapped(self) -> None:
+        prediction, normalized = gp._normalize_prediction_payload({"text": ("hello",)}, task="S2TT")
+        self.assertEqual(prediction, "hello")
+        self.assertEqual(normalized, {"text": "hello"})
+
+    def test_nested_prediction_text_list_is_unwrapped(self) -> None:
+        prediction, _ = gp._normalize_prediction_payload(
+            {"prediction": {"text": ["nested"]}}, task="ASR"
+        )
+        self.assertEqual(prediction, "nested")
+
+    def test_plain_string_text_is_untouched(self) -> None:
+        prediction, normalized = gp._normalize_prediction_payload({"text": "严浩出演的电影有什么"}, task="ASR")
+        self.assertEqual(prediction, "严浩出演的电影有什么")
+        self.assertEqual(normalized, {"text": "严浩出演的电影有什么"})
+
+    def test_empty_text_list_stays_empty(self) -> None:
+        prediction, normalized = gp._normalize_prediction_payload({"text": []}, task="ASR")
+        self.assertEqual(prediction, "")
+        self.assertEqual(normalized, {"text": ""})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/scripts/test_reval_prediction_source.py
+++ b/sure/skills/sure_eval/scripts/test_reval_prediction_source.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from resolve_model_dir import resolve_approved_model_identity
+from resolve_prediction_source import build_payload
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value) + "\n", encoding="utf-8")
+
+
+class RevalPredictionSourceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        root = Path(self.temp.name)
+        self.models = root / "models"
+        self.results = root / "results"
+        self.model = self.models / "demo"
+        self.model.mkdir(parents=True)
+        (self.model / "config.yaml").write_text("task: ASR\n", encoding="utf-8")
+        write_json(self.model / "artifacts" / "verdict.json", {"status": "success"})
+
+        result = self.results / "demo" / "approved-run"
+        predictions = result / "predictions"
+        predictions.mkdir(parents=True)
+        (result / "protocol.yaml").write_text("protocol_id: standard_system\n", encoding="utf-8")
+        write_json(
+            result / "report.jsonl",
+            {
+                "dataset": {"name": "aishell1__v1.0.2"},
+                "run": {"protocol_id": "standard_system"},
+                "model": {"model_name": "demo"},
+                "prediction": {"file": "aishell1__v1.0.2.txt"},
+            },
+        )
+        (predictions / "aishell1__v1.0.2.txt").write_text("sample-1\tprediction\n", encoding="utf-8")
+
+    def args(self) -> argparse.Namespace:
+        return argparse.Namespace(
+            model="demo",
+            datasets=["aishell1__v1.0.2"],
+            protocol_id="standard_system",
+        )
+
+    def test_resolves_approved_predictions_without_deployment_runtime_artifacts(self) -> None:
+        payload = build_payload(
+            self.args(),
+            approved_models_root=self.models,
+            approved_results_root=self.results,
+        )
+
+        self.assertEqual(payload["model_name"], "demo")
+        self.assertFalse(payload["inference_allowed"])
+        self.assertFalse((self.model / "artifacts" / "deployment_ready.json").exists())
+
+    def test_identity_rejects_non_successful_verdict(self) -> None:
+        write_json(self.model / "artifacts" / "verdict.json", {"status": "partial"})
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertFalse(identity["ok"])
+        self.assertIn("not successful", identity["identity_error"])
+        with self.assertRaisesRegex(ValueError, "successful verdict"):
+            build_payload(
+                self.args(),
+                approved_models_root=self.models,
+                approved_results_root=self.results,
+            )
+
+    def test_identity_prefers_artifacts_verdict_over_legacy_top_level(self) -> None:
+        write_json(self.model / "verdict.json", {"status": "success"})
+        write_json(self.model / "artifacts" / "verdict.json", {"status": "failed"})
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertFalse(identity["ok"])
+        self.assertEqual(identity["verdict_status"], "failed")
+        self.assertEqual(identity["verdict_path"], str((self.model / "artifacts" / "verdict.json").resolve()))
+
+    def test_identity_falls_back_to_legacy_top_level_verdict(self) -> None:
+        (self.model / "artifacts" / "verdict.json").unlink()
+        write_json(self.model / "verdict.json", {"status": "success"})
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertTrue(identity["ok"])
+        self.assertEqual(identity["verdict_path"], str((self.model / "verdict.json").resolve()))
+
+    def test_identity_requires_config(self) -> None:
+        (self.model / "config.yaml").unlink()
+
+        identity = resolve_approved_model_identity("demo", approved_root=self.models)
+
+        self.assertFalse(identity["ok"])
+        self.assertEqual(identity["identity_error"], "approved model config.yaml is missing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/scripts/test_source_conversion.py
+++ b/sure/skills/sure_eval/scripts/test_source_conversion.py
@@ -95,6 +95,10 @@ class SourceConversionTests(unittest.TestCase):
         self.assertEqual(row["task"], "ASR")
         self.assertEqual(row["language"], "zh")
         self.assertEqual(row["target"], "你好")
+        expected_audio = self.dataset_root / "raws" / "sample" / "utt1.wav"
+        self.assertEqual(row["path"], str(expected_audio))
+        self.assertTrue(expected_audio.is_file())
+        self.assertFalse((self.manager.sure_dir / "demo_ds" / "raws").exists())
         meta = row["metadata"]
         self.assertEqual(meta["source"], "aispeech_ds_pool")
         self.assertEqual(meta["source_dataset_root"], str(self.dataset_root))

--- a/sure/skills/sure_eval/scripts/test_wait_vc_execution.py
+++ b/sure/skills/sure_eval/scripts/test_wait_vc_execution.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import wait_vc_execution as waiter
+
+
+class WaitVcExecutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.run_dir = Path(self.temporary.name) / "run"
+        self.artifacts = self.run_dir / "artifacts"
+        self.artifacts.mkdir(parents=True)
+        self.token = "a" * 32
+        self.terminal_relative = f"artifacts/vc_terminal_status.{self.token}.json"
+        self.terminal_path = self.run_dir / self.terminal_relative
+        self.submit = {
+            "execution_path": "vc_submit",
+            "execution_requested": "vc",
+            "vc_job_id": "job-test",
+            "submission_token": self.token,
+            "terminal_status_path": self.terminal_relative,
+            "submitted_at": "2026-08-30T00:00:00+00:00",
+            "host": "job-test",
+            "command": "bash run_evaluation.sh",
+            "cwd": "/workspace",
+            "stdout_log": "vc_logs/job.log",
+            "stderr_log": "vc_logs/job.log",
+            "device_request": "auto",
+            "device_actual": "cuda:0",
+            "cuda_visible_devices": "",
+        }
+
+    def write_sentinel(self, *, exit_code: int, token: str | None = None) -> None:
+        self.terminal_path.write_text(
+            json.dumps(
+                {
+                    "schema": "sure.eval.vc_terminal_status.v1",
+                    "submission_token": token or self.token,
+                    "job_status": "succeeded" if exit_code == 0 else "failed",
+                    "exit_code": exit_code,
+                    "started_at": "2026-08-30T00:00:01Z",
+                    "ended_at": "2026-08-30T00:00:03Z",
+                    "duration_seconds": 2,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def wait(self, **overrides: object) -> dict:
+        options = {
+            "run_dir": self.run_dir,
+            "submit": self.submit,
+            "timeout_seconds": 0.0,
+            "poll_interval_seconds": 0.1,
+            "terminal_grace_seconds": 0.0,
+            "run_vc": lambda command: subprocess.CompletedProcess(command, 0, "", ""),
+        }
+        options.update(overrides)
+        return waiter.wait_for_vc_execution(**options)
+
+    def test_success_sentinel_is_authoritative(self) -> None:
+        self.write_sentinel(exit_code=0)
+
+        result = self.wait()
+
+        self.assertEqual(result["job_status"], "succeeded")
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["completion_source"], "terminal_sentinel")
+        self.assertFalse(result["timed_out"])
+
+    def test_nonzero_sentinel_records_terminal_failure(self) -> None:
+        self.write_sentinel(exit_code=23)
+
+        result = self.wait()
+
+        self.assertEqual(result["job_status"], "failed")
+        self.assertEqual(result["exit_code"], 23)
+        self.assertEqual(waiter._validation_errors(result, self.submit), [])
+
+    def test_cleaned_pod_without_sentinel_is_failure(self) -> None:
+        def run_vc(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command[1] == "info":
+                output = "StartTime: 2026-08-30 00:00:01\nEndTime: 2026-08-30 00:00:03\n"
+            else:
+                output = "\u672a\u67e5\u5230\u8be5\u4efb\u52a1\u4fe1\u606f\nNone\n"
+            return subprocess.CompletedProcess(command, 0, output, "")
+
+        result = self.wait(run_vc=run_vc)
+
+        self.assertEqual(result["job_status"], "failed")
+        self.assertEqual(result["completion_source"], "vc_terminal_without_sentinel")
+        self.assertEqual(result["exit_code"], 1)
+
+    def test_missing_before_observation_waits_for_sentinel(self) -> None:
+        def run_vc(command: list[str]) -> subprocess.CompletedProcess[str]:
+            output = (
+                "job\u4e0d\u5b58\u5728: job-test"
+                if command[1] == "info"
+                else "\u672a\u67e5\u5230\u8be5\u4efb\u52a1\u4fe1\u606f\nNone"
+            )
+            return subprocess.CompletedProcess(command, 0, output, "")
+
+        ticks = iter((0.0, 0.0))
+        result = self.wait(
+            timeout_seconds=10.0,
+            run_vc=run_vc,
+            monotonic=lambda: next(ticks),
+            sleep=lambda _: self.write_sentinel(exit_code=0),
+        )
+
+        self.assertEqual(result["job_status"], "succeeded")
+        self.assertEqual(result["completion_source"], "terminal_sentinel")
+        self.assertEqual(result["poll_count"], 1)
+
+    def test_missing_after_observation_is_terminal_failure(self) -> None:
+        poll = 0
+
+        def run_vc(command: list[str]) -> subprocess.CompletedProcess[str]:
+            nonlocal poll
+            if command[1] == "info":
+                poll += 1
+            if poll == 1:
+                output = (
+                    "StartTime: 2026-08-30 00:00:01\nEndTime:\n"
+                    if command[1] == "info"
+                    else "Running"
+                )
+            else:
+                output = (
+                    "job\u4e0d\u5b58\u5728: job-test"
+                    if command[1] == "info"
+                    else "\u672a\u67e5\u5230\u8be5\u4efb\u52a1\u4fe1\u606f\nNone"
+                )
+            return subprocess.CompletedProcess(command, 0, output, "")
+
+        ticks = iter((0.0, 0.0, 1.0))
+        result = self.wait(
+            timeout_seconds=10.0,
+            run_vc=run_vc,
+            monotonic=lambda: next(ticks),
+            sleep=lambda _: None,
+        )
+
+        self.assertEqual(result["job_status"], "failed")
+        self.assertEqual(result["completion_source"], "vc_terminal_without_sentinel")
+        self.assertEqual(result["poll_count"], 2)
+
+    def test_vc_query_errors_are_not_terminal_evidence(self) -> None:
+        result = self.wait(
+            run_vc=lambda command: subprocess.CompletedProcess(command, 1, "", "connection failed")
+        )
+
+        self.assertEqual(result["job_status"], "running")
+        self.assertEqual(result["completion_source"], "wait_timeout")
+        self.assertTrue(result["timed_out"])
+
+    def test_timeout_stays_running_and_fails_gate_validation(self) -> None:
+        def run_vc(command: list[str]) -> subprocess.CompletedProcess[str]:
+            output = "StartTime: 2026-08-30 00:00:01\nEndTime:\n" if command[1] == "info" else "Running"
+            return subprocess.CompletedProcess(command, 0, output, "")
+
+        result = self.wait(run_vc=run_vc)
+
+        self.assertEqual(result["job_status"], "running")
+        self.assertEqual(result["completion_source"], "wait_timeout")
+        self.assertTrue(result["timed_out"])
+        self.assertIn("still running", "; ".join(waiter._validation_errors(result, self.submit)))
+
+    def test_stale_submission_token_is_rejected(self) -> None:
+        self.write_sentinel(exit_code=0, token="b" * 32)
+
+        with self.assertRaisesRegex(ValueError, "current submission token"):
+            self.wait()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/scripts/vc_check.py
+++ b/sure/skills/sure_eval/scripts/vc_check.py
@@ -103,6 +103,21 @@ def main() -> int:
     requested = _execution_requested(data, run_dir)
     local_paths = {"local_docker"}
 
+    if execution_path == "vc_submit":
+        required = ("vc_job_id", "submission_token", "terminal_status_path")
+        missing = [
+            field
+            for field in required
+            if not isinstance(data.get(field), str) or not data[field].strip()
+        ]
+        if missing:
+            print(
+                "SUBMIT_EXECUTION gate: vc_submit requires non-empty control fields: "
+                + ", ".join(missing),
+                file=sys.stderr,
+            )
+            return 1
+
     if requested == "vc" and execution_path != "vc_submit":
         print(
             "SUBMIT_EXECUTION gate: user requested execution=vc, so "

--- a/sure/skills/sure_eval/scripts/wait_vc_execution.py
+++ b/sure/skills/sure_eval/scripts/wait_vc_execution.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Wait for a submitted VC run and materialize its authoritative result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+TERMINAL_JOB_STATUSES = {"succeeded", "failed", "partial"}
+VC_TERMINAL_STATUSES = {"completed", "succeeded", "failed", "error", "terminated", "aborted"}
+VC_MISSING_MARKERS = ("job\u4e0d\u5b58\u5728", "\u672a\u67e5\u5230\u8be5\u4efb\u52a1\u4fe1\u606f", "not found", "does not exist")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp-{os.getpid()}")
+    temporary.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _path_under_run(run_dir: Path, value: str, *, default: Path | None = None) -> Path:
+    path = Path(value).expanduser() if value else default
+    if path is None:
+        raise ValueError("required run-local path is missing")
+    if not path.is_absolute():
+        path = run_dir / path
+    path = path.resolve()
+    try:
+        path.relative_to(run_dir.resolve())
+    except ValueError as exc:
+        raise ValueError(f"control artifact path must stay under the run directory: {path}") from exc
+    return path
+
+
+def _run_vc(command: list[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        return subprocess.run(command, capture_output=True, text=True, check=False, timeout=30)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return subprocess.CompletedProcess(command, 127, "", str(exc))
+
+
+def _excerpt(completed: subprocess.CompletedProcess[str]) -> str:
+    return (completed.stdout or completed.stderr or "").strip()[-2000:]
+
+
+def _vc_terminal_evidence(info: str, describe: str) -> bool:
+    end_match = re.search(r"(?mi)^EndTime:\s*(.+?)\s*$", info)
+    if end_match and end_match.group(1).strip():
+        return True
+    status_match = re.search(r"(?mi)^Status:\s*([A-Za-z_-]+)\s*$", info)
+    if status_match and status_match.group(1).lower() in VC_TERMINAL_STATUSES:
+        return True
+    return False
+
+
+def _vc_missing_evidence(info: str, describe: str) -> bool:
+    info_lower = info.lower()
+    describe_lower = describe.lower()
+    return any(marker in info_lower for marker in VC_MISSING_MARKERS) and any(
+        marker in describe_lower for marker in VC_MISSING_MARKERS
+    )
+
+
+def _vc_job_observed(*results: subprocess.CompletedProcess[str]) -> bool:
+    for result in results:
+        excerpt = _excerpt(result)
+        if result.returncode != 0 or not excerpt:
+            continue
+        if not any(marker in excerpt.lower() for marker in VC_MISSING_MARKERS):
+            return True
+    return False
+
+
+def _duration_seconds(started_at: Any, ended_at: Any) -> float | None:
+    try:
+        started = datetime.fromisoformat(str(started_at).replace("Z", "+00:00"))
+        ended = datetime.fromisoformat(str(ended_at).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return max(0.0, (ended - started).total_seconds())
+
+
+def _execution_payload(
+    *,
+    submit: dict[str, Any],
+    job_status: str,
+    exit_code: int | None,
+    completion_source: str,
+    terminal_status_path: str,
+    poll_count: int,
+    timed_out: bool,
+    sentinel: dict[str, Any] | None,
+    info: subprocess.CompletedProcess[str] | None,
+    describe: subprocess.CompletedProcess[str] | None,
+) -> dict[str, Any]:
+    started_at = (sentinel or {}).get("started_at") or submit.get("submitted_at") or ""
+    ended_at = (sentinel or {}).get("ended_at") or _utc_now()
+    duration = (sentinel or {}).get("duration_seconds")
+    if not isinstance(duration, (int, float)):
+        duration = _duration_seconds(started_at, ended_at)
+    payload: dict[str, Any] = {
+        "job_status": job_status,
+        "vc_job_id": str(submit.get("vc_job_id") or ""),
+        "execution_path": "vc_submit",
+        "execution_requested": str(submit.get("execution_requested") or "vc"),
+        "log_path": str(submit.get("stdout_log") or submit.get("stderr_log") or ""),
+        "host": str(submit.get("host") or submit.get("vc_job_id") or ""),
+        "command": str(submit.get("command") or ""),
+        "cwd": str(submit.get("cwd") or ""),
+        "started_at": str(started_at),
+        "ended_at": str(ended_at),
+        "stdout_log": str(submit.get("stdout_log") or ""),
+        "stderr_log": str(submit.get("stderr_log") or ""),
+        "device_request": str(submit.get("device_request") or ""),
+        "device_actual": str(submit.get("device_actual") or ""),
+        "cuda_visible_devices": str(submit.get("cuda_visible_devices") or ""),
+        "completion_source": completion_source,
+        "submission_token": str(submit.get("submission_token") or ""),
+        "terminal_sentinel": terminal_status_path,
+        "timed_out": timed_out,
+        "poll_count": poll_count,
+        "vc_info_excerpt": _excerpt(info) if info is not None else "",
+        "vc_describe_excerpt": _excerpt(describe) if describe is not None else "",
+    }
+    if exit_code is not None:
+        payload["exit_code"] = exit_code
+    if duration is not None:
+        payload["duration_seconds"] = duration
+    return payload
+
+
+def _validated_sentinel(path: Path, submit: dict[str, Any]) -> dict[str, Any] | None:
+    sentinel = _read_json(path)
+    if not sentinel:
+        return None
+    if sentinel.get("schema") != "sure.eval.vc_terminal_status.v1":
+        raise ValueError(f"invalid VC terminal sentinel schema: {path}")
+    if sentinel.get("submission_token") != submit.get("submission_token"):
+        raise ValueError("VC terminal sentinel does not match the current submission token")
+    exit_code = sentinel.get("exit_code")
+    if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+        raise ValueError("VC terminal sentinel exit_code must be an integer")
+    expected_status = "succeeded" if exit_code == 0 else "failed"
+    if sentinel.get("job_status") != expected_status:
+        raise ValueError("VC terminal sentinel job_status conflicts with exit_code")
+    return sentinel
+
+
+def wait_for_vc_execution(
+    *,
+    run_dir: Path,
+    submit: dict[str, Any],
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+    terminal_grace_seconds: float,
+    run_vc: Callable[[list[str]], subprocess.CompletedProcess[str]] = _run_vc,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    if submit.get("execution_path") != "vc_submit":
+        raise ValueError("wait_vc_execution.py only waits for execution_path=vc_submit")
+    job_id = str(submit.get("vc_job_id") or "")
+    token = str(submit.get("submission_token") or "")
+    if not job_id or not token:
+        raise ValueError("VC submit_result.json must declare vc_job_id and submission_token")
+    terminal_relative = str(submit.get("terminal_status_path") or "")
+    terminal_path = _path_under_run(run_dir, terminal_relative)
+    deadline = monotonic() + max(0.0, timeout_seconds)
+    terminal_seen_at: float | None = None
+    job_observed = False
+    poll_count = 0
+    last_info: subprocess.CompletedProcess[str] | None = None
+    last_describe: subprocess.CompletedProcess[str] | None = None
+
+    while True:
+        sentinel = _validated_sentinel(terminal_path, submit)
+        if sentinel is not None:
+            return _execution_payload(
+                submit=submit,
+                job_status=str(sentinel["job_status"]),
+                exit_code=int(sentinel["exit_code"]),
+                completion_source="terminal_sentinel",
+                terminal_status_path=terminal_relative,
+                poll_count=poll_count,
+                timed_out=False,
+                sentinel=sentinel,
+                info=last_info,
+                describe=last_describe,
+            )
+
+        last_info = run_vc(["vc", "info", "--job", job_id])
+        last_describe = run_vc(["vc", "describe", "--job", job_id])
+        poll_count += 1
+        now = monotonic()
+        info_excerpt = _excerpt(last_info)
+        describe_excerpt = _excerpt(last_describe)
+        job_observed = job_observed or _vc_job_observed(last_info, last_describe)
+        terminal_evidence = _vc_terminal_evidence(info_excerpt, describe_excerpt) or (
+            job_observed and _vc_missing_evidence(info_excerpt, describe_excerpt)
+        )
+        if terminal_evidence:
+            terminal_seen_at = terminal_seen_at if terminal_seen_at is not None else now
+            if now - terminal_seen_at >= max(0.0, terminal_grace_seconds):
+                return _execution_payload(
+                    submit=submit,
+                    job_status="failed",
+                    exit_code=1,
+                    completion_source="vc_terminal_without_sentinel",
+                    terminal_status_path=terminal_relative,
+                    poll_count=poll_count,
+                    timed_out=False,
+                    sentinel=None,
+                    info=last_info,
+                    describe=last_describe,
+                )
+        else:
+            terminal_seen_at = None
+
+        if now >= deadline:
+            return _execution_payload(
+                submit=submit,
+                job_status="running",
+                exit_code=None,
+                completion_source="wait_timeout",
+                terminal_status_path=terminal_relative,
+                poll_count=poll_count,
+                timed_out=True,
+                sentinel=None,
+                info=last_info,
+                describe=last_describe,
+            )
+        sleep(min(max(0.1, poll_interval_seconds), max(0.1, deadline - now)))
+
+
+def _validation_errors(result: dict[str, Any], submit: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    status = str(result.get("job_status") or "")
+    if status == "running":
+        errors.append("VC execution is still running; rerun wait_vc_execution.py --wait")
+    elif status not in TERMINAL_JOB_STATUSES:
+        errors.append(f"execution_result.json has invalid job_status: {status!r}")
+    if result.get("execution_path") != submit.get("execution_path"):
+        errors.append("execution_result.json execution_path differs from submit_result.json")
+    if submit.get("execution_path") == "vc_submit":
+        if result.get("vc_job_id") != submit.get("vc_job_id"):
+            errors.append("execution_result.json vc_job_id differs from submit_result.json")
+        token = submit.get("submission_token")
+        if token and result.get("submission_token") != token:
+            errors.append("execution_result.json submission_token differs from submit_result.json")
+        if token and not result.get("completion_source"):
+            errors.append("execution_result.json completion_source is required for tokenized VC submissions")
+    if status == "succeeded" and result.get("exit_code") != 0:
+        errors.append("succeeded execution_result.json must declare exit_code=0")
+    if status == "failed" and result.get("exit_code") in (None, 0):
+        errors.append("failed execution_result.json must declare a non-zero exit_code")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--produces", help="Path to execution_result.json")
+    parser.add_argument("--wait", action="store_true", help="Wait and write execution_result.json")
+    parser.add_argument("--timeout-seconds", type=float, default=7200)
+    parser.add_argument("--poll-interval-seconds", type=float, default=10)
+    parser.add_argument("--terminal-grace-seconds", type=float, default=30)
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir).expanduser().resolve()
+    artifacts_dir = run_dir / "artifacts"
+    output_path = _path_under_run(
+        run_dir,
+        args.produces or "",
+        default=artifacts_dir / "execution_result.json",
+    )
+    submit = _read_json(artifacts_dir / "submit_result.json")
+    if not submit:
+        print(f"submit_result.json not found or invalid under {artifacts_dir}", file=sys.stderr)
+        return 1
+
+    if args.wait:
+        if submit.get("execution_path") != "vc_submit":
+            result = _read_json(output_path)
+            errors = _validation_errors(result, submit)
+            if errors:
+                print("execute_wait gate failed: " + "; ".join(errors), file=sys.stderr)
+                return 1
+        else:
+            try:
+                result = wait_for_vc_execution(
+                    run_dir=run_dir,
+                    submit=submit,
+                    timeout_seconds=args.timeout_seconds,
+                    poll_interval_seconds=args.poll_interval_seconds,
+                    terminal_grace_seconds=args.terminal_grace_seconds,
+                )
+            except ValueError as exc:
+                print(f"execute_wait failed: {exc}", file=sys.stderr)
+                return 1
+            _write_json_atomic(output_path, result)
+    else:
+        result = _read_json(output_path)
+
+    errors = _validation_errors(result, submit)
+    if errors:
+        print("execute_wait gate failed: " + "; ".join(errors), file=sys.stderr)
+        return 1
+    print(
+        f"execute_wait OK: job_status={result.get('job_status')} "
+        f"completion_source={result.get('completion_source', 'local_process')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sure/skills/sure_reval/SKILL.md
+++ b/sure/skills/sure_reval/SKILL.md
@@ -42,7 +42,7 @@ Example:
 
 ## State Machine
 
-1. `resolve_approved_model`: resolve the exact model below the NFS model root and require runtime files plus verdict existence.
+1. `resolve_approved_model`: resolve the exact model below the NFS model root and require `config.yaml` plus a successful verdict. Model deployment runtime files are not read because re-evaluation never runs inference.
 2. `resolve_approved_result`: inspect only immediate approved result directories for that model.
 3. `verify_source_identity`: require exact model, protocol, and sorted dataset-set equality; bind the NFS report, model fingerprint, prediction hashes, and sample counts.
 4. `resolve_evaluation_route`: resolve every requested exact `pipeline_id` through the standalone sure-evaluation engine.

--- a/sure/skills/sure_trans/scripts/templates/__init__.py
+++ b/sure/skills/sure_trans/scripts/templates/__init__.py
@@ -1,5 +1,5 @@
 """SURE trans adapter package."""
 
-from model import ModelWrapper
+from .model import ModelWrapper
 
 __all__ = ["ModelWrapper"]


### PR DESCRIPTION
## Summary

- synchronize the deterministic public projection through GitLab commit 338f7a7
- add GitHub Public CI for repository contracts and public startup
- preserve the GitHub-only README and terminal assets
- scope runner temporary paths at step level and install the pinned uv bootstrap required by harness tests

## Verification

- deterministic public export: 1,594 source entries, reproduced twice
- actionlint 1.7.12
- targeted CI regression: 135 passed, 2 skipped
- repository contracts: 10 of 11 local checks passed; Biome was blocked only by the host glibc version
- prior full suite: 397 Python tests and 375 coding-agent tests, 2 skipped
- fail-closed public startup, configured doctor, and offline help