### PR TITLE
feat(sure): support sealed local Python evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ A model score is useful only when people can establish exactly how it was produc
 SURE gives you both automation and experimental credibility:
 
 - **Deploy and evaluate with integrated commands.** Start a complete discovery, adaptation, deployment, or evaluation stage with one slash command instead of manually assembling scripts and environments.
-- **Reproduce the whole system, not just the score.** Every result is tied to the inference implementation, model and Harness Runtime, immutable image digest, parameters, dataset version, evaluation engine commit, exact pipeline, and reports.
+- **Reproduce the whole system, not just the score.** Every result is tied to the inference implementation, model and Harness Runtime, immutable deployment identity, parameters, dataset version, evaluation engine commit, exact pipeline, and reports.
 - **Make results credible and comparable.** Two results can be compared against the concrete framework, configuration, inputs, normalization, and metric route that produced them, rather than against an unexplained number.
-- **Keep automation accountable.** Agents handle research and adaptation, while deterministic state machines, schemas, smoke tests, and container checks reject incomplete or inconsistent work.
+- **Keep automation accountable.** Agents handle research and adaptation, while deterministic state machines, schemas, smoke tests, and runtime-specific checks reject incomplete or inconsistent work.
 
 The central promise is simple: SURE reduces deployment and evaluation work without trading away reproducibility. Convenience comes with a complete evidence chain.
 
@@ -39,11 +39,11 @@ Model repository       Runnable deployment       Predictions + metrics       New
 | Workflow | What the agent does | Reproducible product |
 | --- | --- | --- |
 | Discover | Researches a Hugging Face, ModelScope, or GitHub model and resolves its capabilities, runtime, fixtures, and I/O contract | Canonical `model_input.yaml` plus source evidence |
-| Onboard | Adapts and validates the model, generates a runnable inference package when needed, and seals local models in a digest-pinned OCI image | Portable model bundle plus `deployment_ready.json` |
+| Onboard | Adapts and validates the model, generates a runnable inference package when needed, and seals local models as a digest-pinned OCI image or content-addressed Python runtime | Portable model bundle plus `deployment_ready.json` |
 | Evaluate | Runs approved inference, resolves a deterministic evaluation route, and computes metrics | Predictions, protocol, reports, metrics, and sample-level evidence |
 | Re-evaluate | Reuses approved predictions with an explicit pipeline | A new evaluation batch without repeating inference |
 
-For common PyTorch and Transformers models, the onboarding agent can synthesize missing load and inference adapters from upstream documentation and source evidence. Every generated path must still pass local, container, interface, and artifact-contract gates before it can be marked ready.
+For common PyTorch and Transformers models, the onboarding agent can synthesize missing load and inference adapters from upstream documentation and source evidence. Every generated path must still pass environment, selected-runtime, interface, and artifact-contract gates before it can be marked ready.
 
 Promotion is intentionally human-reviewed. SURE stages model bundles and evaluation results, but it never silently copies them into configured approved storage. This keeps convenience from weakening the experiment's trust boundary.
 
@@ -64,9 +64,9 @@ The following path was designed for a Bash-compatible Linux environment.
 - Git
 - Python 3.11 and [uv](https://docs.astral.sh/uv/)
 - Credentials for at least one supported coding-agent provider
-- Docker and access to an OCI registry when onboarding or evaluating a local model
+- Docker and access to an OCI registry when using the `docker-registry` profile or VC execution
 
-The registry must support authenticated push and digest-pinned pull from the machine that runs SURE. API-only model onboarding does not require a local model image.
+The registry must support authenticated push and digest-pinned pull from the machine that runs SURE. API-only onboarding and local `package=none` Python execution do not require a model image.
 
 ### 2. Clone and install
 
@@ -111,6 +111,9 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container
 EOF
 
 npm run sure:site-info
@@ -167,7 +170,7 @@ Consume the handoff by its normalized directory name:
 /sure_onboard model=Qwen__Qwen3-ASR-1.7B
 ```
 
-For a local model, SURE researches the upstream implementation, materializes an isolated model runtime, generates or repairs the adapter, validates import/load/inference and the tool contract, builds an OCI image, pushes it, and verifies the immutable digest. A successful bundle ends with:
+For a local model, SURE researches the upstream implementation, materializes an isolated build environment, generates or repairs the adapter, and validates import, load, inference, and the tool contract. The selected package profile then seals either a digest-pinned OCI image or a content-addressed Model Python runtime. A successful bundle ends with:
 
 ```text
 sure/models/Qwen__Qwen3-ASR-1.7B/artifacts/deployment_ready.json
@@ -175,7 +178,13 @@ sure/models/Qwen__Qwen3-ASR-1.7B/artifacts/deployment_ready.json
 
 `deployment_ready.json` is a readiness marker, not an approval. Review the complete model directory, then copy that directory into one of the configured `approved_models_roots`. `/sure_eval` only accepts the exact directory name below an approved root.
 
-Local models require the default `docker-registry` package profile and a usable registry; a local-only Docker tag is not Eval-ready. See [`/sure_onboard`](./sure/skills/sure_onboard/SKILL.md) for API models, explicit handoff paths, device selection, and repair flows.
+Omitting `package` keeps the default `docker-registry` profile. For a self-hosted local evaluation that does not need Docker, select the Python profile explicitly:
+
+```text
+/sure_onboard model=Qwen__Qwen3-ASR-1.7B package=none
+```
+
+The Python profile requires the `uv` backend, a hash-locked requirements file, and `python` in the site's `execution.local_runtimes`. SURE seals a portable runtime identity into the promoted model bundle and resolves the matching runtime below `storage.runtime_root` during `/sure_eval`. It never accepts an arbitrary host Python or model-local `.venv`, and Python deployments cannot be submitted to VC. See [`/sure_onboard`](./sure/skills/sure_onboard/SKILL.md) for API models, explicit handoff paths, device selection, and repair flows.
 
 ### Evaluate an approved model with `/sure_eval`
 

--- a/config/site.example.yaml
+++ b/config/site.example.yaml
@@ -19,3 +19,6 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -43,10 +43,11 @@ The machine-readable contract is [sure/site/policy.schema.json](../sure/site/pol
 | `storage.approved_models_roots` | yes | Read-only roots containing human-approved model packages |
 | `storage.approved_results_roots` | yes | Read-only roots containing human-approved evaluation results |
 | `storage.forbidden_output_roots` | yes | Roots where automated `output_dir` writes are forbidden |
-| `storage.runtime_root` | yes | Declared site-owned cache root for adapters and future runtime placement |
+| `storage.runtime_root` | yes | Site-owned cache root for content-addressed Model Python runtimes and adapters |
 | `datasets.allowed_source_roots` | yes | Roots accepted by the strict dataset source resolver |
 | `datasets.projection_root` | optional | Writable root for generated dataset JSONL indexes and metadata; raw data remains in the allowed source root |
 | `execution.surfaces` | yes | Enabled execution surfaces: `local`, `vc`, or both |
+| `execution.local_runtimes` | optional | Permitted local runtimes: `python`, `container`, or both; omission remains container-only |
 | `execution.vc_partitions` | when needed | Declared VC partitions for adapters and deployment documentation |
 | `execution.vc_partition_priority` | optional | Numeric priority map used by automatic VC selection |
 | `network` | optional | Non-secret site endpoints used by private adapters and documentation |
@@ -57,6 +58,8 @@ Policy v1 accepts exactly one path in each root list. The list shape leaves room
 
 `execution.surfaces` constrains automatic and explicit execution selection. `execution.vc_partitions` documents site choices but does not replace the existing live `vc info -u` authorization check; changing partition authorization semantics is outside this separation phase.
 
+`execution.local_runtimes` is a permission boundary, not a package-manager choice. Enabling `python` permits an explicitly sealed Model Python runtime; it does not make host execution the default and does not permit Python execution on VC.
+
 ## Path Semantics
 
 - Every configured root is absolute.
@@ -65,7 +68,8 @@ Policy v1 accepts exactly one path in each root list. The list shape leaves room
 - A configured dataset projection root must stay outside forbidden output roots and must not overlap an allowed source root.
 - Path authorization resolves existing symlinks before comparison, so alternate names cannot bypass a protected root.
 - The policy validator does not create directories and does not require network access. Runtime commands perform their existing availability and permission checks at the same stages as before.
-- This compatibility phase does not redirect the locked Harness Runtime or Evaluation Runtime. They continue to materialize in their pre-existing repository-local locations; changing that behavior requires a separate differential migration.
+- Sealed Model Python runtimes materialize under `storage.runtime_root/models/<runtime_id>`. The promoted model stores only the portable runtime identity and manifest; `/sure_eval` resolves and verifies the matching site runtime before use.
+- The locked Harness Runtime and Evaluation Runtime remain in their repository-local locations. `storage.runtime_root` does not redirect either role.
 - Container deployments must mount configured roots at paths that preserve the command's existing host/container path contract.
 
 ## Minimal Local Example
@@ -92,6 +96,9 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container
 ```
 
 For shared storage, replace these placeholders with roots visible to every host and container that executes a workflow. The projection root is the only writable dataset workspace; source roots are mounted read-only. For a local-only fixture, create temporary model, result, dataset, projection, and runtime roots and point the local policy at them.

--- a/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
@@ -98,6 +98,31 @@ function withEnv<T>(name: string, value: string | undefined, fn: () => T): T {
 	}
 }
 
+function writePythonSitePolicy(cwd: string): string {
+	const path = join(cwd, "config", "site.local.yaml");
+	mkdirSync(resolve(path, ".."), { recursive: true });
+	writeFileSync(
+		path,
+		[
+			"schema: sure.site.policy.v1",
+			"site_id: test",
+			"policy_version: 1",
+			"storage:",
+			`  approved_models_roots: [${join(cwd, "sure", "models")}]`,
+			`  approved_results_roots: [${join(cwd, "sure", "results")}]`,
+			`  forbidden_output_roots: [${join(cwd, "forbidden")}]`,
+			`  runtime_root: ${join(cwd, ".runtime")}`,
+			"datasets:",
+			`  allowed_source_roots: [${join(cwd, "datasets")}]`,
+			"execution:",
+			"  surfaces: [local]",
+			"  local_runtimes: [python]",
+		].join("\n") + "\n",
+		"utf-8",
+	);
+	return path;
+}
+
 function seedModelInputResolved(runDir: string, overrides: Record<string, unknown> = {}): void {
 	writeArtifact(runDir, "model_input_resolved.json", {
 		model_id: "owner/model",
@@ -322,6 +347,37 @@ describe("sure_onboard MODEL_INPUT startup", () => {
 		const result = preStart(ctx);
 		expect(result.ok).toBe(false);
 		expect(result.repair).toContain('package "vc" is not one of');
+	});
+
+	it("rejects package=none when the site has no local execution surface", () => {
+		const { ctx, cwd } = preStartCtx(
+			"python-without-local-surface",
+			"model_id=owner/model repo=https://example.test/model task_type=asr deployment_type=local package=none",
+		);
+		const sitePolicy = join(cwd, "config", "site.local.yaml");
+		mkdirSync(resolve(sitePolicy, ".."), { recursive: true });
+		writeFileSync(
+			sitePolicy,
+			[
+				"schema: sure.site.policy.v1",
+				"site_id: test",
+				"policy_version: 1",
+				"storage:",
+				`  approved_models_roots: [${join(cwd, "models")}]`,
+				`  approved_results_roots: [${join(cwd, "results")}]`,
+				`  forbidden_output_roots: [${join(cwd, "forbidden")}]`,
+				`  runtime_root: ${join(cwd, ".runtime")}`,
+				"datasets:",
+				`  allowed_source_roots: [${join(cwd, "datasets")}]`,
+				"execution:",
+				"  surfaces: [vc]",
+				"  local_runtimes: [python]",
+			].join("\n") + "\n",
+			"utf-8",
+		);
+		const result = withEnv("SURE_SITE_POLICY", sitePolicy, () => preStart(ctx));
+		expect(result.ok).toBe(false);
+		expect(result.repair).toContain("execution.surfaces");
 	});
 });
 
@@ -786,10 +842,11 @@ describe("sure_onboard MODEL_INPUT materializer", () => {
 describe("sure_onboard end-to-end state-machine replay", () => {
 	it("replays MODEL_INPUT to final sure_finish through all gates", () => {
 		const { ctx, cwd, runDir } = preStartCtx("full-replay-reference-adoption", "");
+		const sitePolicy = writePythonSitePolicy(cwd);
 		const modelInputPath = join(cwd, "sure", "handoffs", "rednote-hilab__dots.tts-base", "model_input.yaml");
 		writeModelInput(modelInputPath);
 		ctx.args = `model_input_path=${modelInputPath} package=none`;
-		const start = preStart(ctx);
+		const start = withEnv("SURE_SITE_POLICY", sitePolicy, () => preStart(ctx));
 		expect(start.ok).toBe(true);
 
 		const materialize = spawnSync(
@@ -813,7 +870,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 
 		ctx.point = "post_tool_result";
 		const advance = (expectedCurrentUnit: string): CheckpointData => {
-			const result = postToolResult(ctx);
+			const result = withEnv("SURE_SITE_POLICY", sitePolicy, () => postToolResult(ctx));
 			expect(result.ok, result.repair).toBe(true);
 			const checkpoint = persistCheckpointFrom(runDir, result);
 			expect(checkpoint?.currentUnit).toBe(expectedCurrentUnit);
@@ -828,7 +885,12 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 		const modelArtifacts = join(modelDir, "artifacts");
 		mkdirSync(modelArtifacts, { recursive: true });
 		for (const name of ["model.spec.yaml", "model.py", "server.py", "__init__.py", "validate.py", "config.yaml"]) {
-			const content = name === "model.py" ? "class Model:\n\tpass\n" : `${name}\n`;
+			const content =
+				name === "model.py"
+					? "class Model:\n\tpass\n"
+					: name === "config.yaml"
+						? "server:\n  command: [.venv/bin/python, server.py]\n  working_dir: .\ntools:\n  - name: synthesize\nresources:\n  gpu: false\n"
+						: `${name}\n`;
 			writeFileSync(join(modelDir, name), content, "utf-8");
 		}
 		const checkpointDir = join(modelDir, "checkpoints", "tiny");
@@ -890,6 +952,11 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 			context_selection_path: "artifacts/context_selection.json",
 			backend_choice_path: "artifacts/backend_choice.json",
 			steps: [
+				{
+					state: "build_env",
+					action: "seal Model Python runtime",
+					command: "python3 scripts/materialize_model_runtime.py --input build_env_draft.json",
+				},
 				{ state: "validate_spec", action: "check generated spec" },
 				{ state: "prepare_fixture", action: "stage task fixture into model_dir" },
 				{ state: "build_env", action: "reuse test python" },
@@ -962,18 +1029,33 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 		advance("build_env");
 
 		const pythonExecutable = writePythonShim(modelDir);
-		writeArtifact(runDir, "build_env_result.json", {
+		writeFileSync(join(modelDir, "requirements.lock"), "", "utf-8");
+		writeArtifact(runDir, "build_env_draft.json", {
 			env_ready: true,
 			backend: "uv",
-			python_version: "3.11",
 			python_executable: pythonExecutable,
 			model_dir: modelDir,
 			artifacts_dir: modelArtifacts,
-			lockfile_path: null,
+			lockfile_path: "requirements.lock",
+			runtime_checks: { required_imports: [] },
 			duration_seconds: 0,
 			log_path: "build.log",
 			failures: [],
 		});
+		const modelRuntime = spawnSync(
+			"python3",
+			[
+				join(PACKAGE_DIR, "scripts", "materialize_model_runtime.py"),
+				"--run-dir",
+				runDir,
+				"--input",
+				join(runDir, "artifacts", "build_env_draft.json"),
+				"--produces",
+				join(runDir, "artifacts", "build_env_result.json"),
+			],
+			{ cwd, encoding: "utf-8", env: { ...process.env, SURE_SITE_POLICY: sitePolicy } },
+		);
+		expect(modelRuntime.status, modelRuntime.stderr || modelRuntime.stdout).toBe(0);
 		advance("fetch_weights");
 
 		writeArtifact(runDir, "weights_manifest.json", {
@@ -1078,7 +1160,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 		writeArtifact(runDir, "docker_registry_result.json", {
 			schema: "sure.onboard.docker_registry_result.v2",
 			status: "skipped",
-			reason: "package=none is diagnostic-only",
+			reason: "package=none uses the sealed local Python runtime",
 		});
 		advance("save_artifacts");
 
@@ -1103,6 +1185,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 					load_result: { path: "artifacts/load_result.json" },
 					infer_result: { path: "artifacts/infer_result.json" },
 					contract_result: { path: "artifacts/contract_result.json" },
+					model_runtime_manifest: { path: "artifacts/model_runtime_manifest.json" },
 					sample_output: { path: "artifacts/sample_output.json" },
 					manifest: { path: "artifacts/artifact_manifest.json" },
 				},
@@ -1110,6 +1193,10 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 				optional: {},
 			},
 		};
+		writeFileSync(
+			join(modelArtifacts, "model_runtime_manifest.json"),
+			readFileSync(join(runDir, "artifacts", "model_runtime_manifest.json")),
+		);
 		writeArtifact(runDir, "artifact_manifest.json", manifest);
 		writeJson(join(modelArtifacts, "artifact_manifest.json"), manifest);
 		advance("package_gate");
@@ -1125,7 +1212,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 				container_ready: false,
 				docker_ready: false,
 				registry_ready: false,
-				bundle_ready: false,
+				bundle_ready: true,
 				vc_ready: null,
 			},
 			local: {
@@ -1151,13 +1238,13 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 				"--model-dir",
 				modelDir,
 			],
-			{ encoding: "utf-8" },
+			{ cwd, encoding: "utf-8", env: { ...process.env, SURE_SITE_POLICY: sitePolicy } },
 		);
 		expect(inventory.status, inventory.stderr || inventory.stdout).toBe(0);
 		advance("verdict");
 
 		writeArtifact(runDir, "verdict.json", {
-			status: "partial",
+			status: "passed",
 			model_id: resolved.model_id,
 			model_name: resolved.model_name,
 			package: { profile: "none" },
@@ -1165,7 +1252,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 				local_ready: true,
 				docker_ready: false,
 				registry_ready: false,
-				bundle_ready: false,
+				bundle_ready: true,
 				vc_ready: null,
 			},
 			build: { success: true, log_path: "artifacts/build.log" },
@@ -1193,19 +1280,19 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 				"--produces",
 				join(runDir, "artifacts", "deployment_ready.json"),
 			],
-			{ encoding: "utf-8" },
+			{ cwd, encoding: "utf-8", env: { ...process.env, SURE_SITE_POLICY: sitePolicy } },
 		);
 		expect(finalize.status, finalize.stderr || finalize.stdout).toBe(0);
 		const terminal = advance("finalize_model_bundle");
 		expect(terminal.completedUnits).toContain("finalize_model_bundle");
 
 		ctx.point = "pre_finish";
-		ctx.event = { finish: { status: "incomplete" } } as never;
-		const finish = preFinish(ctx);
+		ctx.event = { finish: { status: "success" } } as never;
+		const finish = withEnv("SURE_SITE_POLICY", sitePolicy, () => preFinish(ctx));
 		const patch = statePatch(finish);
 		expect(finish.ok, finish.repair).toBe(true);
-		expect(patch.phase?.status).toBe("incomplete");
-	});
+		expect(patch.phase?.status).toBe("success");
+	}, 30_000);
 });
 
 // Regression guard for the --kind routing bug: runGateScript injected
@@ -1394,6 +1481,11 @@ describe("sure_onboard new alignment gates", () => {
 			package_profile: "none",
 			steps: [
 				{ state: "BUILD_ENV", action: "create uv env", command: "uv sync" },
+				{
+					state: "BUILD_ENV",
+					action: "seal Model Python runtime",
+					command: "python3 scripts/materialize_model_runtime.py --input build_env_draft.json",
+				},
 				{ state: "VALIDATE_IMPORT", action: "run documented import command" },
 			],
 			blockers: [],
@@ -2460,7 +2552,7 @@ describe("sure_onboard new alignment gates", () => {
 		expect(contract.io_contract_satisfied).toBe(true);
 	});
 
-	it("advances package_gate for package=none when local_ready is true", () => {
+	it("blocks package=none until the Model Runtime is sealed", () => {
 		const { ctx, runDir } = freshCtx("package-gate-none-pass");
 		const modelDir = seedLocalReadyArtifacts(runDir);
 		seedModelInputResolved(runDir, { model_dir: modelDir });
@@ -2503,9 +2595,8 @@ describe("sure_onboard new alignment gates", () => {
 			},
 		});
 		const result = postToolResult(ctx);
-		expect(result.ok).toBe(true);
-		const checkpoint = (result.state_patch as { checkpoint?: { data: CheckpointData } }).checkpoint;
-		expect(checkpoint?.data.currentUnit).toBe("write_runtime_inventory");
+		expect(result.ok).toBe(false);
+		expect(result.repair).toContain("Model Runtime sealing");
 	});
 
 	it("blocks package_gate when local_ready is claimed without an artifact manifest", () => {
@@ -2637,7 +2728,7 @@ describe("sure_onboard artifact manifest structure compatibility", () => {
 		expect(result.repair).toContain("not permitted");
 	});
 
-	it("adopts an upstream reference model into a harness-local package-gated model dir", () => {
+	it("adopts an upstream reference model without claiming a sealed Python runtime", () => {
 		const { cwd } = preStartCtx("adopt-reference-model", "");
 		const referenceDir = join(cwd, "reference", "models", "AdoptedModel");
 		const targetDir = join(cwd, "sure", "models", "AdoptedModel");
@@ -2693,7 +2784,6 @@ describe("sure_onboard artifact manifest structure compatibility", () => {
 
 		for (const [script, artifact] of [
 			["check_artifact_manifest.py", "artifact_manifest.json"],
-			["check_package_gate.py", "package_gate.json"],
 			["check_verdict.py", "verdict.json"],
 		]) {
 			const gate = spawnSync(
@@ -2709,6 +2799,19 @@ describe("sure_onboard artifact manifest structure compatibility", () => {
 			);
 			expect(gate.status, gate.stderr || gate.stdout).toBe(0);
 		}
+		const packageGate = spawnSync(
+			"python3",
+			[
+				join(PACKAGE_DIR, "scripts", "check_package_gate.py"),
+				"--run-dir",
+				targetDir,
+				"--produces",
+				join(targetDir, "artifacts", "package_gate.json"),
+			],
+			{ encoding: "utf-8" },
+		);
+		expect(packageGate.status).not.toBe(0);
+		expect(packageGate.stderr).toContain("Model Runtime sealing");
 	});
 
 	it("stages run artifacts into the model directory and writes a gate-valid preferred manifest", () => {
@@ -2727,7 +2830,7 @@ describe("sure_onboard artifact manifest structure compatibility", () => {
 			repo_url: "https://modelscope.cn/models/Qwen/Qwen3-ASR-1.7B",
 			task_type: "asr",
 			deployment_type: "local",
-			package_profile: "none",
+			package_profile: "docker-local",
 		});
 		for (const name of [
 			"context_selection.json",
@@ -2845,10 +2948,10 @@ describe("sure_onboard verdict structure compatibility", () => {
 		expect(proc.status, proc.stderr || proc.stdout).toBe(0);
 	});
 
-	it("rejects a success verdict for a non-registry local package", () => {
+	it("rejects a success verdict for diagnostic docker-local packaging", () => {
 		const { ctx, runDir } = freshCtx("verdict-local-ready-pass");
 		const modelDir = seedLocalReadyArtifacts(runDir);
-		seedModelInputResolved(runDir, { model_dir: modelDir });
+		seedModelInputResolved(runDir, { model_dir: modelDir, package_profile: "docker-local" });
 		seedCheckpoint(runDir, {
 			currentUnit: "verdict",
 			completedUnits: [
@@ -2876,7 +2979,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		writeArtifact(runDir, "package_gate.json", {
 			schema: "sure.onboard.package_gate.v2",
 			status: "passed",
-			package_profile: "none",
+			package_profile: "docker-local",
 			model_dir: modelDir,
 			artifact_manifest_path: join(runDir, "artifacts", "artifact_manifest.json"),
 			readiness: {
@@ -2890,7 +2993,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		});
 		writeArtifact(runDir, "verdict.json", {
 			status: "passed",
-			package: { profile: "none" },
+			package: { profile: "docker-local" },
 			readiness: {
 				local_ready: true,
 				docker_ready: false,
@@ -2914,7 +3017,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		});
 		const result = postToolResult(ctx);
 		expect(result.ok).toBe(false);
-		expect(result.repair).toContain("local_only");
+		expect(result.repair).toContain("diagnostic-only");
 	});
 
 	it("accepts verdict artifact paths relative to the repository root", () => {

--- a/packages/coding-agent/test/sure/site-loader.test.ts
+++ b/packages/coding-agent/test/sure/site-loader.test.ts
@@ -37,6 +37,26 @@ describe("validateSitePolicy execution.vc_default_partition", () => {
 	});
 });
 
+describe("validateSitePolicy execution.local_runtimes", () => {
+	it("keeps omitted policies container-only", () => {
+		const result = validateSitePolicy(policy({ execution: { surfaces: ["local"] } }));
+		expect(result.execution.local_runtimes).toEqual(["container"]);
+	});
+
+	it("returns explicitly permitted Python and container runtimes", () => {
+		const result = validateSitePolicy(
+			policy({ execution: { surfaces: ["local"], local_runtimes: ["python", "container"] } }),
+		);
+		expect(result.execution.local_runtimes).toEqual(["python", "container"]);
+	});
+
+	it("rejects an unsupported local runtime", () => {
+		expect(() =>
+			validateSitePolicy(policy({ execution: { surfaces: ["local"], local_runtimes: ["virtualenv"] } })),
+		).toThrow(/execution\.local_runtimes/);
+	});
+});
+
 describe("validateSitePolicy absolute paths", () => {
 	it("rejects a path that does not start with a slash", () => {
 		expect(() =>

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,8 +1,8 @@
 {
   "schema": "sure.public_export_manifest.v1",
-  "source_commit": "338f7a700563007e2ab6f7b0f9cff0d1ed099fd4",
+  "source_commit": "4e058840e661c6347094e0eb5af89152999d021f",
   "source_dirty": false,
-  "tree_sha256": "ddb7a97e72957c0ca209d3dafd200e3c40e9e4501d9baaa7a3155b7fae6f729a",
+  "tree_sha256": "a3139d951ddfd247b0eb6d8379bc17b8461d09b9ede38cf00b300135d03d1937",
   "files": [
     {
       "path": ".github/workflows/public-ci.yml",
@@ -47,7 +47,7 @@
     {
       "path": "README.md",
       "type": "file",
-      "sha256": "30e9d64b51bb9ea4d5def953ccf0210c49b3396e480c33fb81f6caeb015f71b8"
+      "sha256": "cb870658d2c82af2b3db0c72e8dfb3373f853567bbc179be1b6dcdf867ade9fc"
     },
     {
       "path": "SECURITY.md",
@@ -62,7 +62,7 @@
     {
       "path": "config/site.example.yaml",
       "type": "file",
-      "sha256": "b473b676724abef89ed4d7a50c87825be521d7e287883bcdb27ba5d67a2bf4bb"
+      "sha256": "9e1faa1ad515aae62fcca437ce1d02665ec323783cb69769478b1f365e9c0454"
     },
     {
       "path": "docs/evaluation_engine.md",
@@ -72,7 +72,7 @@
     {
       "path": "docs/site-configuration.md",
       "type": "file",
-      "sha256": "8bf5ca23c2e8137019877dd2f397866c2e3ae6118293d62fd713eeef0cba0a3d"
+      "sha256": "1663adb9a8d8ddcc7694bdab2c34befab3a877585269f87090497a22ef8aecb1"
     },
     {
       "path": "fixtures/README.md",
@@ -4642,7 +4642,7 @@
     {
       "path": "packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts",
       "type": "file",
-      "sha256": "dc3882c48cdc9802a5903626e66707c6c987459f34c1be15448373df8048fafb"
+      "sha256": "8eb0adde38e5116a5130f3a177e806a3ecb5fdf6214a3307f61f0633067827bc"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-onboard-terminal.test.ts",
@@ -4737,7 +4737,7 @@
     {
       "path": "packages/coding-agent/test/sure/site-loader.test.ts",
       "type": "file",
-      "sha256": "bdf32a5b6f69c054f42cc74e302280a5c908db3abc38d45dba760fb8b461d5f4"
+      "sha256": "05e338ac533ebb9c482f81c0600bc68514432a4afe77d7c3c9e7e5c099d21ea5"
     },
     {
       "path": "packages/coding-agent/test/syntax-highlight.test.ts",
@@ -5590,6 +5590,21 @@
       "sha256": "4f9cb37f8bd4a4b8c60237b4832b82d581b432ac4796f115dc327889df0407ca"
     },
     {
+      "path": "sure/runtime/model/__init__.py",
+      "type": "file",
+      "sha256": "a93a4c3de5fbda6b925f93be6190c6879403bde1bab689f7ae8123c9fb319e42"
+    },
+    {
+      "path": "sure/runtime/model/bootstrap.py",
+      "type": "file",
+      "sha256": "3d3eb4e6c028347f559e46effae678a54665e309854746fffa5446d84a829b65"
+    },
+    {
+      "path": "sure/runtime/model/test_bootstrap.py",
+      "type": "file",
+      "sha256": "c8b8f516e8d91fce221ba0f00351ddd3ff33a730eff51640429032714d8a4e31"
+    },
+    {
       "path": "sure/runtime/runtime_binding.schema.json",
       "type": "file",
       "sha256": "232f6c87d785ae35c33b3a196dcb2e2397daeed7239aa3befa307b773c4b7ded"
@@ -5607,27 +5622,27 @@
     {
       "path": "sure/site/loader.py",
       "type": "file",
-      "sha256": "eafb7eeb31a8f326f51563264e6091bcf0865a82166689c86d815ba237aef21c"
+      "sha256": "e27ef27cb7b3e5ec6c2f6261a9d9cedb65e4080df81e9867aec2214d8be529dc"
     },
     {
       "path": "sure/site/loader.ts",
       "type": "file",
-      "sha256": "ab704b6fed3a91a306398433d36361c9cee6cdcfc5c970de4173ab727f0ab19e"
+      "sha256": "5fd432eb4ff6ed1081927d16b9d3a20a75a814f1944c48b28d3845db9a5b017b"
     },
     {
       "path": "sure/site/policy.schema.json",
       "type": "file",
-      "sha256": "1c8678d4a12cac7e73a10d910073b52f01e2d43c95e8368bfab78848d86edc26"
+      "sha256": "10baa836e26a8f5386ec7c3d0387892744072f28d4b731c1b1de8d0d98d2900c"
     },
     {
       "path": "sure/site/public.example.yaml",
       "type": "file",
-      "sha256": "b473b676724abef89ed4d7a50c87825be521d7e287883bcdb27ba5d67a2bf4bb"
+      "sha256": "9e1faa1ad515aae62fcca437ce1d02665ec323783cb69769478b1f365e9c0454"
     },
     {
       "path": "sure/site/test_loader.py",
       "type": "file",
-      "sha256": "e9cd231fe17896a9777cef6c8b7dc8fd5b37b693ce62c042a640eaf5440e7c8b"
+      "sha256": "b22af9b94f1b8c966aa9a1c025ad0cfe9210dcedd69225ff6fea37f35b597e6f"
     },
     {
       "path": "sure/skills/README.md",
@@ -5637,7 +5652,7 @@
     {
       "path": "sure/skills/sure_eval/SKILL.md",
       "type": "file",
-      "sha256": "3e74294e80267774f6aed3d27e28aa7090bd380aa00e9a6afd28b3a090e3f705"
+      "sha256": "0b19de1b9ea2f5d84414f8168b0021d8e3dc8459f143753c033da1a0e5d6390c"
     },
     {
       "path": "sure/skills/sure_eval/config/protocols.yaml",
@@ -5662,7 +5677,7 @@
     {
       "path": "sure/skills/sure_eval/hooks/state-machine.ts",
       "type": "file",
-      "sha256": "7ec00303576f01e75514ab35331086d9fd9b0d163da7e9ac1d5e63ea09e9e52c"
+      "sha256": "545855e2af19f0ecd94c0d487531f6ce6ed2d872a674ce6c1b742cefcecb9f28"
     },
     {
       "path": "sure/skills/sure_eval/hooks/validate.ts",
@@ -5727,7 +5742,7 @@
     {
       "path": "sure/skills/sure_eval/references/contracts/main_agent_tool_readiness_unit.md",
       "type": "file",
-      "sha256": "94c6d40da6ea43fbaff20ff6ad9ada90709c3cf7abf4166f802722e6fea3baf2"
+      "sha256": "f8faea9652882a4b52a979cc4ab540f290eef10bff2981cebe25949d040e5339"
     },
     {
       "path": "sure/skills/sure_eval/references/contracts/main_agent_worked_example.md",
@@ -5807,12 +5822,17 @@
     {
       "path": "sure/skills/sure_eval/schemas/execution_result.schema.json",
       "type": "file",
-      "sha256": "4b8980c3bb2b968614edc2a3a9208487abb72be8fb534fb23f1bf6cc55a4fea6"
+      "sha256": "82bafd24ad9606d1ab1862228287cf4a20854a3fa5bd00be6f62d9a560251727"
     },
     {
       "path": "sure/skills/sure_eval/schemas/execution_surface.schema.json",
       "type": "file",
       "sha256": "b3c9e2b646df587f9b66c6df71d149682a726f9c76d55fe98f4f5068397fa5ba"
+    },
+    {
+      "path": "sure/skills/sure_eval/schemas/execution_surface_v2.schema.json",
+      "type": "file",
+      "sha256": "e0c8819e913b2badfa8e248e16bc1387377cc931a451a9bbe9a8a61b5e29550a"
     },
     {
       "path": "sure/skills/sure_eval/schemas/inference_protocol.schema.json",
@@ -5837,7 +5857,7 @@
     {
       "path": "sure/skills/sure_eval/schemas/run_report.schema.json",
       "type": "file",
-      "sha256": "764d5b1984ba4b71ec20266b41e75bcb15baaf42d62c5ffc696210cedf65d6a6"
+      "sha256": "f3aa2d9d0d679d0d1dbd76b30b2df008a5124b474f49c726c593a7f52c72ddb4"
     },
     {
       "path": "sure/skills/sure_eval/schemas/script_routing.schema.json",
@@ -5852,7 +5872,7 @@
     {
       "path": "sure/skills/sure_eval/schemas/submit_result.schema.json",
       "type": "file",
-      "sha256": "dc920f09b94eaf01b66fae244a5dce75e1fbe459db018e9c9b15bbcd2040eed8"
+      "sha256": "4598658f1659190a08672160ae3498b8e53e9918cf1c6e226c790f32b3422468"
     },
     {
       "path": "sure/skills/sure_eval/schemas/task_classification.schema.json",
@@ -5872,7 +5892,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/check_execution_surface_compliance.py",
       "type": "file",
-      "sha256": "d03bf40ae5ce55a3138e35ed7613748d4feff002225fcd1b7377e33c3a3c1926"
+      "sha256": "e9503e9df0ca97ef6c9863eb4a95420eeb38ed6306acd4ba96dd299ef7886a6f"
     },
     {
       "path": "sure/skills/sure_eval/scripts/check_main_flow_reference.py",
@@ -5882,7 +5902,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/check_run_report.py",
       "type": "file",
-      "sha256": "f6e528f4e55141b9daae3bd52e1e8359f99fd5197cd1b28ccb57ccdfb3c28c1f"
+      "sha256": "62a3677a7ede227bcc4ee7fe4a153b615d8e0a9ef2030a6129daeee5b6d7ebdd"
     },
     {
       "path": "sure/skills/sure_eval/scripts/check_script_routing.py",
@@ -5902,7 +5922,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/container_execution.py",
       "type": "file",
-      "sha256": "5c98ba7468d1f0e70f0ed38931da4da753613ed6ccdf32776685d89005dd6dfc"
+      "sha256": "7c829972c9e28fa5b092693eb647af812d12f93ef446e5f2cb020fbf664550f4"
     },
     {
       "path": "sure/skills/sure_eval/scripts/convert_sure_to_jsonl.py",
@@ -5917,7 +5937,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/deployment_binding.py",
       "type": "file",
-      "sha256": "7e914c8e5113ab4a4947464020584fa68a11a94eb94d4cdb8289b1c8f0b52275"
+      "sha256": "c3d74dc377ca7555710a1fc14c415c55221f7a9fba5d8af519846924de769bd0"
     },
     {
       "path": "sure/skills/sure_eval/scripts/download_sure_data.py",
@@ -5927,7 +5947,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/evaluate_predictions.py",
       "type": "file",
-      "sha256": "0802f480f0e198d5664c7aad6d8f6207376e31aab180cdbd921258c48ba85c3b"
+      "sha256": "1044f89b8b6736110fe240fa9fad90f25e64812df9c3190565cfbfc085076f9f"
     },
     {
       "path": "sure/skills/sure_eval/scripts/evaluation_capabilities.py",
@@ -5952,7 +5972,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/generate_predictions_via_server.py",
       "type": "file",
-      "sha256": "ed0740cc8d4a014f37be55356353c792ff388749bb724e8b3765b3435a59082e"
+      "sha256": "c00300cf4affd70c10e824f8b6d7a4c8aea7386b4aa5747fbcdc78e8f7a77fe4"
     },
     {
       "path": "sure/skills/sure_eval/scripts/generate_report_snapshot.py",
@@ -6000,6 +6020,11 @@
       "sha256": "9ff543e8a4548653fc5b26c1f08392761bef275173f199eec1d8bd8a49e622fe"
     },
     {
+      "path": "sure/skills/sure_eval/scripts/python_execution.py",
+      "type": "file",
+      "sha256": "434d51641f89bb2178d1f0063902c643f2f5ee36d9edc4e193bc119227f68b9d"
+    },
+    {
       "path": "sure/skills/sure_eval/scripts/recover_dnsmos_segment.py",
       "type": "file",
       "sha256": "a4fedf22f99eb0c2f52ec91d7048a899ca8546298e2a57408593ed268a614cc1"
@@ -6012,7 +6037,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/resolve_eval_input.py",
       "type": "file",
-      "sha256": "b7dd377d95d1e32a47158131477029a3de195556004b8188b1c440e970065244"
+      "sha256": "500f64e9fcf0bc9447b365341c9ec30f8090c1fca0ebf79484f9db59c742faaf"
     },
     {
       "path": "sure/skills/sure_eval/scripts/resolve_evaluation_engine.py",
@@ -6037,7 +6062,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/run_local_execution.py",
       "type": "file",
-      "sha256": "008dbe4152b7fe073532f031a8c15e019bd31b7da3055d2a58e9bd16b31686fc"
+      "sha256": "254e42ce8fd89ea05ad7743482e485d9e0358d33e57da0b15064b5225a27044d"
     },
     {
       "path": "sure/skills/sure_eval/scripts/run_main_flow_parity_validation.py",
@@ -6057,7 +6082,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/run_smoke.py",
       "type": "file",
-      "sha256": "c449e69be017baab944d94aa0b809c7aa850009d0c83c3f3fe4058e6e22bdfd3"
+      "sha256": "38082d475daca699ebc8d62f29ef9393a6015d2ee2e1174d06f871653d892abb"
     },
     {
       "path": "sure/skills/sure_eval/scripts/run_sure_evaluation.py",
@@ -6552,7 +6577,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/templates/main_agent_execution_surface.json",
       "type": "file",
-      "sha256": "9df7112d500ee36ddab5a70b0d6fd9be99b4c0b0bbbcac98f2bab0f2265d4144"
+      "sha256": "6b29fb4f8ae07f95f786582dbec52a7cb1e423eb865b5806b2793d530e57a6d2"
     },
     {
       "path": "sure/skills/sure_eval/scripts/templates/main_agent_plan.json",
@@ -6627,12 +6652,12 @@
     {
       "path": "sure/skills/sure_eval/scripts/test_deployment_binding.py",
       "type": "file",
-      "sha256": "2a1b3329023b5dee5e9b2f8d207f99fe07374f5604eb5df2f8f2fe2ec654f525"
+      "sha256": "704d2e9ac214f690fead8b962b10a6ff32ee7211340e54af81286d292e83d25a"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_eval_input_policy.py",
       "type": "file",
-      "sha256": "d5ad84a94480b8ba7fded6a8c13e40a98632d619dd72096c9ac06e7e73ca0d59"
+      "sha256": "4a70623c466baaa8b9310de46c15ccf1c5990fcd8c0bcd10cdb0b1b2f0f104ce"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_evaluation_runtime.py",
@@ -6642,7 +6667,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/test_execution_surface_checks.py",
       "type": "file",
-      "sha256": "84fae27a6883aa36fd202a0dfc112bf2d4e581d545af26902e516ff4a8ce381a"
+      "sha256": "55fb6b5e6f099b320caee25cc04e175ccb570f6441360281f26b1c7a1d9665d0"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_external_bridge.py",
@@ -6698,6 +6723,16 @@
       "path": "sure/skills/sure_eval/scripts/test_protocol_provenance.py",
       "type": "file",
       "sha256": "58b0ba4b8e9049ea6bcf842903dcc574c20ff11c0199b298d8f8a376fcf92632"
+    },
+    {
+      "path": "sure/skills/sure_eval/scripts/test_python_deployment_binding.py",
+      "type": "file",
+      "sha256": "e61703c183663c0e96f1fa26923d080f6032084ea32c9cefef3c8fbe92097528"
+    },
+    {
+      "path": "sure/skills/sure_eval/scripts/test_python_execution.py",
+      "type": "file",
+      "sha256": "6abbb820abb524e3109992fe3b161268dbc337f6ab67ec6aaaa2133df572ceed"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_report_provenance.py",
@@ -6762,7 +6797,7 @@
     {
       "path": "sure/skills/sure_eval/scripts/vc_check.py",
       "type": "file",
-      "sha256": "4c02b757436bc6ace9b4eeab082148ac465fad1fff1ff90a6bc7c3f192c54e1c"
+      "sha256": "3dda57f320b271a9f56004d93b87b25fe5bd95d3f307e185d3d89d253d963111"
     },
     {
       "path": "sure/skills/sure_eval/scripts/wait_vc_execution.py",
@@ -6772,7 +6807,7 @@
     {
       "path": "sure/skills/sure_eval/sure.skill.json",
       "type": "file",
-      "sha256": "b55a84d05c80c188518d159b44da8cf0aeda2447450d07159376fd5e1554c7e9"
+      "sha256": "847686a058bb3b58f7cb060dc5a69a09d448d4361d525cfbba98b7af5bb583ce"
     },
     {
       "path": "sure/skills/sure_feed/SKILL.md",
@@ -6992,7 +7027,7 @@
     {
       "path": "sure/skills/sure_onboard/SKILL.md",
       "type": "file",
-      "sha256": "0871ffb9fa6791e7cf95650d56bde2584192d032fd6e2c65b258286ae4fad291"
+      "sha256": "e4287fc4eea9c01d86be6c9ca78cd60f5031ced165605c0819e251291e42103d"
     },
     {
       "path": "sure/skills/sure_onboard/examples/minimal-input.json",
@@ -7007,12 +7042,12 @@
     {
       "path": "sure/skills/sure_onboard/hooks/index.ts",
       "type": "file",
-      "sha256": "a471cda275ead2bb44443a76edda08ab6720fb4815e937467f6f82f5308e2cdb"
+      "sha256": "7da8b702513f644fd8b8d345179988c0fff9b4fb4b2f5df3e17d53743457708b"
     },
     {
       "path": "sure/skills/sure_onboard/hooks/state-machine.ts",
       "type": "file",
-      "sha256": "cc33d93bc47a005191ea2e5d969c6abd8a610c5316aca8c25374b4669834b182"
+      "sha256": "f92a332d65a07dcb708b19045970f35014416c3cc4e9a6efacde839ddfb77cbd"
     },
     {
       "path": "sure/skills/sure_onboard/hooks/validate.ts",
@@ -7022,7 +7057,7 @@
     {
       "path": "sure/skills/sure_onboard/references/AGENTS.md",
       "type": "file",
-      "sha256": "76c16f5eb8ba464af6e9e7914b75118dee6af52a2662d095e4a7f393473e567b"
+      "sha256": "511dc9600e9a7fd06f4857fac23654f59dd392d187412e27ab8e0f41a77e9d8a"
     },
     {
       "path": "sure/skills/sure_onboard/references/contracts/fixture_policy.md",
@@ -7047,12 +7082,12 @@
     {
       "path": "sure/skills/sure_onboard/references/experience_loss_register.md",
       "type": "file",
-      "sha256": "1a91bb82468d06f1d2322a41b19ef9ac075c7cf1a163d5fcc5f4d77c49ff1e9e"
+      "sha256": "bf298ba7a730deaf41be0e2d89cb073510062ffb51a04b5da53f255bc55159ea"
     },
     {
       "path": "sure/skills/sure_onboard/references/memory/COMMON.md",
       "type": "file",
-      "sha256": "a042a550c059f0d60da4e76d33cc24e0a3f3f60b61c1c0ab6235db983273b3f0"
+      "sha256": "9a7d84a0f2789b4bb54a19b3d86022f4fd18e80774339a28be7b9beab938833b"
     },
     {
       "path": "sure/skills/sure_onboard/references/memory/README.md",
@@ -7182,7 +7217,7 @@
     {
       "path": "sure/skills/sure_onboard/references/playbooks/env_uv.md",
       "type": "file",
-      "sha256": "1173b7aef2b8e26cb106c78ce9c136e50ddaa0d70abee0b913c78a9951753cf3"
+      "sha256": "0c33940ae61b6c7888e1596576dc8160e1c42bc2361d79ab8e1fdca8ad657160"
     },
     {
       "path": "sure/skills/sure_onboard/references/playbooks/failure_taxonomy.md",
@@ -7207,7 +7242,7 @@
     {
       "path": "sure/skills/sure_onboard/references/policies/backend_selection.md",
       "type": "file",
-      "sha256": "45b0323c8bc85434ad4aa427f4788255577cc468b0aec05331de969f55b3978e"
+      "sha256": "fa4497590d80e77598a1789c39938249cd9f2034963f15ab03eb7397034e676c"
     },
     {
       "path": "sure/skills/sure_onboard/references/policies/constitution.md",
@@ -7302,7 +7337,7 @@
     {
       "path": "sure/skills/sure_onboard/schemas/build_env_result.schema.json",
       "type": "file",
-      "sha256": "4f98c4994e43601453150c256016bc1898703026c22d7bc911a2a5925c814d46"
+      "sha256": "08dbd5b3662591a7473dd4ee67660a701d80ac65a200df2b9fcdbe9b245746ee"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/build_plan.schema.json",
@@ -7328,6 +7363,16 @@
       "path": "sure/skills/sure_onboard/schemas/deployment_ready.schema.json",
       "type": "file",
       "sha256": "78d9673a9e21608704a9847ab8ea8fc3d5bdc7ec1353d9fb3d1c93eae04b7b4d"
+    },
+    {
+      "path": "sure/skills/sure_onboard/schemas/deployment_ready_output.schema.json",
+      "type": "file",
+      "sha256": "d19b5e825d129313d1dfbcfdca4dbd9fa5521c343d5e16cdb7894510bfa9dc63"
+    },
+    {
+      "path": "sure/skills/sure_onboard/schemas/deployment_ready_v2.schema.json",
+      "type": "file",
+      "sha256": "53cde4a687a1b30502e24f25714ad6881fb681779bbe6fdc187ecc46014c3914"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/docker_build_result.schema.json",
@@ -7377,7 +7422,7 @@
     {
       "path": "sure/skills/sure_onboard/schemas/package_gate.schema.json",
       "type": "file",
-      "sha256": "b3ac1cc764cd0f6b655254f8c8b775c28c251b6ae4c125952118fee9ef2091b1"
+      "sha256": "3b756c600a670c965cc0166f0ff18715c8c59821616146ebdbf732f93cd90c10"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/repo_summary.schema.json",
@@ -7387,7 +7432,7 @@
     {
       "path": "sure/skills/sure_onboard/schemas/runtime_inventory.schema.json",
       "type": "file",
-      "sha256": "e753f89d820512cb4c8591d5092f5299dc866ae4d86c38193ccd49bb186df589"
+      "sha256": "fbd7cb3ba8f10e41aa5d784f12695074ea584d841e3e0c187f1f443167145e7d"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/spec_validation.schema.json",
@@ -7422,7 +7467,7 @@
     {
       "path": "sure/skills/sure_onboard/scripts/check_build_plan.py",
       "type": "file",
-      "sha256": "ceac6930f5ca78c312823370685aa76fd23b0b3570c400db33ec1a682954ece5"
+      "sha256": "009ae25b42f2cdb0772f2f705f40688e306d27a3cb7cbdb8524357aa44662ee6"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_container_package.py",
@@ -7432,7 +7477,7 @@
     {
       "path": "sure/skills/sure_onboard/scripts/check_env.py",
       "type": "file",
-      "sha256": "97b16d95cc926075b5160143ee654ef61991b6d49a56169471b141dfe7e86402"
+      "sha256": "52ccb8bb39c205a1ce6c5a08e3408e730651d704982c7c31a5154164d7a77b38"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_env_compat.py",
@@ -7447,7 +7492,7 @@
     {
       "path": "sure/skills/sure_onboard/scripts/check_finalized_bundle.py",
       "type": "file",
-      "sha256": "bc203d131b26d374f58621970b00022691061bbf55e7c5de5bee7805ddca7219"
+      "sha256": "ec7308d00e2d6f81e12585214d827f31c82069749c4cd91508d97ab92b287096"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_fixture.py",
@@ -7462,12 +7507,12 @@
     {
       "path": "sure/skills/sure_onboard/scripts/check_package_gate.py",
       "type": "file",
-      "sha256": "5d6782707b5ae496e5e2c493dc3c90d704499f4af44cd282fa50da97ba32aaf5"
+      "sha256": "0b8cd925832a7e38242a82755addf9e5beaf6d522118b940aa2ce603399c8196"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_runtime_inventory.py",
       "type": "file",
-      "sha256": "3106f020aeaa217b1d31b571dc7a961a3405d96e63088382ee8af8b2fe1eb277"
+      "sha256": "93e5d87f43588e9f31d6311740fda3d402c025f7d819e3577710f38de4c79757"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_spec.py",
@@ -7477,7 +7522,7 @@
     {
       "path": "sure/skills/sure_onboard/scripts/check_verdict.py",
       "type": "file",
-      "sha256": "879d7996d68133c1f9584908bf41b0bc9009f182ae2541b956aa2f53a70ef91d"
+      "sha256": "31bfb1ada4ddd6d0efa516081875ce15bb814ce4f347e553855ce1943b41a5cc"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_weights.py",
@@ -7497,7 +7542,12 @@
     {
       "path": "sure/skills/sure_onboard/scripts/finalize_model_bundle.py",
       "type": "file",
-      "sha256": "6057eacb87e474cd4255c95f0793dfdeea3ff2ddd679eb890d983ceecc38ba67"
+      "sha256": "ff774620d068ddf926082f574370caf4896db3756b43436754c48c332b120418"
+    },
+    {
+      "path": "sure/skills/sure_onboard/scripts/materialize_model_runtime.py",
+      "type": "file",
+      "sha256": "d028edd747b260268fa8de8856876e572b48b6df54067480184df3253f6db78e"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/materialize_onboard_inputs.py",
@@ -7522,7 +7572,7 @@
     {
       "path": "sure/skills/sure_onboard/scripts/stage_model_artifacts.py",
       "type": "file",
-      "sha256": "8a0a2d9e7693355fb8f288f305a1c43ebc606782354ba6729864a3edf303df21"
+      "sha256": "8f35bc9137b09974907b5da871d15e93dc3a8106c9bf6597e594163fb859fddb"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/sure_eval/__init__.py",
@@ -7622,12 +7672,22 @@
     {
       "path": "sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py",
       "type": "file",
-      "sha256": "647007af40a56682f7c2112911903cadc06caf40385f37a7da2d69ac27e53037"
+      "sha256": "0371ccc67bd985ea5d2f020962789bcc426fb27927de2bd60e906ee7696b1e8f"
+    },
+    {
+      "path": "sure/skills/sure_onboard/scripts/test_model_runtime.py",
+      "type": "file",
+      "sha256": "668e4013e37368a641d01f9cdc7c764ed5dad62ceb586d3f9d232ce80d4e23ba"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/test_model_runtime_env.py",
       "type": "file",
       "sha256": "03dbddf715eba2e8244d81505b6521064b2f2df01bc71fa13b9625997b2f97d6"
+    },
+    {
+      "path": "sure/skills/sure_onboard/scripts/test_python_delivery_contract.py",
+      "type": "file",
+      "sha256": "752c11a666c4d17e42adf4efce2e979242eefca76288c7b61f5837a9dc567e72"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/test_run_validate_paths.py",
@@ -7647,12 +7707,12 @@
     {
       "path": "sure/skills/sure_onboard/scripts/write_runtime_inventory.py",
       "type": "file",
-      "sha256": "acf142624ede6b90438226a95340ae0f550e4b04fb5ff8c6ea42b2f097d9e1c1"
+      "sha256": "fc014f4e7f6248c31e2f8c7da165ea26e53181cd787a873f66ee618952a482c9"
     },
     {
       "path": "sure/skills/sure_onboard/sure.skill.json",
       "type": "file",
-      "sha256": "f8341caf1667a6e88ccb6f3b8d07f4a0b44cf916d65d8f11ca4297f511043a0e"
+      "sha256": "dedebac8c2b8a41a7e03d35b570ae5930a5207c1947bf8d1f98fce68ec3b44b9"
     },
     {
       "path": "sure/skills/sure_reval/SKILL.md",

--- a/sure/runtime/model/__init__.py
+++ b/sure/runtime/model/__init__.py
@@ -1,0 +1,1 @@
+"""Shared Model Python runtime contracts."""

--- a/sure/runtime/model/bootstrap.py
+++ b/sure/runtime/model/bootstrap.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Materialize and verify content-addressed Model Python runtimes."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "sure.model.runtime.manifest.v1"
+MATERIALIZATION_VERSION = 1
+MANIFEST_NAME = "runtime-manifest.json"
+LOCK_NAME = "requirements.lock"
+PACKAGES_NAME = "installed-packages.txt"
+
+
+class ModelRuntimeError(RuntimeError):
+    """The selected Model Python runtime is missing or invalid."""
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def manifest_sha256(manifest: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ModelRuntimeError(f"invalid Model Runtime manifest {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ModelRuntimeError(f"Model Runtime manifest must be a JSON object: {path}")
+    return value
+
+
+def _probe(python: Path) -> dict[str, str]:
+    code = (
+        "import hashlib,json,platform,sys,sysconfig;"
+        "base=__import__('pathlib').Path(sys._base_executable).resolve();"
+        "print(json.dumps({'python_version':platform.python_version(),"
+        "'python_abi':sysconfig.get_config_var('SOABI') or '',"
+        "'python_platform':sysconfig.get_platform(),"
+        "'base_python':str(base),"
+        "'base_python_sha256':hashlib.sha256(base.read_bytes()).hexdigest()}))"
+    )
+    completed = subprocess.run(
+        [str(python), "-I", "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+        raise ModelRuntimeError(f"Model Python probe failed: {detail}")
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise ModelRuntimeError("Model Python probe returned invalid JSON") from exc
+    if not isinstance(value, dict) or not all(isinstance(item, str) and item for item in value.values()):
+        raise ModelRuntimeError("Model Python probe returned incomplete identity data")
+    return value
+
+
+def _runtime_id(lock_sha256: str, probe: dict[str, str]) -> str:
+    identity = {
+        "backend": "uv",
+        "base_python_sha256": probe["base_python_sha256"],
+        "lock_sha256": lock_sha256,
+        "materialization": "uv_venv",
+        "materialization_version": MATERIALIZATION_VERSION,
+        "python_abi": probe["python_abi"],
+        "python_platform": probe["python_platform"],
+        "python_version": probe["python_version"],
+    }
+    digest = hashlib.sha256(
+        json.dumps(identity, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return f"sure-model-python-v{MATERIALIZATION_VERSION}-{digest[:24]}"
+
+
+def _uv_binary(explicit: str | None = None) -> str:
+    candidate = (explicit or os.environ.get("SURE_UV_BIN", "").strip() or shutil.which("uv") or "")
+    if not candidate or not Path(candidate).is_file():
+        raise ModelRuntimeError("uv is required to materialize package=none Model Python runtimes")
+    return str(Path(candidate).resolve())
+
+
+def _run(command: list[str], *, env: dict[str, str], timeout: int) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        command,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
+        raise ModelRuntimeError(f"Model Runtime command failed ({command[1]}): {detail}")
+    return completed
+
+
+def _expected_manifest(
+    *,
+    runtime_id: str,
+    lock_sha256: str,
+    probe: dict[str, str],
+    installed_packages_sha256: str,
+) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "runtime_id": runtime_id,
+        "runtime_type": "model_python",
+        "backend": "uv",
+        "materialization": "uv_venv",
+        "materialization_version": MATERIALIZATION_VERSION,
+        "python_executable": "bin/python",
+        "python_version": probe["python_version"],
+        "python_abi": probe["python_abi"],
+        "python_platform": probe["python_platform"],
+        "base_python_sha256": probe["base_python_sha256"],
+        "lock_file": LOCK_NAME,
+        "lock_sha256": lock_sha256,
+        "installed_packages_file": PACKAGES_NAME,
+        "installed_packages_sha256": installed_packages_sha256,
+    }
+
+
+def verify_runtime(runtime_root: Path, expected: dict[str, Any]) -> dict[str, Any]:
+    """Resolve a portable manifest against one site's runtime root."""
+    if expected.get("schema") != SCHEMA:
+        raise ModelRuntimeError("unsupported Model Runtime manifest schema")
+    runtime_id = str(expected.get("runtime_id") or "")
+    if not re.fullmatch(r"sure-model-python-v1-[0-9a-f]{24}", runtime_id):
+        raise ModelRuntimeError("invalid Model Runtime ID")
+    fixed_fields = {
+        "runtime_type": "model_python",
+        "backend": "uv",
+        "materialization": "uv_venv",
+        "materialization_version": MATERIALIZATION_VERSION,
+        "python_executable": "bin/python",
+        "lock_file": LOCK_NAME,
+        "installed_packages_file": PACKAGES_NAME,
+    }
+    for key, value in fixed_fields.items():
+        if expected.get(key) != value:
+            raise ModelRuntimeError(f"invalid Model Runtime {key}")
+    root = runtime_root.expanduser().resolve()
+    runtime_dir = (root / runtime_id).resolve()
+    try:
+        runtime_dir.relative_to(root)
+    except ValueError as exc:
+        raise ModelRuntimeError("Model Runtime ID escapes the configured runtime root") from exc
+    manifest_path = runtime_dir / MANIFEST_NAME
+    actual = _read_json(manifest_path)
+    if actual != expected:
+        raise ModelRuntimeError("site Model Runtime manifest disagrees with the sealed model binding")
+    lock_path = runtime_dir / LOCK_NAME
+    packages_path = runtime_dir / PACKAGES_NAME
+    python = runtime_dir / str(expected["python_executable"])
+    if not lock_path.is_file() or sha256_file(lock_path) != expected.get("lock_sha256"):
+        raise ModelRuntimeError("site Model Runtime lock hash mismatch")
+    if not packages_path.is_file() or sha256_file(packages_path) != expected.get("installed_packages_sha256"):
+        raise ModelRuntimeError("site Model Runtime package inventory hash mismatch")
+    if not python.is_file() or not os.access(python, os.X_OK):
+        raise ModelRuntimeError(f"site Model Python is missing or not executable: {python}")
+    probe = _probe(python)
+    for key in ("python_version", "python_abi", "python_platform", "base_python_sha256"):
+        if probe.get(key) != expected.get(key):
+            raise ModelRuntimeError(f"site Model Runtime {key} mismatch")
+    return {
+        **actual,
+        "runtime_root": str(runtime_dir),
+        "manifest_path": str(manifest_path),
+        "python_executable_resolved": str(python),
+        "manifest_sha256": manifest_sha256(actual),
+        "probe": probe,
+    }
+
+
+def materialize_runtime(
+    *,
+    runtime_root: Path,
+    source_python: Path,
+    lock_path: Path,
+    uv_bin: str | None = None,
+) -> dict[str, Any]:
+    """Build one immutable uv environment and return its verified contract."""
+    source_python = source_python.expanduser().resolve()
+    lock_path = lock_path.expanduser().resolve()
+    if not source_python.is_file() or not os.access(source_python, os.X_OK):
+        raise ModelRuntimeError(f"selected source Python is missing or not executable: {source_python}")
+    if not lock_path.is_file():
+        raise ModelRuntimeError(f"locked requirements file is missing: {lock_path}")
+    source_probe = _probe(source_python)
+    lock_sha256 = sha256_file(lock_path)
+    runtime_id = _runtime_id(lock_sha256, source_probe)
+    root = runtime_root.expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    runtime_dir = root / runtime_id
+    lock_file = root / f".{runtime_id}.lock"
+
+    with lock_file.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        if runtime_dir.exists():
+            return verify_runtime(root, _read_json(runtime_dir / MANIFEST_NAME))
+
+        staging = Path(tempfile.mkdtemp(prefix=f".{runtime_id}.", dir=root))
+        try:
+            uv = _uv_binary(uv_bin)
+            cache_dir = root / ".uv-cache"
+            cache_dir.mkdir(exist_ok=True)
+            env = os.environ.copy()
+            env.pop("PYTHONHOME", None)
+            env.pop("PYTHONPATH", None)
+            env["UV_CACHE_DIR"] = str(cache_dir)
+            _run(
+                [uv, "venv", "--no-project", "--no-python-downloads", "--python", source_probe["base_python"], str(staging)],
+                env=env,
+                timeout=180,
+            )
+            runtime_python = staging / "bin" / "python"
+            _run(
+                [
+                    uv,
+                    "pip",
+                    "sync",
+                    "--python",
+                    str(runtime_python),
+                    "--require-hashes",
+                    "--strict",
+                    "--allow-empty-requirements",
+                    "--no-python-downloads",
+                    str(lock_path),
+                ],
+                env=env,
+                timeout=1800,
+            )
+            frozen = _run(
+                [uv, "pip", "freeze", "--python", str(runtime_python), "--strict", "--no-python-downloads"],
+                env=env,
+                timeout=180,
+            ).stdout
+            packages_path = staging / PACKAGES_NAME
+            packages_path.write_text(frozen, encoding="utf-8")
+            shutil.copy2(lock_path, staging / LOCK_NAME)
+            runtime_probe = _probe(runtime_python)
+            for key in ("python_version", "python_abi", "python_platform", "base_python_sha256"):
+                if runtime_probe[key] != source_probe[key]:
+                    raise ModelRuntimeError(f"materialized Model Runtime {key} differs from source Python")
+            manifest = _expected_manifest(
+                runtime_id=runtime_id,
+                lock_sha256=lock_sha256,
+                probe=runtime_probe,
+                installed_packages_sha256=sha256_file(packages_path),
+            )
+            (staging / MANIFEST_NAME).write_text(
+                json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+            staging.rename(runtime_dir)
+        except (OSError, subprocess.SubprocessError):
+            raise
+        finally:
+            if staging.exists():
+                shutil.rmtree(staging)
+    return verify_runtime(root, _read_json(runtime_dir / MANIFEST_NAME))

--- a/sure/runtime/model/test_bootstrap.py
+++ b/sure/runtime/model/test_bootstrap.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from bootstrap import ModelRuntimeError, materialize_runtime, verify_runtime
+
+
+class ModelRuntimeBootstrapTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.runtime_root = self.root / "runtimes"
+        self.lock = self.root / "requirements.lock"
+        self.lock.write_text("", encoding="utf-8")
+
+    def test_materializes_and_reuses_content_addressed_uv_runtime(self) -> None:
+        first = materialize_runtime(
+            runtime_root=self.runtime_root,
+            source_python=Path(sys.executable),
+            lock_path=self.lock,
+        )
+        second = materialize_runtime(
+            runtime_root=self.runtime_root,
+            source_python=Path(sys.executable),
+            lock_path=self.lock,
+        )
+
+        self.assertEqual(first["runtime_id"], second["runtime_id"])
+        self.assertEqual(first["manifest_sha256"], second["manifest_sha256"])
+        self.assertTrue(Path(first["python_executable_resolved"]).is_file())
+        manifest = json.loads(Path(first["manifest_path"]).read_text(encoding="utf-8"))
+        self.assertNotIn("runtime_root", manifest)
+        self.assertNotIn(str(self.root), json.dumps(manifest))
+
+    def test_rejects_tampered_package_inventory(self) -> None:
+        contract = materialize_runtime(
+            runtime_root=self.runtime_root,
+            source_python=Path(sys.executable),
+            lock_path=self.lock,
+        )
+        manifest = json.loads(Path(contract["manifest_path"]).read_text(encoding="utf-8"))
+        (Path(contract["runtime_root"]) / "installed-packages.txt").write_text("tampered\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(ModelRuntimeError, "package inventory hash mismatch"):
+            verify_runtime(self.runtime_root, manifest)
+
+    def test_rejects_python_path_outside_content_addressed_runtime(self) -> None:
+        contract = materialize_runtime(
+            runtime_root=self.runtime_root,
+            source_python=Path(sys.executable),
+            lock_path=self.lock,
+        )
+        manifest_path = Path(contract["manifest_path"])
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest["python_executable"] = "../outside-python"
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        (self.runtime_root / "outside-python").symlink_to(sys.executable)
+
+        with self.assertRaisesRegex(ModelRuntimeError, "invalid Model Runtime python_executable"):
+            verify_runtime(self.runtime_root, manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/site/loader.py
+++ b/sure/site/loader.py
@@ -82,10 +82,21 @@ def validate_site_policy(value: Any) -> dict[str, Any]:
     datasets = _mapping(root.get("datasets"), "datasets")
     _reject_unknown(datasets, {"allowed_source_roots", "projection_root"}, "datasets")
     execution = _mapping(root.get("execution"), "execution")
-    _reject_unknown(execution, {"surfaces", "vc_partitions", "vc_partition_priority", "vc_default_partition"}, "execution")
+    _reject_unknown(
+        execution,
+        {"surfaces", "local_runtimes", "vc_partitions", "vc_partition_priority", "vc_default_partition"},
+        "execution",
+    )
     surfaces = _unique_strings(execution.get("surfaces"), "execution.surfaces", absolute=False)
     if any(surface not in {"local", "vc"} for surface in surfaces):
         raise SitePolicyError("execution.surfaces contains an unsupported value")
+    local_runtimes = _unique_strings(
+        execution.get("local_runtimes", ["container"]),
+        "execution.local_runtimes",
+        absolute=False,
+    )
+    if any(runtime not in {"python", "container"} for runtime in local_runtimes):
+        raise SitePolicyError("execution.local_runtimes contains an unsupported value")
 
     policy: dict[str, Any] = {
         "schema": SITE_POLICY_SCHEMA,
@@ -100,7 +111,7 @@ def validate_site_policy(value: Any) -> dict[str, Any]:
         "datasets": {
             "allowed_source_roots": _unique_strings(datasets.get("allowed_source_roots"), "datasets.allowed_source_roots", absolute=True),
         },
-        "execution": {"surfaces": surfaces},
+        "execution": {"surfaces": surfaces, "local_runtimes": local_runtimes},
     }
     if "projection_root" in datasets:
         policy["datasets"]["projection_root"] = _absolute_path(

--- a/sure/site/loader.ts
+++ b/sure/site/loader.ts
@@ -8,6 +8,7 @@ export const SITE_POLICY_ENV = "SURE_SITE_POLICY";
 export const SITE_POLICY_SCHEMA = "sure.site.policy.v1";
 
 export type ExecutionSurface = "local" | "vc";
+export type LocalRuntime = "python" | "container";
 export type SitePolicySource = "environment" | "bundled" | "local";
 
 export interface SitePolicy {
@@ -26,6 +27,7 @@ export interface SitePolicy {
 	};
 	execution: {
 		surfaces: ExecutionSurface[];
+		local_runtimes: LocalRuntime[];
 		vc_partitions?: string[];
 		vc_partition_priority?: Record<string, number>;
 		vc_default_partition?: string;
@@ -105,10 +107,18 @@ export function validateSitePolicy(value: unknown): SitePolicy {
 	const datasets = expectRecord(root.datasets, "datasets");
 	rejectUnknown(datasets, ["allowed_source_roots", "projection_root"], "datasets");
 	const execution = expectRecord(root.execution, "execution");
-	rejectUnknown(execution, ["surfaces", "vc_partitions", "vc_partition_priority", "vc_default_partition"], "execution");
+	rejectUnknown(
+		execution,
+		["surfaces", "local_runtimes", "vc_partitions", "vc_partition_priority", "vc_default_partition"],
+		"execution",
+	);
 	const surfaces = expectUniqueStrings(execution.surfaces, "execution.surfaces", false);
 	if (surfaces.some((surface) => surface !== "local" && surface !== "vc")) {
 		throw new Error("execution.surfaces contains an unsupported value");
+	}
+	const localRuntimes = expectUniqueStrings(execution.local_runtimes ?? ["container"], "execution.local_runtimes", false);
+	if (localRuntimes.some((runtime) => runtime !== "python" && runtime !== "container")) {
+		throw new Error("execution.local_runtimes contains an unsupported value");
 	}
 
 	let network: SitePolicy["network"];
@@ -148,6 +158,7 @@ export function validateSitePolicy(value: unknown): SitePolicy {
 		},
 		execution: {
 			surfaces: surfaces as ExecutionSurface[],
+			local_runtimes: localRuntimes as LocalRuntime[],
 		},
 	};
 	if (datasets.projection_root !== undefined) {

--- a/sure/site/policy.schema.json
+++ b/sure/site/policy.schema.json
@@ -40,6 +40,12 @@
 					"uniqueItems": true,
 					"items": { "enum": ["local", "vc"] }
 				},
+				"local_runtimes": {
+					"type": "array",
+					"minItems": 1,
+					"uniqueItems": true,
+					"items": { "enum": ["python", "container"] }
+				},
 				"vc_partitions": {
 					"type": "array",
 					"minItems": 1,

--- a/sure/site/public.example.yaml
+++ b/sure/site/public.example.yaml
@@ -19,3 +19,6 @@ datasets:
 execution:
   surfaces:
     - local
+  local_runtimes:
+    - python
+    - container

--- a/sure/site/test_loader.py
+++ b/sure/site/test_loader.py
@@ -49,6 +49,25 @@ class VcDefaultPartitionTest(unittest.TestCase):
         self.assertIn("execution.vc_default_partition", str(raised.exception))
 
 
+class LocalRuntimeTest(unittest.TestCase):
+    def test_omitted_local_runtimes_remain_container_only(self) -> None:
+        policy = validate_site_policy(_policy(execution={"surfaces": ["local"]}))
+        self.assertEqual(policy["execution"]["local_runtimes"], ["container"])
+
+    def test_python_runtime_requires_explicit_site_permission(self) -> None:
+        policy = validate_site_policy(
+            _policy(execution={"surfaces": ["local"], "local_runtimes": ["python", "container"]})
+        )
+        self.assertEqual(policy["execution"]["local_runtimes"], ["python", "container"])
+
+    def test_rejects_an_unsupported_local_runtime(self) -> None:
+        with self.assertRaises(SitePolicyError) as raised:
+            validate_site_policy(
+                _policy(execution={"surfaces": ["local"], "local_runtimes": ["virtualenv"]})
+            )
+        self.assertIn("execution.local_runtimes", str(raised.exception))
+
+
 class ContainerRegistryTest(unittest.TestCase):
     def test_container_registry_is_returned(self) -> None:
         policy = validate_site_policy(_policy(network={"container_registry": "registry.example/hpc"}))

--- a/sure/skills/sure_eval/SKILL.md
+++ b/sure/skills/sure_eval/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: sure-eval
-description: Run reproducible inference from an approved NFS model's immutable container binding, then execute the selected evaluation pipeline and stage complete results for review.
+description: Run reproducible inference from an approved model's sealed container or local Python binding, then execute the selected evaluation pipeline and stage complete results for review.
 ---
 
 # /sure_eval
 
-Orchestrate inference plus deterministic evaluation for an audio model that has been human-approved into a configured `approved_models_roots` directory. Approved storage is read-only; new evaluation products are staged under repository-local `sure/results` for later human promotion.
+Orchestrate inference plus deterministic evaluation for a model that has been human-approved into a configured `approved_models_roots` directory. Container bindings mount approved storage read-only. A site-approved Python binding runs on a trusted host and verifies model-core hashes before and after execution. New evaluation products are staged under repository-local `sure/results` for later human promotion.
 
 A private distribution may carry an upstream main-flow mirror under `references/main_flow_agent/` for audit and parity review only. The public distribution omits that mirror. It is never a runtime template or execution source; adapt harness execution only under this skill package.
 
@@ -24,8 +24,8 @@ Control principle: **agent decides scope, scripts enforce format and execution.*
 | `device` | — | `auto \| cpu \| cuda \| cuda:<index>`. Default `auto`; resolved by `scripts/resolve_eval_input.py` and passed through inference/evaluation templates when materialized. For `execution=local`, `cuda:<index>` selects the local host GPU by setting `CUDA_VISIBLE_DEVICES=<index>`. For `execution=vc`, the allocated container GPU is addressed as `cuda:0`; choose hardware with `vc_partition`/`vc_gpu`, not a host CUDA ordinal. |
 | `target` | — | Target metric or paper to compare against. |
 | `max_samples` | — | Sample cap for bounded validation runs. Omitted or `0` means full dataset. |
-| `execution` | — | `auto \| local \| vc`. Default `auto`; `local` is an explicit user choice, `vc` requires a real vc submission, `auto` prefers vc when available. |
-| `execution_path` | — | Legacy alias: `auto \| vc_submit \| local_docker`. `local_bash` is normalized to `local_docker`; host inference is forbidden. |
+| `execution` | — | `auto \| local \| vc`. Default `auto`; containers prefer VC when available, while approved Python runtimes are local-only. `vc` requires an approved container and a real submission. |
+| `execution_path` | — | Legacy alias: `auto \| vc_submit \| local_docker \| local_python`. `local_bash` is normalized to the approved local runtime; arbitrary host inference is forbidden. |
 | `vc_partition` / `vc_cpu` / `vc_mem` / `vc_gpu` | — | Optional VC resource overrides. The image cannot be overridden and always comes from the approved deployment binding. |
 | `metrics` | — | Comma-separated reported metrics, e.g. `metrics=cer`. Selects the current default route per metric; use an exact `pipeline_id` via `/sure_reval` for route variants. |
 | `vc_job_name` | — | Optional vc job name recorded with the submit result. |
@@ -102,16 +102,16 @@ Advance happens **only** when the current unit's `produces` artifact is complian
 Each unit must satisfy: **Inputs** (previous unit's produces + evidence sources to read) → **Output** (`produces` JSON, schema in `schemas/`) → **Allowed** (value domain) → **Must Not Do** (forbidden fields that belong to later units — anti step-merge) → **Failure** classification.
 
 - **task_classification**: Inputs = `eval_input_resolved.json` + exact NFS model. Output = `task_classification.json` {task_type, reason, need_tool_workflow, confidence, input_signals}. Allowed: task_type ∈ {onboarding_then_evaluate,evaluate_existing_model,repair_broken_model,audit_results}. Must Not Do: do not select datasets or set `execution_path`/`report_persisted` (later units).
-- **tool_readiness_routing**: Inputs = exact approved NFS model with `artifacts/deployment_ready.json`, `runtime_inventory.json`, `package_gate.json`, and their declared hashes. Local readiness requires `docker-registry`, `container_only`, a digest-pinned image, disabled image/host overrides, and a read-only NFS model policy. Missing or inconsistent fields route back to `/sure_onboard` and human promotion.
+- **tool_readiness_routing**: Inputs = exact approved NFS model with `artifacts/deployment_ready.json`, `runtime_inventory.json`, `package_gate.json`, and their declared hashes. Readiness requires either a `docker-registry`/digest-pinned/container-only binding, or a `package=none`/uv/content-addressed Python binding permitted by the active site. Python additionally requires model-core hashes and the matching site runtime. Missing or inconsistent fields route back to `/sure_onboard` and human promotion.
 - **plan**: Inputs = task classification + tool readiness + `eval_input_resolved.json`. Output follows `main_agent_plan.schema.json` and describes execution order only.
 - **dataset_scope**: Inputs = `eval_input_resolved.json` + explicit human constraints. Output = {selection_basis, selected_datasets, skipped_datasets}. User-provided datasets are validated/canonicalized here; this unit should not silently invent a different dataset scope.
 - **execution_surface** / **execute_wait**: produce the declared JSON; see `schemas/`. Do not emit later-unit fields.
 - **script_routing**: Output steps[] each {name, script}. name ∈ the whitelist (see `schemas/script_routing.schema.json`); `script` must resolve under `scripts/`.
-- **execution_surface**: Output {entrypoint_path or entrypoint, source_provenance.template_file, deployment_binding}. The script comes only from `scripts/templates/`. Copy the approved binding summary from `eval_input_resolved.json`: schema, image ref, bundle identity, `container_only`, read-only model mount, and writable result mount. Do not declare a host model interpreter or a mutable image.
-- **execution_readiness**: `check_execution_surface_compliance.py` compares the surface binding with the approved input, rejects `local_bash`, `.venv`, `/usr/bin/python3`, image changes, writable NFS models, and tool mismatches. It also preserves template isolation and validates the standalone evaluation route plan.
-- **smoke_test**: bounded smoke on a tiny slice using local Docker and the approved digest-pinned image; `smoke_passed` true.
-- **submit_vc_run**: `execution=vc` uses the same approved image through `vc_submit`; `execution=local` uses `local_docker`; `auto` prefers VC when available. VC precheck verifies the immutable image, partition, mounts, and resources. It does not infer or rewrite a model `.venv`.
-- **execute_wait**: For VC, run `scripts/wait_vc_execution.py --run-dir <sure_run_dir> --wait` once. The waiter matches the current submission token, prefers the atomic terminal sentinel, and uses `vc info`/`vc describe` only to classify missing-container and timeout cases. Do not hand-author polling or a terminal result. Local Docker already writes its own result, which this gate validates.
+- **execution_surface**: Output {entrypoint_path or entrypoint, source_provenance.template_file, deployment_binding}. The script comes only from `scripts/templates/`. Copy the approved binding summary from `eval_input_resolved.json` exactly, including its schema version, runtime kind, bundle identity, execution mode, model integrity policy, and writable result policy. Current resolved bindings use `sure.eval.deployment_binding.v2`; historical container-only v1 surfaces remain accepted. Container surfaces also bind the immutable image. Do not invent or override a model interpreter.
+- **execution_readiness**: `check_execution_surface_compliance.py` compares the surface binding with the approved input, rejects `local_bash`, unapproved `.venv`/host interpreters, image changes, model-policy mismatches, and tool mismatches. It live-probes the exact approved container or site Model Python and validates the standalone evaluation route plan.
+- **smoke_test**: bounded smoke on a tiny slice using the approved local container or Python runtime; `smoke_passed` true.
+- **submit_vc_run**: Containers use `vc_submit` or `local_docker` according to the resolved policy. Python uses `local_python` and is never submitted to VC. Neither route may infer or rewrite a model `.venv`.
+- **execute_wait**: For VC, run `scripts/wait_vc_execution.py --run-dir <sure_run_dir> --wait` once. The waiter matches the current submission token, prefers the atomic terminal sentinel, and uses `vc info`/`vc describe` only to classify missing-container and timeout cases. Do not hand-author polling or a terminal result. Local Docker and Python runners already write their own result, which this gate validates.
 - **assessment**: {anomaly_detected, user_confirmed}. Anomaly (e.g. WER/CER > 50%, Accuracy < 20%) requires user confirmation.
 - **run_report**: {report_persisted, execution_path_actual}. Record `execution_path_requested`, `execution_path_actual`, `device_request`, `device_actual`, `max_samples`, total dataset samples, and evaluated samples. Non-vc paths are valid for explicit `execution=local`; auto local fallback requires a reason and, if vc was available, explicit fallback approval.
 
@@ -135,9 +135,9 @@ When materializing the execution surface (run_evaluation.sh):
 [SYSTEM_CONSTRAINT: EXECUTION_POLICY]
 The user controls where formal model inference runs:
 1. EXECUTION_REQUEST:
-   - `execution=local`: run the materialized surface in local Docker. Host model inference is never valid.
-   - `execution=vc`: submit through vc. If `which vc && vc info` fails, the run must fail instead of falling back.
-   - `execution=auto` or omitted: prefer vc when available; otherwise local fallback is allowed and must record the reason.
+   - `execution=local`: run the materialized surface through its approved `local_docker` or `local_python` binding.
+   - `execution=vc`: submit the approved container through VC. Python bindings reject this request.
+   - `execution=auto` or omitted: containers prefer VC when available; Python bindings select their site-approved local-only route. Any container fallback records its reason.
 2. DEVICE_REQUEST:
    - `device=cpu` hides `CUDA_VISIBLE_DEVICES`.
    - `device=cuda:<index>` records the user request, sets `CUDA_VISIBLE_DEVICES=<index>` for local execution, and records process-visible `device_actual=cuda:0`.
@@ -194,7 +194,8 @@ in `scripts/templates/`. Run them as:
 ```
 
 For `execution=local`, call `scripts/run_local_execution.py --run-dir <sure_run_dir>`
-from the submit unit. It runs `run_evaluation.sh` inside the approved image and writes
+from the submit unit. It runs `run_evaluation.sh` through the approved container or
+site Model Python and writes
 both `submit_result.json` and `execution_result.json`. For `execution=vc`, use
 `scripts/run_vc_execution.py --run-dir <sure_run_dir>` from the submit unit. It
 writes `submit_result.json`, includes the exact `vc submit` command and a
@@ -206,11 +207,14 @@ authoritative exit code. When vc resources
 are selected at submit time, the effective digest-pinned image, partition, CPU,
 GPU, memory, entrypoint, and log snapshot is recorded in both `submit_result.vc_submission`
 and `execution_surface.vc_runtime.resolved_submission`.
-Both local Docker and VC inject the Model Python and server command declared by
+All execution routes inject the Model Python and server command declared by
 `runtime_inventory.json`, plus the independently resolved, versioned common
-`HARNESS_PYTHON_BIN`. The two executables are validated separately and must not
-silently collapse to the same interpreter. Host model-interpreter overrides and
-`.venv` rewrites are rejected.
+`HARNESS_PYTHON_BIN`. Container routes resolve both roles inside the image. Python
+routes resolve the portable Model Runtime ID against the active site's
+`storage.runtime_root`, pass a sanitized environment, redirect caches into the run
+directory, and verify model-core hashes before and after execution. The two
+executables are validated separately and must not silently collapse to the same
+interpreter. Host model-interpreter overrides and `.venv` rewrites are rejected.
 The standalone evaluator uses a third role, `SURE_EVALUATION_PYTHON`. Its root
 dependencies are resolved from the versioned contract under
 `sure/runtime/evaluation/`, cached by engine commit and lock hash under
@@ -257,9 +261,10 @@ contract according to the selected route's required roles. Repeated `--metric`
 values produce one dataset-metric result each, and `--merge-payload` merges
 segmented TTS/VC evaluation payloads without rerunning metrics.
 
-`run_smoke.py` launches the approved local container with a bounded sample.
-`generate_predictions_via_server.py --device cpu` hides `CUDA_VISIBLE_DEVICES`
-inside that container; it never starts a host model runtime.
+`run_smoke.py` launches the approved local container or site Model Python with a
+bounded sample. `generate_predictions_via_server.py --device cpu` hides
+`CUDA_VISIBLE_DEVICES` in the selected runtime; it never falls back to an
+unapproved host interpreter.
 
 ## Gate Checks (enforced by hooks)
 

--- a/sure/skills/sure_eval/hooks/state-machine.ts
+++ b/sure/skills/sure_eval/hooks/state-machine.ts
@@ -210,7 +210,7 @@ export const MAIN_FLOW_UNITS: Unit[] = [
 		label: "Execution surface",
 		kind: "gate",
 		produces: "execution_surface.json",
-		schemaRef: "execution_surface.schema.json",
+		schemaRef: "execution_surface_v2.schema.json",
 		requiredFields: ["source_provenance", "deployment_binding"],
 		forbiddenFields: ["report_persisted", "execution_path_actual"],
 		gateCheck: checkExecutionSurface,

--- a/sure/skills/sure_eval/references/contracts/main_agent_tool_readiness_unit.md
+++ b/sure/skills/sure_eval/references/contracts/main_agent_tool_readiness_unit.md
@@ -12,16 +12,26 @@ This unit prevents `/sure_eval` from repairing, guessing, or executing an unappr
 
 ## Required Evidence
 
-For a local model, `ready` requires all of the following:
+For a local model, `ready` requires exactly one approved deployment binding.
 
-- `artifacts/deployment_ready.json` with status `ready` and package `docker-registry`;
-- `artifacts/runtime_inventory.json` schema v2 with `container_only` execution;
-- `artifacts/package_gate.json` schema v2 with local, Docker, registry, and bundle readiness;
-- exact tag, digest, and digest-pinned image agreement across those files;
-- valid hashes declared by the deployment marker;
-- read-only NFS model policy, writable separate results, no host Python fallback, and no image override.
+Container binding:
 
-`config.yaml`, `model.py`, `server.py`, and verdict remain model evidence, but they cannot replace the deployment binding. `.venv`, Dockerfile text, logs, local image listings, and similar image names are never readiness sources.
+- `deployment_ready.json` has status `ready` and package `docker-registry`;
+- `runtime_inventory.json` declares `container_only` execution;
+- `package_gate.json` proves local, Docker, registry, and bundle readiness;
+- tag, digest, and digest-pinned image agree across all artifacts;
+- approved model storage is read-only and results are written separately.
+
+Local Python binding:
+
+- the active site permits `local` plus the `python` local runtime;
+- `deployment_ready.json` has status `ready` and package `none`;
+- `runtime_inventory.json` declares `eval_runtime=python` and `execution_mode=local_only`;
+- `package_gate.json` proves local and bundle readiness without Docker or registry claims;
+- the sealed uv Model Runtime manifest resolves below the active site's `storage.runtime_root` and passes live verification;
+- model-core hashes are declared and verified before and after trusted-host execution.
+
+Both bindings require valid deployment-marker hashes and an independently writable results directory. `config.yaml`, `model.py`, `server.py`, and verdict remain model evidence, but they cannot replace the deployment binding. A model-local `.venv`, Dockerfile text, logs, local image listings, and similar image names are never readiness sources.
 
 ## Routing
 

--- a/sure/skills/sure_eval/schemas/execution_result.schema.json
+++ b/sure/skills/sure_eval/schemas/execution_result.schema.json
@@ -11,7 +11,8 @@
 			"enum": ["succeeded", "running", "failed", "partial"]
 		},
 		"vc_job_id": { "type": "string" },
-		"execution_path": { "type": "string", "enum": ["vc_submit", "local_bash", "local_docker"] },
+		"execution_path": { "type": "string", "enum": ["vc_submit", "local_bash", "local_docker", "local_python"] },
+		"runtime_kind": { "type": "string", "enum": ["container", "python"] },
 		"execution_requested": { "type": "string", "enum": ["auto", "local", "vc"] },
 		"predictions_path": { "type": "string" },
 		"log_path": { "type": "string" },

--- a/sure/skills/sure_eval/schemas/execution_surface_v2.schema.json
+++ b/sure/skills/sure_eval/schemas/execution_surface_v2.schema.json
@@ -1,0 +1,69 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "execution_surface_v2.schema.json",
+	"title": "SURE-EVAL execution surface v2",
+	"description": "Execution surface for versioned container or trusted-host Python deployment bindings.",
+	"type": "object",
+	"required": ["source_provenance", "deployment_binding"],
+	"properties": {
+		"run_id": { "type": "string" },
+		"timestamp": { "type": "string" },
+		"execution_surface_type": { "type": "string" },
+		"materialized": { "type": "boolean" },
+		"entrypoint": { "type": "string" },
+		"entrypoint_path": { "type": "string" },
+		"entrypoint_path_actual": { "type": "string" },
+		"execution": { "type": "object", "additionalProperties": true },
+		"deployment_binding": {
+			"type": "object",
+			"required": ["schema", "runtime_kind", "execution_mode", "model_mount_read_only", "result_mount_writable"],
+			"properties": {
+				"schema": { "const": "sure.eval.deployment_binding.v2" },
+				"runtime_kind": { "enum": ["container", "python"] },
+				"target_image_ref": { "type": ["string", "null"], "pattern": "@sha256:[0-9a-f]{64}$" },
+				"bundle_identity_sha256": { "type": ["string", "null"] },
+				"execution_mode": { "enum": ["container_only", "python"] },
+				"model_mount_read_only": { "type": "boolean" },
+				"model_integrity": { "enum": ["image_digest", "verify_before_after"] },
+				"result_mount_writable": { "const": true }
+			},
+			"additionalProperties": false
+		},
+		"inference_runtime": { "type": "object", "additionalProperties": true },
+		"evaluation_runtime": { "type": "object", "additionalProperties": true },
+		"vc_runtime": { "type": "object", "additionalProperties": true },
+		"generation_method": { "type": "string" },
+		"source_provenance": {
+			"type": "object",
+			"required": ["template_file"],
+			"properties": {
+				"template_file": { "type": "string" },
+				"template_sha256": { "type": "string" },
+				"source_template_file": { "type": "string" },
+				"source_template_sha256": { "type": "string" },
+				"mirror_template_file": { "type": "string" },
+				"mirror_template_sha256": { "type": "string" },
+				"files_read_during_generation": { "type": "array", "items": { "type": "string" } },
+				"isolation_compliance": {
+					"type": "object",
+					"properties": {
+						"eval_runs_referenced": { "type": "boolean" },
+						"prior_run_scripts_copied": { "type": "boolean" },
+						"template_parameters_deviated": { "type": "array", "items": { "type": "string" } },
+						"deviation_approved_by_user": { "type": "boolean" }
+					},
+					"additionalProperties": true
+				},
+				"materialized_at": { "type": "string" }
+			},
+			"additionalProperties": false
+		},
+		"resolved_inputs": { "type": "object", "additionalProperties": true },
+		"expected_outputs": { "type": "object", "additionalProperties": true },
+		"commands": { "type": "array", "items": { "type": "string" } },
+		"env": { "type": "object", "additionalProperties": { "type": "string" } },
+		"reason": { "type": "string" },
+		"notes": { "type": "array", "items": { "type": "string" } }
+	},
+	"additionalProperties": false
+}

--- a/sure/skills/sure_eval/schemas/run_report.schema.json
+++ b/sure/skills/sure_eval/schemas/run_report.schema.json
@@ -79,7 +79,7 @@
 		},
 		"execution_path_actual": {
 			"type": "string",
-			"description": "Actual execution path used: vc_submit | local_bash | local_docker."
+			"description": "Actual execution path used: vc_submit | local_bash | local_docker | local_python."
 		},
 		"execution_path_requested": {
 			"type": "string",

--- a/sure/skills/sure_eval/schemas/submit_result.schema.json
+++ b/sure/skills/sure_eval/schemas/submit_result.schema.json
@@ -8,8 +8,9 @@
 	"properties": {
 		"execution_path": {
 			"type": "string",
-			"enum": ["vc_submit", "local_bash", "local_docker"]
+			"enum": ["vc_submit", "local_bash", "local_docker", "local_python"]
 		},
+		"runtime_kind": { "type": "string", "enum": ["container", "python"] },
 		"vc_available": {
 			"type": "boolean",
 			"description": "True when `which vc && vc info` both pass (set by scripts/vc_check.py)."

--- a/sure/skills/sure_eval/scripts/check_execution_surface_compliance.py
+++ b/sure/skills/sure_eval/scripts/check_execution_surface_compliance.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import shlex
 import subprocess
 import sys
@@ -30,6 +31,7 @@ from typing import Any
 from resolve_evaluation_route_plan import build_route_plan
 from harness_runtime import HarnessRuntimeBindingError, harness_runtime_from_eval_input
 from container_execution import resolve_container_harness_runtime
+from deployment_binding import DEPLOYMENT_BINDING_V1, DEPLOYMENT_BINDING_V2
 
 
 def _sha256_file(path: Path) -> str:
@@ -233,7 +235,10 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
     model = eval_input.get("model") if isinstance(eval_input.get("model"), dict) else {}
     approved = model.get("deployment_binding")
     declared_binding = data.get("deployment_binding")
-    if not isinstance(approved, dict) or approved.get("schema") != "sure.eval.deployment_binding.v1":
+    if not isinstance(approved, dict) or approved.get("schema") not in {
+        DEPLOYMENT_BINDING_V1,
+        DEPLOYMENT_BINDING_V2,
+    }:
         return {"passed": False, "evidence": "eval input has no approved deployment binding"}
     if not isinstance(declared_binding, dict):
         return {"passed": False, "evidence": "execution surface must declare deployment_binding"}
@@ -247,25 +252,45 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
         issues.append(str(exc))
         approved_harness = {}
 
-    expected_fields = {
-        "schema": approved.get("schema"),
-        "target_image_ref": approved.get("target_image_ref"),
-        "bundle_identity_sha256": (approved.get("evidence") or {}).get("bundle_identity_sha256"),
-        "execution_mode": "container_only",
-        "model_mount_read_only": True,
-        "result_mount_writable": True,
-    }
+    binding_schema = approved.get("schema")
+    runtime_kind = str(approved.get("runtime_kind") or "container")
+    expected_fields = (
+        {
+            "schema": DEPLOYMENT_BINDING_V1,
+            "target_image_ref": approved.get("target_image_ref"),
+            "bundle_identity_sha256": (approved.get("evidence") or {}).get("bundle_identity_sha256"),
+            "execution_mode": "container_only",
+            "model_mount_read_only": True,
+            "result_mount_writable": True,
+        }
+        if binding_schema == DEPLOYMENT_BINDING_V1
+        else {
+            "schema": DEPLOYMENT_BINDING_V2,
+            "runtime_kind": runtime_kind,
+            "bundle_identity_sha256": (approved.get("evidence") or {}).get("bundle_identity_sha256"),
+            "execution_mode": (approved.get("policy") or {}).get("execution_mode"),
+            "model_mount_read_only": runtime_kind == "container",
+            "model_integrity": (approved.get("policy") or {}).get("model_integrity", "image_digest"),
+            "result_mount_writable": True,
+        }
+    )
+    if binding_schema == DEPLOYMENT_BINDING_V2 and runtime_kind == "container":
+        expected_fields["target_image_ref"] = approved.get("target_image_ref")
     for key, expected in expected_fields.items():
         if declared_binding.get(key) != expected:
             issues.append(f"deployment_binding.{key} must equal approved value {expected!r}")
     path_planned = str(execution.get("path_planned") or "")
-    if path_planned not in {"local_docker", "vc_submit"}:
-        issues.append("formal inference path must be local_docker or vc_submit")
+    approved_python = approved.get("python") if isinstance(approved.get("python"), dict) else {}
+    allowed_paths = {"local_python"} if runtime_kind == "python" else {"local_docker", "vc_submit"}
+    if path_planned not in allowed_paths:
+        issues.append(f"formal {runtime_kind} inference path must be one of {sorted(allowed_paths)}")
     if isinstance(env.get("SURE_EVAL_CONTAINER_IMAGE"), str) and env["SURE_EVAL_CONTAINER_IMAGE"] != approved.get("target_image_ref"):
         issues.append("execution surface image differs from the approved digest-pinned image")
     for key in ("MODEL_PYTHON", "PYTHON_BIN"):
         value = env.get(key)
-        if isinstance(value, str) and (".venv" in value or value == "/usr/bin/python3"):
+        if runtime_kind == "python" and isinstance(value, str) and value and value != approved_python.get("python_executable"):
+            issues.append(f"{key} differs from the approved Model Python")
+        elif runtime_kind == "container" and isinstance(value, str) and (".venv" in value or value == "/usr/bin/python3"):
             issues.append(f"{key} must not bind a host interpreter; the container runner injects approved runtime Python")
     declared_harness_python = env.get("HARNESS_PYTHON_BIN")
     if isinstance(declared_harness_python, str) and declared_harness_python:
@@ -285,7 +310,8 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
         (value for value in (env.get("TOOL_NAME"), resolved_inputs.get("tool_name")) if isinstance(value, str) and value),
         "",
     )
-    approved_tools = ((approved.get("container") or {}).get("tool_names") or [])
+    approved_runtime = approved_python if runtime_kind == "python" else (approved.get("container") or {})
+    approved_tools = approved_runtime.get("tool_names") or []
     if declared_tool and declared_tool not in approved_tools:
         issues.append(f"tool name {declared_tool!r} is not in the approved deployment binding: {approved_tools}")
 
@@ -302,7 +328,7 @@ def check_inference_runtime(surface_path: Path) -> dict[str, Any]:
     return {
         "passed": True,
         "live_runtime_probe": live_probe,
-        "evidence": f"approved container-only deployment verified: {approved.get('target_image_ref')}",
+        "evidence": f"approved {runtime_kind} deployment verified",
     }
 
 
@@ -312,6 +338,54 @@ def _live_runtime_probe(
     *,
     run=subprocess.run,
 ) -> dict[str, Any]:
+    if binding.get("runtime_kind") == "python":
+        python = binding.get("python") if isinstance(binding.get("python"), dict) else {}
+        model_python = str(python.get("python_executable") or "")
+        harness_python = str(host_harness.get("python_executable") or "")
+        if not model_python or not harness_python or model_python == harness_python:
+            return {
+                "passed": False,
+                "failure_class": "HARNESS_MODEL_RUNTIME_ALIAS",
+                "exit_code": None,
+                "evidence": "approved Harness Python and Model Python must be distinct",
+            }
+        imports = [str(item) for item in python.get("required_imports") or [] if isinstance(item, str)]
+        script = "import importlib,json;[importlib.import_module(n) for n in json.loads(" + repr(json.dumps(imports)) + ")]"
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if key in {"PATH", "LANG", "LC_ALL", "CUDA_VISIBLE_DEVICES", "LD_LIBRARY_PATH"}
+        }
+        env.update({"PYTHONDONTWRITEBYTECODE": "1", "PYTHONNOUSERSITE": "1"})
+        try:
+            completed = run(
+                [model_python, "-s", "-c", script],
+                cwd=str(python.get("working_dir") or binding.get("model_dir") or ""),
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {
+                "passed": False,
+                "failure_class": "MODEL_RUNTIME_NOT_MATERIALIZED",
+                "exit_code": None,
+                "evidence": f"Python runtime probe could not start: {exc}",
+            }
+        detail = (completed.stderr or completed.stdout or "").strip()
+        return {
+            "passed": completed.returncode == 0,
+            "failure_class": None if completed.returncode == 0 else "MODEL_RUNTIME_NEEDS_REPAIR",
+            "exit_code": completed.returncode,
+            "model_python": model_python,
+            "runtime_id": python.get("runtime_id"),
+            "required_imports": imports,
+            "evidence": "approved Python runtime probe passed"
+            if completed.returncode == 0
+            else f"MODEL_RUNTIME_NEEDS_REPAIR: {detail or f'exit {completed.returncode}'}",
+        }
     repo_root = Path(__file__).resolve().parents[4]
     try:
         harness, mounted = resolve_container_harness_runtime(binding, host_harness, repo_root)

--- a/sure/skills/sure_eval/scripts/check_run_report.py
+++ b/sure/skills/sure_eval/scripts/check_run_report.py
@@ -175,16 +175,29 @@ def _validate_protocol(root: Path) -> list[str]:
         errors.append("protocol.yaml inference_parameters.argument_policy is required for generated predictions")
     provenance = protocol.get("provenance") if isinstance(protocol.get("provenance"), dict) else {}
     inference_environment = protocol.get("inference_environment") if isinstance(protocol.get("inference_environment"), dict) else {}
+    runtime_kind = str(inference_environment.get("runtime_kind") or "container")
     container = inference_environment.get("container") if isinstance(inference_environment.get("container"), dict) else {}
+    model_runtime = inference_environment.get("model_runtime") if isinstance(inference_environment.get("model_runtime"), dict) else {}
     runtime_inventory = inference_environment.get("runtime_inventory") if isinstance(inference_environment.get("runtime_inventory"), dict) else {}
     harness_runtime = inference_environment.get("harness_runtime") if isinstance(inference_environment.get("harness_runtime"), dict) else {}
     mount_policy = inference_environment.get("mount_policy") if isinstance(inference_environment.get("mount_policy"), dict) else {}
-    if "@sha256:" not in str(container.get("image_ref") or ""):
-        errors.append("protocol.yaml container.image_ref must be digest-pinned")
-    if container.get("execution_mode") != "container_only":
-        errors.append("protocol.yaml container.execution_mode must be container_only")
-    if container.get("host_python_fallback") is not False:
-        errors.append("protocol.yaml must disable container host_python_fallback")
+    if runtime_kind == "container":
+        if "@sha256:" not in str(container.get("image_ref") or ""):
+            errors.append("protocol.yaml container.image_ref must be digest-pinned")
+        if container.get("execution_mode") != "container_only":
+            errors.append("protocol.yaml container.execution_mode must be container_only")
+        if container.get("host_python_fallback") is not False:
+            errors.append("protocol.yaml must disable container host_python_fallback")
+    elif runtime_kind == "python":
+        for key in ("runtime_id", "python_executable", "lock_sha256", "manifest_sha256"):
+            if not model_runtime.get(key):
+                errors.append(f"protocol.yaml model_runtime.{key} is required for Python inference")
+        if model_runtime.get("execution_mode") != "python":
+            errors.append("protocol.yaml model_runtime.execution_mode must be python")
+        if model_runtime.get("host_python_fallback") is not False:
+            errors.append("protocol.yaml must disable Python host fallback")
+    else:
+        errors.append(f"protocol.yaml inference_environment.runtime_kind is unsupported: {runtime_kind}")
     if runtime_inventory.get("schema") != "sure.onboard.runtime_inventory.v2":
         errors.append("protocol.yaml must record runtime_inventory schema v2")
     if not prediction_reuse.get("enabled"):
@@ -193,8 +206,13 @@ def _validate_protocol(root: Path) -> list[str]:
         for key in ("runtime_id", "python_executable", "lock_sha256", "manifest_path", "runtime_root"):
             if not harness_runtime.get(key):
                 errors.append(f"protocol.yaml harness_runtime.{key} is required for generated predictions")
-    if mount_policy.get("nfs_models_read_only") is not True:
+    if runtime_kind == "container" and mount_policy.get("nfs_models_read_only") is not True:
         errors.append("protocol.yaml must record a read-only NFS model mount")
+    if runtime_kind == "python":
+        if mount_policy.get("nfs_models_read_only") is not False:
+            errors.append("protocol.yaml must accurately record the trusted-host Python model mount")
+        if mount_policy.get("model_integrity") != "verify_before_after":
+            errors.append("protocol.yaml must record before/after model integrity verification")
     if provenance.get("raw_response_source_of_truth") is not False:
         errors.append("protocol.yaml provenance.raw_response_source_of_truth must be false")
     if prediction_reuse.get("enabled"):
@@ -412,7 +430,7 @@ def _execution_requested(data: dict[str, Any], run_dir: Path, report_path: Path)
                 return value
             if value == "vc_submit":
                 return "vc"
-            if value in {"local_bash", "local_docker"}:
+            if value in {"local_bash", "local_docker", "local_python"}:
                 return "local"
 
     eval_input = _read_optional_json(run_dir / "artifacts" / "eval_input_resolved.json")
@@ -424,7 +442,7 @@ def _execution_requested(data: dict[str, Any], run_dir: Path, report_path: Path)
     execution_path_declared = str(data.get("execution_path_declared") or "")
     if execution_path_declared == "vc_submit":
         return "vc"
-    if execution_path_declared in {"local_bash", "local_docker"}:
+    if execution_path_declared in {"local_bash", "local_docker", "local_python"}:
         return "local"
     return "auto"
 
@@ -513,6 +531,15 @@ def _validate_failed_execution_report(run_dir: Path, report_path: Path, data: di
 
 
 def _submitted_image_error(execution_path: str, submit_result: dict, approved: dict) -> str | None:
+    runtime_kind = str(approved.get("runtime_kind") or "container")
+    if runtime_kind == "python":
+        if execution_path != "local_python":
+            return "approved Python runtime must execute through local_python"
+        expected_runtime = approved.get("python") if isinstance(approved.get("python"), dict) else {}
+        actual_runtime = submit_result.get("model_runtime") if isinstance(submit_result.get("model_runtime"), dict) else {}
+        if actual_runtime.get("runtime_id") != expected_runtime.get("runtime_id"):
+            return "local Python runtime differs from the approved runtime identity"
+        return None
     approved_ref = str(approved.get("target_image_ref") or "")
     if execution_path != "vc_submit":
         actual_ref = ((submit_result.get("container_binding") or {}).get("image_ref")) or submit_result.get("vc_image")
@@ -561,10 +588,19 @@ def main() -> int:
         return 1
 
     execution_path_actual = data.get("execution_path_actual", "")
-    if not execution_path_actual:
+    allowed_execution_paths = {
+        "vc_submit",
+        "local_bash",
+        "local_docker",
+        "local_python",
+        "blocked_before_submit",
+        "not_submitted",
+        "failed_before_submit",
+    }
+    if execution_path_actual not in allowed_execution_paths:
         print(
-            "RUN_REPORT_UNIT gate: execution_path_actual must be declared "
-            "(vc_submit / local_bash / local_docker).",
+            "RUN_REPORT_UNIT gate: execution_path_actual must be one of "
+            "vc_submit / local_bash / local_docker / local_python.",
             file=sys.stderr,
         )
         return 1
@@ -579,7 +615,7 @@ def main() -> int:
         fallback_reason = data.get("local_fallback_reason") or submit_result.get("local_fallback_reason", "")
         if execution_path_actual == "local_bash" and not evaluation_only and not failed_pre_submit:
             print(
-                "RUN_REPORT_UNIT gate: formal model inference cannot use local_bash; expected local_docker.",
+                "RUN_REPORT_UNIT gate: formal model inference cannot use local_bash; use the approved local runtime.",
                 file=sys.stderr,
             )
             return 1

--- a/sure/skills/sure_eval/scripts/container_execution.py
+++ b/sure/skills/sure_eval/scripts/container_execution.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from harness_runtime import harness_runtime_from_eval_input
 from evaluation_runtime import evaluation_runtime_from_eval_input
+from deployment_binding import DEPLOYMENT_BINDING_V1, DEPLOYMENT_BINDING_V2
 
 
 ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -29,7 +30,10 @@ def deployment_binding(eval_input: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(binding, dict):
         runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
         binding = runtime.get("deployment_binding")
-    if not isinstance(binding, dict) or binding.get("schema") != "sure.eval.deployment_binding.v1":
+    if not isinstance(binding, dict) or binding.get("schema") not in {
+        DEPLOYMENT_BINDING_V1,
+        DEPLOYMENT_BINDING_V2,
+    }:
         raise ValueError("eval input does not contain an approved deployment binding")
     policy = binding.get("policy") if isinstance(binding.get("policy"), dict) else {}
     if policy.get("execution_mode") != "container_only" or policy.get("host_python_fallback") is not False:

--- a/sure/skills/sure_eval/scripts/deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/deployment_binding.py
@@ -1,12 +1,25 @@
 #!/usr/bin/env python3
-"""Validate and normalize the approved NFS container deployment contract."""
+"""Validate and normalize an approved model deployment contract."""
 
 from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from sure.runtime.model.bootstrap import ModelRuntimeError, manifest_sha256, verify_runtime
+from sure.site.loader import SitePolicyError, load_site_policy
+
+
+DEPLOYMENT_READY_V1 = "sure.onboard.deployment_ready.v1"
+DEPLOYMENT_READY_V2 = "sure.onboard.deployment_ready.v2"
+DEPLOYMENT_BINDING_V1 = "sure.eval.deployment_binding.v1"
+DEPLOYMENT_BINDING_V2 = "sure.eval.deployment_binding.v2"
 
 
 class DeploymentBindingError(ValueError):
@@ -61,6 +74,160 @@ def _require(condition: bool, message: str) -> None:
         raise DeploymentBindingError(message)
 
 
+def _verified_bundle_evidence(model_dir: Path, marker: dict[str, Any]) -> tuple[dict[str, str], str]:
+    declared = marker.get("required_artifact_sha256")
+    _require(isinstance(declared, dict) and bool(declared), "deployment artifact hashes are missing")
+    verified: dict[str, str] = {}
+    for relative, expected in declared.items():
+        _require(isinstance(relative, str) and isinstance(expected, str), "deployment artifact hash entry is invalid")
+        actual = _sha256(_artifact_path(model_dir, relative))
+        _require(actual == expected, f"deployment artifact hash mismatch: {relative}")
+        verified[relative] = actual
+    bundle_identity = str(marker.get("bundle_identity_sha256") or "")
+    calculated = hashlib.sha256(
+        json.dumps(declared, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    _require(bundle_identity == calculated, "deployment bundle identity does not match required artifact hashes")
+    return verified, bundle_identity
+
+
+def _verified_model_core(model_dir: Path, inventory: dict[str, Any]) -> dict[str, str]:
+    evidence = inventory.get("evidence") if isinstance(inventory.get("evidence"), dict) else {}
+    declared = evidence.get("model_core_sha256")
+    _require(isinstance(declared, dict) and bool(declared), "Python deployment model integrity hashes are missing")
+    verified: dict[str, str] = {}
+    for relative, expected in declared.items():
+        _require(isinstance(relative, str) and isinstance(expected, str), "model integrity hash entry is invalid")
+        actual = _sha256(_artifact_path(model_dir, relative))
+        _require(actual == expected, f"approved model integrity hash mismatch: {relative}")
+        verified[relative] = actual
+    return verified
+
+
+def _load_python_binding(
+    model_dir: Path,
+    model_name: str,
+    marker: dict[str, Any],
+    inventory: dict[str, Any],
+    package: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        configured = load_site_policy(required=True)
+    except SitePolicyError as exc:
+        raise DeploymentBindingError(str(exc)) from exc
+    assert configured is not None
+    site = configured["policy"]
+    _require("python" in site["execution"]["local_runtimes"], "local Python Eval is disabled by site policy")
+    _require("local" in site["execution"]["surfaces"], "local execution is disabled by site policy")
+    _require(marker.get("status") == "ready", "deployment_ready status must be ready")
+    _require(marker.get("model_name") == model_name, "deployment_ready model_name does not match requested model")
+    policy = marker.get("execution_policy")
+    _require(isinstance(policy, dict), "deployment_ready execution_policy is missing")
+    expected_policy = {
+        "container_only": False,
+        "eval_runtime": "python",
+        "isolation": "trusted_host",
+        "model_integrity": "verify_before_after",
+        "nfs_models_read_only": False,
+        "model_bundle_mutation_allowed": False,
+        "host_python_fallback": False,
+        "approved_image_override": False,
+    }
+    for key, expected in expected_policy.items():
+        _require(policy.get(key) == expected, f"Python deployment policy {key} must be {expected!r}")
+
+    _require(inventory.get("schema") == "sure.onboard.runtime_inventory.v2", "unsupported runtime_inventory schema")
+    _require(inventory.get("status") == "ready", "runtime_inventory status must be ready")
+    model = inventory.get("model") if isinstance(inventory.get("model"), dict) else {}
+    inventory_policy = inventory.get("policy") if isinstance(inventory.get("policy"), dict) else {}
+    runtime = inventory.get("model_runtime") if isinstance(inventory.get("model_runtime"), dict) else {}
+    _require(model.get("name") == model_name, "runtime_inventory model does not match")
+    _require(inventory_policy.get("eval_runtime") == "python", "runtime inventory is not Python-ready")
+    _require(inventory_policy.get("host_python_fallback") is False, "runtime inventory enables host fallback")
+    _require(inventory_policy.get("nfs_models_mutable_by_eval") is False, "runtime inventory allows model mutation")
+    _require(runtime.get("required") is True and runtime.get("backend") == "uv", "approved Model Runtime must be sealed by uv")
+
+    _require(package.get("schema") == "sure.onboard.package_gate.v2", "unsupported package_gate schema")
+    _require(package.get("status") == "passed" and package.get("package_profile") == "none", "package_gate is not Python-ready")
+    readiness = package.get("readiness") if isinstance(package.get("readiness"), dict) else {}
+    _require(readiness.get("local_ready") is True and readiness.get("bundle_ready") is True, "Python package readiness is incomplete")
+    for key in ("container_ready", "docker_ready", "registry_ready"):
+        _require(readiness.get(key) is False, f"Python package readiness.{key} must be false")
+
+    manifest = _read_json(model_dir, "artifacts/model_runtime_manifest.json")
+    marker_runtime = marker.get("model_runtime") if isinstance(marker.get("model_runtime"), dict) else {}
+    _require(runtime.get("runtime_id") == manifest.get("runtime_id"), "runtime inventory Model Runtime ID mismatch")
+    _require(marker_runtime.get("runtime_id") == manifest.get("runtime_id"), "deployment Model Runtime ID mismatch")
+    expected_manifest_hash = manifest_sha256(manifest)
+    _require(runtime.get("manifest_sha256") == expected_manifest_hash, "runtime inventory manifest hash mismatch")
+    _require(marker_runtime.get("manifest_sha256") == expected_manifest_hash, "deployment manifest hash mismatch")
+    lock_path = _artifact_path(model_dir, str(runtime.get("lockfile_path") or ""))
+    _require(_sha256(lock_path) == manifest.get("lock_sha256") == runtime.get("lock_sha256"), "Model Runtime lock hash mismatch")
+    try:
+        resolved_runtime = verify_runtime(Path(site["storage"]["runtime_root"]) / "models", manifest)
+    except ModelRuntimeError as exc:
+        raise DeploymentBindingError(str(exc)) from exc
+
+    command = runtime.get("server_command")
+    tools = runtime.get("tool_names")
+    relative_python = str(runtime.get("python_executable") or "")
+    _require(
+        isinstance(command, list)
+        and bool(command)
+        and all(isinstance(item, str) and item for item in command)
+        and command[0] == relative_python,
+        "approved Python server_command is invalid",
+    )
+    _require(isinstance(tools, list) and bool(tools) and all(isinstance(item, str) and item for item in tools), "approved Python tool_names are invalid")
+    working_dir = (model_dir / str(runtime.get("working_dir") or ".")).resolve()
+    _require(_is_relative_to(working_dir, model_dir) and working_dir.is_dir(), "approved Python working_dir is invalid")
+    verified_hashes, bundle_identity = _verified_bundle_evidence(model_dir, marker)
+    model_hashes = _verified_model_core(model_dir, inventory)
+    python_executable = str(resolved_runtime["python_executable_resolved"])
+    return {
+        "schema": DEPLOYMENT_BINDING_V2,
+        "runtime_kind": "python",
+        "model_name": model_name,
+        "model_dir": str(model_dir),
+        "source": "approved_nfs_models",
+        "package_profile": "none",
+        "python": {
+            "runtime_id": manifest["runtime_id"],
+            "backend": "uv",
+            "python_executable": python_executable,
+            "python_version": manifest["python_version"],
+            "python_abi": manifest["python_abi"],
+            "runtime_root": resolved_runtime["runtime_root"],
+            "manifest_path": resolved_runtime["manifest_path"],
+            "manifest_sha256": expected_manifest_hash,
+            "lockfile_path": str(lock_path),
+            "lock_sha256": manifest["lock_sha256"],
+            "working_dir": str(working_dir),
+            "server_command": [python_executable, *command[1:]],
+            "tool_names": tools,
+            "required_imports": runtime.get("required_imports") or [],
+            "gpu_required": runtime.get("gpu_required") is True,
+        },
+        "policy": {
+            "execution_mode": "python",
+            "isolation": "trusted_host",
+            "model_integrity": "verify_before_after",
+            "model_bundle_mutation_allowed": False,
+            "host_python_fallback": False,
+            "image_override_allowed": False,
+        },
+        "evidence": {
+            "deployment_ready": str(_artifact_path(model_dir, "artifacts/deployment_ready.json")),
+            "runtime_inventory": str(_artifact_path(model_dir, "artifacts/runtime_inventory.json")),
+            "package_gate": str(_artifact_path(model_dir, "artifacts/package_gate.json")),
+            "model_runtime_manifest": str(_artifact_path(model_dir, "artifacts/model_runtime_manifest.json")),
+            "verified_sha256": verified_hashes,
+            "model_core_sha256": model_hashes,
+            "bundle_identity_sha256": bundle_identity,
+        },
+    }
+
+
 def _normalize_harness_runtime(binding: dict[str, Any]) -> dict[str, Any]:
     """Accept legacy bindings by deriving root from their manifest location."""
     manifest_value = str(binding.get("manifest_path") or "")
@@ -107,7 +274,11 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
     inventory = _read_json(model_dir, "artifacts/runtime_inventory.json")
     package = _read_json(model_dir, "artifacts/package_gate.json")
 
-    _require(marker.get("schema") == "sure.onboard.deployment_ready.v1", "unsupported deployment_ready schema")
+    if marker.get("package_profile") == "none":
+        _require(marker.get("schema") == DEPLOYMENT_READY_V2, "unsupported Python deployment_ready schema")
+        return _load_python_binding(model_dir, model_name, marker, inventory, package)
+
+    _require(marker.get("schema") == DEPLOYMENT_READY_V1, "unsupported deployment_ready schema")
     _require(marker.get("status") == "ready", "deployment_ready status must be ready")
     _require(marker.get("model_name") == model_name, "deployment_ready model_name does not match requested model")
     _require(marker.get("package_profile") == "docker-registry", "approved local model must use docker-registry")
@@ -223,7 +394,8 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
     _require(bundle_identity == calculated_bundle_identity, "deployment bundle identity does not match required artifact hashes")
 
     return {
-        "schema": "sure.eval.deployment_binding.v1",
+        "schema": DEPLOYMENT_BINDING_V2,
+        "runtime_kind": "container",
         "model_name": model_name,
         "model_dir": str(model_dir),
         "source": "approved_nfs_models",

--- a/sure/skills/sure_eval/scripts/evaluate_predictions.py
+++ b/sure/skills/sure_eval/scripts/evaluate_predictions.py
@@ -1544,8 +1544,10 @@ def _write_protocol_yaml(
     status_runtime_inventory = _nested_dict(status_runtime, "runtime_inventory")
     harness_runtime = _safe_dict(status_runtime.get("harness_runtime"))
     inventory_container = _safe_dict(runtime_inventory.get("container_runtime"))
+    inventory_model_runtime = _safe_dict(runtime_inventory.get("model_runtime"))
     inventory_local = _safe_dict(runtime_inventory.get("local_runtime"))
     inventory_policy = _safe_dict(runtime_inventory.get("policy"))
+    runtime_kind = "python" if inventory_policy.get("eval_runtime") == "python" else "container"
     status_server_config = _safe_dict(status_runtime.get("server_config"))
     server_command = status_runtime.get("server_command") or sanitized_server.get("command", [])
     server_working_dir = status_runtime.get("server_working_dir") or sanitized_server.get("working_dir", ".")
@@ -1632,6 +1634,7 @@ def _write_protocol_yaml(
         },
         "inference_environment": {
             "execution_path": os.environ.get("SURE_EVAL_EXECUTION_PATH", "unknown"),
+            "runtime_kind": runtime_kind,
             "vc": {
                 "job_id": os.environ.get("SURE_EVAL_EXECUTION_JOB_ID") or os.environ.get("VC_JOB_ID"),
                 "partition": os.environ.get("SURE_EVAL_VC_PARTITION") or os.environ.get("VC_PARTITION"),
@@ -1652,6 +1655,15 @@ def _write_protocol_yaml(
                 "model_dir": str(model_dir) if model_dir else None,
                 "python_executable": inventory_container.get("python_executable"),
                 "working_dir": inventory_container.get("working_dir"),
+                "execution_mode": inventory_policy.get("eval_runtime"),
+                "host_python_fallback": inventory_policy.get("host_python_fallback"),
+            },
+            "model_runtime": {
+                "runtime_id": inventory_model_runtime.get("runtime_id"),
+                "python_executable": os.environ.get("MODEL_PYTHON") if runtime_kind == "python" else None,
+                "lock_sha256": inventory_model_runtime.get("lock_sha256"),
+                "manifest_sha256": inventory_model_runtime.get("manifest_sha256"),
+                "working_dir": os.environ.get("SURE_EVAL_MODEL_WORKING_DIR") if runtime_kind == "python" else None,
                 "execution_mode": inventory_policy.get("eval_runtime"),
                 "host_python_fallback": inventory_policy.get("host_python_fallback"),
             },
@@ -1699,7 +1711,12 @@ def _write_protocol_yaml(
                     if path is not None
                 ],
                 "reject_repo_internal_runtime_mount_overlays": True,
-                "nfs_models_read_only": _nested_dict(inventory_container, "mount_policy").get("nfs_models_read_only"),
+                "nfs_models_read_only": (
+                    False
+                    if runtime_kind == "python"
+                    else _nested_dict(inventory_container, "mount_policy").get("nfs_models_read_only")
+                ),
+                "model_integrity": "verify_before_after" if runtime_kind == "python" else "image_digest",
                 "result_workspace": _nested_dict(_nested_dict(inventory_container, "mount_policy"), "result_workspace"),
             },
         },

--- a/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
+++ b/sure/skills/sure_eval/scripts/generate_predictions_via_server.py
@@ -66,15 +66,29 @@ def _resolve_server_command(
     runtime_inventory: dict[str, Any],
 ) -> list[str]:
     container = runtime_inventory.get("container_runtime")
+    model_runtime = runtime_inventory.get("model_runtime")
     policy = runtime_inventory.get("policy")
     if runtime_inventory.get("schema") != "sure.onboard.runtime_inventory.v2":
         raise ValueError(f"approved model has unsupported runtime inventory: {model_dir}")
     if runtime_inventory.get("status") != "ready":
         raise ValueError("approved model runtime inventory is not ready")
-    if not isinstance(policy, dict) or policy.get("eval_runtime") != "container_only":
-        raise ValueError("approved model is not bound to container-only execution")
+    if not isinstance(policy, dict):
+        raise ValueError("approved model runtime policy is missing")
     if policy.get("host_python_fallback") is not False or policy.get("image_override_allowed") is not False:
         raise ValueError("approved model runtime policy permits a forbidden fallback or image override")
+    if policy.get("eval_runtime") == "python":
+        if not isinstance(model_runtime, dict) or model_runtime.get("required") is not True:
+            raise ValueError("approved Model Python runtime is missing")
+        command = model_runtime.get("server_command")
+        if not isinstance(command, list) or not command or not all(isinstance(item, str) and item for item in command):
+            raise ValueError("approved Model Python server_command is invalid")
+        actual_python = os.environ.get("MODEL_PYTHON", "")
+        runtime_id = os.environ.get("SURE_EVAL_MODEL_RUNTIME_ID", "")
+        if not actual_python or runtime_id != model_runtime.get("runtime_id"):
+            raise ValueError("active Model Python does not match the approved runtime identity")
+        return [actual_python, *command[1:]]
+    if policy.get("eval_runtime") != "container_only":
+        raise ValueError("approved model has no supported Eval runtime")
     if not isinstance(container, dict):
         raise ValueError("approved model container runtime is missing")
     command = container.get("server_command")
@@ -91,6 +105,17 @@ def _resolve_server_command(
 
 
 def _resolve_working_dir(model_dir: Path, runtime_inventory: dict[str, Any]) -> Path:
+    policy = runtime_inventory.get("policy") if isinstance(runtime_inventory.get("policy"), dict) else {}
+    if policy.get("eval_runtime") == "python":
+        raw = os.environ.get("SURE_EVAL_MODEL_WORKING_DIR", "")
+        path = Path(raw).expanduser().resolve()
+        try:
+            path.relative_to(model_dir.resolve())
+        except ValueError as exc:
+            raise ValueError("approved Model Python working_dir escapes the model bundle") from exc
+        if not path.is_dir():
+            raise ValueError(f"approved Model Python working_dir does not exist: {path}")
+        return path
     container = runtime_inventory.get("container_runtime")
     working_dir = container.get("working_dir") if isinstance(container, dict) else None
     path = Path(str(working_dir or ""))
@@ -459,6 +484,7 @@ def _runtime_inventory_summary(model_dir: Path) -> dict[str, Any]:
         "status": inventory.get("status"),
         "schema": inventory.get("schema"),
         "container_runtime": inventory.get("container_runtime") if isinstance(inventory.get("container_runtime"), dict) else {},
+        "model_runtime": inventory.get("model_runtime") if isinstance(inventory.get("model_runtime"), dict) else {},
         "policy": inventory.get("policy") if isinstance(inventory.get("policy"), dict) else {},
         "evidence": inventory.get("evidence") if isinstance(inventory.get("evidence"), dict) else {},
     }
@@ -1068,8 +1094,13 @@ def main() -> int:
     tool_name = args.tool_name or (tools[0]["name"] if tools else None)
     if not tool_name:
         raise ValueError("No tool name provided and config.yaml has no tools entry")
-    container_runtime = runtime_inventory_document.get("container_runtime")
-    approved_tools = container_runtime.get("tool_names") if isinstance(container_runtime, dict) else []
+    runtime_policy = runtime_inventory_document.get("policy") if isinstance(runtime_inventory_document.get("policy"), dict) else {}
+    selected_runtime = (
+        runtime_inventory_document.get("model_runtime")
+        if runtime_policy.get("eval_runtime") == "python"
+        else runtime_inventory_document.get("container_runtime")
+    )
+    approved_tools = selected_runtime.get("tool_names") if isinstance(selected_runtime, dict) else []
     if tool_name not in approved_tools:
         raise ValueError(f"tool {tool_name!r} is not present in the approved runtime inventory: {approved_tools}")
     tool_args = _merge_protocol_tool_args(

--- a/sure/skills/sure_eval/scripts/python_execution.py
+++ b/sure/skills/sure_eval/scripts/python_execution.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Build an explicitly approved trusted-host Model Python launch."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+from typing import Any, Mapping
+
+from container_execution import surface_env
+from deployment_binding import DEPLOYMENT_BINDING_V2
+from evaluation_runtime import evaluation_runtime_from_eval_input
+from harness_runtime import harness_runtime_from_eval_input
+
+
+ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+HOST_ENV_ALLOW = {
+    "CUDA_VISIBLE_DEVICES",
+    "LANG",
+    "LC_ALL",
+    "LD_LIBRARY_PATH",
+    "NVIDIA_DRIVER_CAPABILITIES",
+    "NVIDIA_VISIBLE_DEVICES",
+    "PATH",
+    "TERM",
+    "TZ",
+}
+SURFACE_ENV_ALLOW = {
+    "DATASET",
+    "DATASETS",
+    "DEVICE",
+    "DEVICE_REQUEST",
+    "DEVICE_RESOLVED",
+    "EXECUTION_PATH",
+    "MAX_SAMPLES",
+    "METRICS",
+    "MODEL_NAME",
+    "PROTOCOL",
+    "RUN_ID",
+    "SMOKE_ONLY",
+    "SMOKE_TEST_SAMPLES",
+    "SURE_EVAL_CONFIG",
+    "SURE_EVAL_DATASETS_ROOT",
+    "TOOL_NAME",
+}
+SENSITIVE_PARTS = (
+    "ACCESS_KEY",
+    "API_KEY",
+    "AUTH",
+    "COOKIE",
+    "CREDENTIAL",
+    "PASSWORD",
+    "PRIVATE_KEY",
+    "SECRET",
+    "TOKEN",
+)
+
+
+def deployment_binding(eval_input: dict[str, Any]) -> dict[str, Any]:
+    model = eval_input.get("model") if isinstance(eval_input.get("model"), dict) else {}
+    binding = model.get("deployment_binding")
+    if not isinstance(binding, dict):
+        runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+        binding = runtime.get("deployment_binding")
+    policy = binding.get("policy") if isinstance(binding, dict) and isinstance(binding.get("policy"), dict) else {}
+    if (
+        not isinstance(binding, dict)
+        or binding.get("schema") != DEPLOYMENT_BINDING_V2
+        or binding.get("runtime_kind") != "python"
+        or policy.get("execution_mode") != "python"
+        or policy.get("host_python_fallback") is not False
+    ):
+        raise ValueError("eval input does not contain an explicitly approved Python deployment binding")
+    return binding
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def verify_model_integrity(binding: dict[str, Any]) -> dict[str, str]:
+    model_dir = Path(str(binding.get("model_dir") or "")).expanduser().resolve()
+    evidence = binding.get("evidence") if isinstance(binding.get("evidence"), dict) else {}
+    declared = evidence.get("model_core_sha256")
+    if not isinstance(declared, dict) or not declared:
+        raise ValueError("approved Python binding has no model integrity baseline")
+    verified: dict[str, str] = {}
+    for relative, expected in declared.items():
+        if not isinstance(relative, str) or not isinstance(expected, str):
+            raise ValueError("approved Python model integrity entry is invalid")
+        path = (model_dir / relative).resolve()
+        try:
+            path.relative_to(model_dir)
+        except ValueError as exc:
+            raise ValueError(f"model integrity path escapes approved model: {relative}") from exc
+        if not path.is_file() or _sha256(path) != expected:
+            raise ValueError(f"approved model changed after onboarding: {relative}")
+        verified[relative] = expected
+    return verified
+
+
+def _safe_environment(source: Mapping[str, str], declared: Mapping[str, str]) -> dict[str, str]:
+    env = {key: value for key, value in source.items() if key in HOST_ENV_ALLOW}
+    for key, value in declared.items():
+        if not ENV_NAME_RE.fullmatch(key) or any(part in key.upper() for part in SENSITIVE_PARTS):
+            continue
+        if key in HOST_ENV_ALLOW or key in SURFACE_ENV_ALLOW or key.startswith(("SURE_EVAL_", "SURE_HARNESS_")):
+            env[key] = str(value)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    return env
+
+
+def build_local_python_command(
+    *,
+    surface: dict[str, Any],
+    eval_input: dict[str, Any],
+    entrypoint: Path,
+    repo_root: Path,
+    extra_env: dict[str, str] | None = None,
+) -> tuple[list[str], dict[str, str], dict[str, Any]]:
+    binding = deployment_binding(eval_input)
+    python = binding.get("python") if isinstance(binding.get("python"), dict) else {}
+    model_python = Path(str(python.get("python_executable") or "")).expanduser()
+    model_dir = Path(str(binding.get("model_dir") or "")).expanduser().resolve()
+    working_dir = Path(str(python.get("working_dir") or model_dir)).expanduser().resolve()
+    if not model_python.is_file() or not os.access(model_python, os.X_OK):
+        raise ValueError("approved Model Python is not materialized")
+    if not model_dir.is_dir() or not working_dir.is_dir():
+        raise ValueError("approved Python model paths are not materialized")
+    verified = verify_model_integrity(binding)
+
+    harness_runtime = harness_runtime_from_eval_input(eval_input)
+    harness_python = Path(str(harness_runtime["python_executable"])).expanduser()
+    if model_python.parent.resolve() / model_python.name == harness_python.parent.resolve() / harness_python.name:
+        raise ValueError("Harness Python and Model Python must remain separate execution roles")
+    evaluation_runtime = evaluation_runtime_from_eval_input(eval_input, prepare=False)
+    runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+    output_dir = Path(str(runtime.get("run_dir") or "")).expanduser().resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    skill_root = (repo_root / "sure" / "skills" / "sure_eval").resolve()
+    if not (skill_root / "scripts").is_dir():
+        raise ValueError(f"SURE-EVAL skill root is invalid: {skill_root}")
+    cache_root = output_dir / ".runtime" / "cache"
+    source_provenance = surface.get("source_provenance") if isinstance(surface.get("source_provenance"), dict) else {}
+
+    declared = surface_env(surface)
+    declared.update(extra_env or {})
+    env = _safe_environment(os.environ, declared)
+    env.update(
+        {
+            "MODEL_DIR": str(model_dir),
+            "REPO_ROOT": str(skill_root),
+            "SURE_EVAL_APPROVED_MODEL_DIR": str(model_dir),
+            "RUN_DIR": str(output_dir),
+            "MODEL_PYTHON": str(model_python),
+            "PYTHON_BIN": str(model_python),
+            "HARNESS_PYTHON_BIN": str(harness_python),
+            "SURE_HARNESS_RUNTIME_ID": str(harness_runtime["runtime_id"]),
+            "SURE_HARNESS_LOCK_SHA256": str(harness_runtime["lock_sha256"]),
+            "SURE_HARNESS_MANIFEST_PATH": str(harness_runtime["manifest_path"]),
+            "SURE_HARNESS_RUNTIME_ROOT": str(harness_runtime["runtime_root"]),
+            "SURE_EVAL_EXECUTION_SURFACE_TYPE": "main_flow_script",
+            "SURE_EVAL_EXECUTION_ENTRYPOINT": str(entrypoint.resolve()),
+            "SURE_EVAL_EXECUTION_GENERATION_METHOD": str(surface.get("generation_method") or "harness_template"),
+            "SURE_EVAL_EXECUTION_TEMPLATE_FILE": str(source_provenance.get("template_file") or ""),
+            "SURE_EVAL_EXECUTION_TEMPLATE_SHA256": str(source_provenance.get("template_sha256") or ""),
+            "SURE_EVAL_PUBLISHED_RUN_DIR": str(output_dir),
+            "SURE_EVAL_MODEL_RUNTIME_KIND": "python",
+            "SURE_EVAL_MODEL_RUNTIME_ID": str(python.get("runtime_id") or ""),
+            "SURE_EVAL_MODEL_WORKING_DIR": str(working_dir),
+            "SURE_EVAL_WRITABLE_CACHE_ROOT": str(cache_root),
+            "SURE_EVAL_CACHE_DIR": str(cache_root / "sure-eval"),
+            "HF_HOME": str(cache_root / "huggingface"),
+            "HF_HUB_CACHE": str(cache_root / "huggingface" / "hub"),
+            "TRANSFORMERS_CACHE": str(cache_root / "huggingface" / "transformers"),
+            "MODELSCOPE_CACHE": str(cache_root / "modelscope"),
+            "TORCH_HOME": str(cache_root / "torch"),
+            "XDG_CACHE_HOME": str(cache_root / "xdg"),
+        }
+    )
+    if evaluation_runtime is not None:
+        env.update(
+            {
+                "SURE_EVALUATION_PYTHON": str(evaluation_runtime["python_executable"]),
+                "SURE_EVALUATION_RUNTIME_ID": str(evaluation_runtime["runtime_id"]),
+                "SURE_EVALUATION_LOCK_SHA256": str(evaluation_runtime["lock_sha256"]),
+                "SURE_EVALUATION_RUNTIME_MANIFEST": str(evaluation_runtime["manifest_path"]),
+                "SURE_EVALUATION_HOME": str(evaluation_runtime["engine_root"]),
+            }
+        )
+    return ["bash", str(entrypoint.resolve())], env, {
+        "runtime_kind": "python",
+        "model_runtime": python,
+        "harness_runtime": harness_runtime,
+        "evaluation_runtime": evaluation_runtime,
+        "model_dir": str(model_dir),
+        "working_dir": str(working_dir),
+        "model_core_sha256": verified,
+        "host_python_fallback": False,
+    }

--- a/sure/skills/sure_eval/scripts/resolve_eval_input.py
+++ b/sure/skills/sure_eval/scripts/resolve_eval_input.py
@@ -450,6 +450,8 @@ def _normalize_execution(
     execution: str | None,
     execution_path: str | None,
     allowed_surfaces: list[str] | None = None,
+    runtime_kind: str = "container",
+    allowed_local_runtimes: list[str] | None = None,
 ) -> dict[str, Any]:
     requested_raw = (execution or "").strip().lower()
     path_raw = (execution_path or "").strip().lower()
@@ -457,6 +459,7 @@ def _normalize_execution(
         "vc_submit": "vc",
         "local_bash": "local",
         "local_docker": "local",
+        "local_python": "local",
         "auto": "auto",
     }
     if not requested_raw:
@@ -468,6 +471,7 @@ def _normalize_execution(
         "local": "local",
         "local_bash": "local",
         "local_docker": "local",
+        "local_python": "local",
         "bash": "local",
         "auto": "auto",
     }
@@ -482,31 +486,43 @@ def _normalize_execution(
                 "Use execution=auto|local|vc, or the matching legacy execution_path."
             )
 
+    if requested == "vc" and runtime_kind != "container":
+        raise ValueError("execution=vc requires an approved container runtime")
+    local_path = "local_python" if runtime_kind == "python" else "local_docker"
     if path_raw and path_raw != "auto":
-        planned_path = "local_docker" if path_raw == "local_bash" else path_raw
+        planned_path = local_path if path_raw == "local_bash" else path_raw
+        if planned_path.startswith("local_") and planned_path != local_path:
+            raise ValueError(
+                f"execution_path={planned_path} conflicts with approved runtime={runtime_kind}; expected {local_path}"
+            )
     elif requested == "vc":
         planned_path = "vc_submit"
     elif requested == "local":
-        planned_path = "local_docker"
+        planned_path = local_path
     else:
         planned_path = "auto"
-    if planned_path not in {"auto", "vc_submit", "local_bash", "local_docker"}:
-        raise ValueError(f"Unsupported execution_path: {execution_path}. Use auto, vc_submit, local_bash, or local_docker.")
+    if planned_path not in {"auto", "vc_submit", "local_bash", "local_docker", "local_python"}:
+        raise ValueError(
+            f"Unsupported execution_path: {execution_path}. Use auto, vc_submit, local_python, or local_docker."
+        )
 
     available = _vc_available()
+    allowed = set(allowed_surfaces or ("local", "vc"))
+    local_runtime_allowed = runtime_kind in set(allowed_local_runtimes or ("container",))
     if planned_path == "auto":
-        allowed = set(allowed_surfaces or ("local", "vc"))
-        if available and "vc" in allowed:
+        if runtime_kind == "container" and available and "vc" in allowed:
             planned_path = "vc_submit"
-        elif "local" in allowed:
-            planned_path = "local_docker"
-        elif "vc" in allowed:
+        elif "local" in allowed and local_runtime_allowed:
+            planned_path = local_path
+        elif runtime_kind == "container" and "vc" in allowed:
             planned_path = "vc_submit"
         else:
-            raise ValueError("site policy enables no supported execution surface")
+            raise ValueError(f"site policy enables no execution surface for the approved {runtime_kind} runtime")
     planned = "vc" if planned_path == "vc_submit" else "local"
     if allowed_surfaces is not None and planned not in set(allowed_surfaces):
         raise ValueError(f'execution surface "{planned}" is not enabled by the active site policy')
+    if planned == "local" and not local_runtime_allowed:
+        raise ValueError(f'local runtime "{runtime_kind}" is not enabled by execution.local_runtimes')
     reason = (
         "user_requested_vc"
         if requested == "vc"
@@ -514,6 +530,8 @@ def _normalize_execution(
         if requested == "local"
         else "auto_selected_vc_available"
         if planned == "vc"
+        else "auto_selected_local_runtime_only"
+        if runtime_kind == "python"
         else "auto_selected_local_vc_unavailable"
     )
     return {
@@ -768,7 +786,9 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             f"{model.get('approved_models_root')}"
         )
     model_dir = Path(str(model["model_dir"]))
-    image_harness = ((model.get("deployment_binding") or {}).get("container") or {}).get("harness_runtime")
+    deployment_binding = model.get("deployment_binding") or {}
+    runtime_kind = str(deployment_binding.get("runtime_kind") or "container")
+    image_harness = ((deployment_binding.get("container") or {})).get("harness_runtime")
     if isinstance(image_harness, dict):
         if image_harness.get("runtime_id") != harness_runtime.get("runtime_id"):
             raise EvalInputError("approved image Harness Runtime ID differs from the active Harness Runtime")
@@ -805,15 +825,24 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     languages = _dedupe([str(item.get("language") or "") for item in datasets if item.get("language")])
     metric_list = _dedupe([metric for item in datasets for metric in item.get("default_metrics", [])])
     allowed_surfaces = list(active_site_policy["policy"]["execution"]["surfaces"])
-    execution = _normalize_execution(args.execution, args.execution_path, allowed_surfaces)
+    allowed_local_runtimes = list(active_site_policy["policy"]["execution"]["local_runtimes"])
+    execution = _normalize_execution(
+        args.execution,
+        args.execution_path,
+        allowed_surfaces,
+        runtime_kind,
+        allowed_local_runtimes,
+    )
     device = _resolve_device(args.device, execution)
     vc_request = _vc_request(args)
     approved_image = str((model.get("deployment_binding") or {}).get("target_image_ref") or "")
-    if vc_request.get("image") and vc_request["image"] != approved_image:
+    if runtime_kind == "python" and vc_request.get("image"):
+        raise EvalInputError("vc_image is not valid for a local Python runtime")
+    if runtime_kind == "container" and vc_request.get("image") and vc_request["image"] != approved_image:
         raise EvalInputError(
             f"vc_image cannot override the approved digest-pinned image {approved_image}"
         )
-    vc_request["image"] = approved_image
+    vc_request["image"] = approved_image if runtime_kind == "container" else ""
     _validate_vc_partition(vc_request, execution)
 
     main_flow_input = {
@@ -845,6 +874,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "device_resolved": device["resolved"],
             "execution": execution,
             "execution_path": execution["path_planned"],
+            "model_runtime": runtime_kind,
             "max_samples": args.max_samples,
             "deployment_binding": model["deployment_binding"],
             "harness_runtime": harness_runtime,
@@ -886,6 +916,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "device": device,
             "execution": execution,
             "execution_path": execution["path_planned"],
+            "model_runtime": runtime_kind,
             "vc": vc_request,
             "deployment_binding": model["deployment_binding"],
             "harness_runtime": harness_runtime,
@@ -922,7 +953,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--metrics", nargs="*", default=[])
     parser.add_argument("--max-samples", type=int, default=0)
     parser.add_argument("--execution", choices=("auto", "local", "vc"))
-    parser.add_argument("--execution-path", default="auto", choices=("local_bash", "local_docker", "vc_submit", "auto"))
+    parser.add_argument(
+        "--execution-path",
+        default="auto",
+        choices=("local_bash", "local_docker", "local_python", "vc_submit", "auto"),
+    )
     parser.add_argument("--vc-partition", default="")
     parser.add_argument("--vc-cpu", type=int, default=0)
     parser.add_argument("--vc-mem", default="")

--- a/sure/skills/sure_eval/scripts/run_local_execution.py
+++ b/sure/skills/sure_eval/scripts/run_local_execution.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any
 
 from container_execution import build_local_container_command, effective_container_exit_code
+from python_execution import build_local_python_command, verify_model_integrity
 
 
 def _utc_now() -> str:
@@ -68,7 +69,9 @@ def _execution_from_surface(surface: dict[str, Any], eval_input: dict[str, Any])
         execution = runtime.get("execution") if isinstance(runtime.get("execution"), dict) else {}
     requested = str(execution.get("requested") or "local")
     planned = str(execution.get("planned") or ("vc" if execution.get("path_planned") == "vc_submit" else "local"))
-    path_planned = str(execution.get("path_planned") or ("vc_submit" if planned == "vc" else "local_docker"))
+    runtime = eval_input.get("runtime") if isinstance(eval_input.get("runtime"), dict) else {}
+    local_path = "local_python" if runtime.get("model_runtime") == "python" else "local_docker"
+    path_planned = str(execution.get("path_planned") or ("vc_submit" if planned == "vc" else local_path))
     return {
         "requested": requested,
         "planned": planned,
@@ -151,9 +154,14 @@ def main() -> int:
     vc_available = _vc_available()
     if execution["requested"] == "vc" or execution["path_planned"] == "vc_submit":
         raise RuntimeError("Refusing local execution because the resolved execution plan requires vc_submit.")
-    if execution["path_planned"] != "local_docker":
-        raise RuntimeError("Refusing host execution: local inference must use local_docker.")
-    if execution["requested"] == "auto" and vc_available and not args.allow_auto_local_override:
+    if execution["path_planned"] not in {"local_docker", "local_python"}:
+        raise RuntimeError("Resolved local execution path must be local_python or local_docker.")
+    if (
+        execution["path_planned"] == "local_docker"
+        and execution["requested"] == "auto"
+        and vc_available
+        and not args.allow_auto_local_override
+    ):
         raise RuntimeError("Refusing local execution because execution=auto and vc is available; submit through vc instead.")
 
     entrypoint = _entrypoint(surface)
@@ -168,49 +176,67 @@ def main() -> int:
 
     local_fallback_reason = ""
     fallback_approved = False
-    if execution["requested"] == "auto" and not vc_available:
+    if execution["requested"] == "auto" and execution["path_planned"] == "local_python":
+        local_fallback_reason = "the approved Python runtime is local-only and cannot be submitted to vc"
+        fallback_approved = vc_available
+    elif execution["requested"] == "auto" and not vc_available:
         local_fallback_reason = "execution=auto selected local execution because vc is unavailable"
     elif execution["requested"] == "auto" and vc_available and args.allow_auto_local_override:
         local_fallback_reason = "execution=auto local override was explicitly allowed while vc was available"
         fallback_approved = True
 
-    command, container_binding = build_local_container_command(
-        surface=surface,
-        eval_input=eval_input,
-        control_run_dir=run_dir,
-        entrypoint=entrypoint,
-        repo_root=cwd,
-        device_request=device_request,
-        extra_env={
-            **device_env,
-            "SURE_EVAL_EXECUTION_PATH": "local_docker",
-            "SURE_EVAL_EXECUTION_REQUESTED": execution["requested"],
-            "SURE_EVAL_EXECUTION_JOB_ID": f"local:{host}:{run_dir.name}",
-            "SURE_EVAL_CONTAINER_REPO_ROOT": str(cwd),
-            "SURE_EVAL_VC_PARTITION": "",
-            "SURE_EVAL_VC_GPU": "0",
-            "SURE_EVAL_VC_CPU": "",
-            "SURE_EVAL_VC_MEMORY": "",
-            "SURE_EVAL_VC_NODES": "0",
-        },
-    )
+    execution_path = execution["path_planned"]
+    extra_env = {
+        **device_env,
+        "SURE_EVAL_EXECUTION_PATH": execution_path,
+        "SURE_EVAL_EXECUTION_REQUESTED": execution["requested"],
+        "SURE_EVAL_EXECUTION_JOB_ID": f"local:{host}:{run_dir.name}",
+        "SURE_EVAL_VC_PARTITION": "",
+        "SURE_EVAL_VC_GPU": "0",
+        "SURE_EVAL_VC_CPU": "",
+        "SURE_EVAL_VC_MEMORY": "",
+        "SURE_EVAL_VC_NODES": "0",
+    }
+    if execution_path == "local_python":
+        command, process_env, launch_binding = build_local_python_command(
+            surface=surface,
+            eval_input=eval_input,
+            entrypoint=entrypoint,
+            repo_root=cwd,
+            extra_env=extra_env,
+        )
+    else:
+        command, launch_binding = build_local_container_command(
+            surface=surface,
+            eval_input=eval_input,
+            control_run_dir=run_dir,
+            entrypoint=entrypoint,
+            repo_root=cwd,
+            device_request=device_request,
+            extra_env={**extra_env, "SURE_EVAL_CONTAINER_REPO_ROOT": str(cwd)},
+        )
+        process_env = os.environ.copy()
 
     start = time.monotonic()
     started_at = _utc_now()
     with stdout_path.open("w", encoding="utf-8") as stdout, stderr_path.open("w", encoding="utf-8") as stderr:
-        process = subprocess.Popen(command, cwd=cwd, env=os.environ.copy(), stdout=stdout, stderr=stderr, text=True)
+        process = subprocess.Popen(command, cwd=cwd, env=process_env, stdout=stdout, stderr=stderr, text=True)
         submit_payload = {
-            "execution_path": "local_docker",
+            "execution_path": execution_path,
+            "runtime_kind": "python" if execution_path == "local_python" else "container",
             "execution_requested": execution["requested"],
             "execution": {
                 "requested": execution["requested"],
                 "actual": "local",
-                "path_actual": "local_docker",
+                "path_actual": execution_path,
             },
             "vc_available": vc_available,
             "vc_job_id": "",
             "vc_info": "local execution selected by user or auto policy",
-            "vc_image": str(container_binding["image_ref"]),
+            "vc_image": str(launch_binding.get("image_ref") or ""),
+            "deployment_binding": launch_binding,
+            "model_runtime": launch_binding.get("model_runtime") or {},
+            "harness_runtime": launch_binding.get("harness_runtime") or {},
             "fallback_approved": fallback_approved,
             "local_fallback_reason": local_fallback_reason,
             "submitted_at": started_at,
@@ -228,12 +254,24 @@ def main() -> int:
         returncode = process.wait()
     stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace") if stdout_path.exists() else ""
     stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace") if stderr_path.exists() else ""
-    returncode = effective_container_exit_code(returncode, stdout_text, stderr_text)
+    if execution_path == "local_docker":
+        returncode = effective_container_exit_code(returncode, stdout_text, stderr_text)
+    else:
+        binding = (eval_input.get("model") or {}).get("deployment_binding") or (
+            eval_input.get("runtime") or {}
+        ).get("deployment_binding")
+        try:
+            verify_model_integrity(binding)
+        except ValueError as exc:
+            with stderr_path.open("a", encoding="utf-8") as stderr:
+                stderr.write(f"\nMODEL_INTEGRITY_VIOLATION: {exc}\n")
+            returncode = returncode or 70
     duration = time.monotonic() - start
     job_status = "succeeded" if returncode == 0 else "failed"
     execution_payload = {
         "job_status": job_status,
-        "execution_path": "local_docker",
+        "execution_path": execution_path,
+        "runtime_kind": "python" if execution_path == "local_python" else "container",
         "execution_requested": execution["requested"],
         "host": host,
         "pid": submit_payload["pid"],

--- a/sure/skills/sure_eval/scripts/run_smoke.py
+++ b/sure/skills/sure_eval/scripts/run_smoke.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from container_execution import build_local_container_command, effective_container_exit_code
+from python_execution import build_local_python_command, verify_model_integrity
 
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -254,21 +255,36 @@ def main() -> int:
     logs_dir.mkdir(parents=True, exist_ok=True)
     log_path = logs_dir / "smoke_test.log"
     device_request = _device_request(surface, eval_input)
-    command, _ = build_local_container_command(
-        surface=surface,
-        eval_input=eval_input,
-        control_run_dir=run_dir.resolve(),
-        entrypoint=entrypoint_path.resolve(),
-        repo_root=Path(__file__).resolve().parents[4],
-        device_request=device_request,
-        extra_env={
-            **_local_device_env(device_request),
-            "SMOKE_ONLY": "1",
-            "SMOKE_TEST_SAMPLES": str(smoke_samples),
-            "SURE_EVAL_EXECUTION_PATH": "local_docker_smoke",
-            "SURE_EVAL_EXECUTION_REQUESTED": _execution_requested(surface),
-        },
-    )
+    binding = (eval_input.get("model") or {}).get("deployment_binding") or (
+        eval_input.get("runtime") or {}
+    ).get("deployment_binding") or {}
+    runtime_kind = str(binding.get("runtime_kind") or "container")
+    extra_env = {
+        **_local_device_env(device_request),
+        "SMOKE_ONLY": "1",
+        "SMOKE_TEST_SAMPLES": str(smoke_samples),
+        "SURE_EVAL_EXECUTION_PATH": f"local_{runtime_kind}_smoke",
+        "SURE_EVAL_EXECUTION_REQUESTED": _execution_requested(surface),
+    }
+    if runtime_kind == "python":
+        command, process_env, _ = build_local_python_command(
+            surface=surface,
+            eval_input=eval_input,
+            entrypoint=entrypoint_path.resolve(),
+            repo_root=Path(__file__).resolve().parents[4],
+            extra_env=extra_env,
+        )
+    else:
+        command, _ = build_local_container_command(
+            surface=surface,
+            eval_input=eval_input,
+            control_run_dir=run_dir.resolve(),
+            entrypoint=entrypoint_path.resolve(),
+            repo_root=Path(__file__).resolve().parents[4],
+            device_request=device_request,
+            extra_env=extra_env,
+        )
+        process_env = os.environ.copy()
 
     exit_code = 1
     try:
@@ -276,7 +292,7 @@ def main() -> int:
             completed = subprocess.run(
                 command,
                 cwd=str(Path(__file__).resolve().parents[4]),
-                env=os.environ.copy(),
+                env=process_env,
                 stdout=log,
                 stderr=subprocess.STDOUT,
                 text=True,
@@ -298,7 +314,16 @@ def main() -> int:
         return 1
 
     log_text = log_path.read_text(encoding="utf-8", errors="replace") if log_path.exists() else ""
-    exit_code = effective_container_exit_code(exit_code, log_text)
+    if runtime_kind == "container":
+        exit_code = effective_container_exit_code(exit_code, log_text)
+    else:
+        try:
+            verify_model_integrity(binding)
+        except ValueError as exc:
+            exit_code = exit_code or 70
+            log_text += f"\nMODEL_INTEGRITY_VIOLATION: {exc}\n"
+            with log_path.open("a", encoding="utf-8") as log:
+                log.write(f"\nMODEL_INTEGRITY_VIOLATION: {exc}\n")
     canonical_dataset = _canonical_dataset(eval_input, dataset)
     pred_path = eval_run_dir / "predictions" / f"{canonical_dataset}.txt"
     total, valid = _count_valid_predictions(pred_path)

--- a/sure/skills/sure_eval/scripts/templates/main_agent_execution_surface.json
+++ b/sure/skills/sure_eval/scripts/templates/main_agent_execution_surface.json
@@ -15,11 +15,13 @@
     "reason": ""
   },
   "deployment_binding": {
-    "schema": "sure.eval.deployment_binding.v1",
+    "schema": "sure.eval.deployment_binding.v2",
+    "runtime_kind": "container",
     "target_image_ref": "",
     "bundle_identity_sha256": null,
     "execution_mode": "container_only",
     "model_mount_read_only": true,
+    "model_integrity": "image_digest",
     "result_mount_writable": true
   },
   "inference_runtime": {

--- a/sure/skills/sure_eval/scripts/test_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_deployment_binding.py
@@ -226,6 +226,7 @@ class DeploymentBindingTests(unittest.TestCase):
 
     def test_loads_exact_digest_binding(self) -> None:
         binding = load_deployment_binding(self.model, "demo")
+        self.assertEqual(binding["schema"], "sure.eval.deployment_binding.v2")
         self.assertEqual(binding["target_image_ref"], self.image_ref)
         self.assertTrue(binding["container"]["model_mount"]["read_only"])
 

--- a/sure/skills/sure_eval/scripts/test_eval_input_policy.py
+++ b/sure/skills/sure_eval/scripts/test_eval_input_policy.py
@@ -71,6 +71,28 @@ class ExecutionSurfacePolicyTests(unittest.TestCase):
                 resolve_eval_input._normalize_execution("vc", "auto", ["local"])
         self.assertIn("not enabled by the active site policy", str(ctx.exception))
 
+    def test_python_runtime_is_local_even_when_vc_is_available(self) -> None:
+        with mock.patch.object(resolve_eval_input, "_vc_available", return_value=True):
+            execution = resolve_eval_input._normalize_execution(
+                "auto",
+                "auto",
+                ["local", "vc"],
+                "python",
+                ["container", "python"],
+            )
+        self.assertEqual(execution["path_planned"], "local_python")
+        self.assertEqual(execution["reason"], "auto_selected_local_runtime_only")
+
+    def test_python_runtime_cannot_be_submitted_to_vc(self) -> None:
+        with self.assertRaisesRegex(ValueError, "approved container runtime"):
+            resolve_eval_input._normalize_execution(
+                "vc",
+                "vc_submit",
+                ["local", "vc"],
+                "python",
+                ["container", "python"],
+            )
+
 
 class OutputDirPolicyTests(unittest.TestCase):
     def setUp(self) -> None:

--- a/sure/skills/sure_eval/scripts/test_execution_surface_checks.py
+++ b/sure/skills/sure_eval/scripts/test_execution_surface_checks.py
@@ -33,10 +33,15 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
         live.start()
         self.addCleanup(live.stop)
         self.approved = {
-            "schema": "sure.eval.deployment_binding.v1",
+            "schema": "sure.eval.deployment_binding.v2",
+            "runtime_kind": "container",
             "target_image_ref": IMAGE_REF,
             "container": {"tool_names": ["transcribe_audio"]},
-            "policy": {"execution_mode": "container_only", "host_python_fallback": False},
+            "policy": {
+                "execution_mode": "container_only",
+                "model_integrity": "image_digest",
+                "host_python_fallback": False,
+            },
             "evidence": {"bundle_identity_sha256": "b" * 64},
         }
         self.harness_root = Path(self.temp.name) / "harness"
@@ -80,10 +85,12 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
         surface = {
             "execution": {"requested": "local", "path_planned": "local_docker"},
             "deployment_binding": {
-                "schema": "sure.eval.deployment_binding.v1",
+                "schema": "sure.eval.deployment_binding.v2",
+                "runtime_kind": "container",
                 "target_image_ref": IMAGE_REF,
                 "bundle_identity_sha256": "b" * 64,
                 "execution_mode": "container_only",
+                "model_integrity": "image_digest",
                 "model_mount_read_only": True,
                 "result_mount_writable": True,
             },
@@ -105,6 +112,36 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
         )
         self.assertTrue(result["passed"], result.get("evidence"))
 
+    def test_legacy_v1_container_surface_still_passes(self) -> None:
+        legacy_approved = {
+            "schema": "sure.eval.deployment_binding.v1",
+            "target_image_ref": IMAGE_REF,
+            "container": {"tool_names": ["transcribe_audio"]},
+            "policy": {
+                "execution_mode": "container_only",
+                "host_python_fallback": False,
+            },
+            "evidence": {"bundle_identity_sha256": "b" * 64},
+        }
+        eval_input_path = self.artifacts / "eval_input_resolved.json"
+        eval_input = json.loads(eval_input_path.read_text(encoding="utf-8"))
+        eval_input["model"]["deployment_binding"] = legacy_approved
+        eval_input_path.write_text(json.dumps(eval_input), encoding="utf-8")
+        legacy_declared = {
+            "schema": "sure.eval.deployment_binding.v1",
+            "target_image_ref": IMAGE_REF,
+            "bundle_identity_sha256": "b" * 64,
+            "execution_mode": "container_only",
+            "model_mount_read_only": True,
+            "result_mount_writable": True,
+        }
+
+        result = checks.check_inference_runtime(
+            self.write_surface(deployment_binding=legacy_declared)
+        )
+
+        self.assertTrue(result["passed"], result.get("evidence"))
+
     def test_local_bash_is_rejected(self) -> None:
         result = checks.check_inference_runtime(
             self.write_surface(execution={"requested": "local", "path_planned": "local_bash"})
@@ -114,10 +151,12 @@ class InferenceRuntimeCheckTests(unittest.TestCase):
 
     def test_image_mismatch_is_rejected(self) -> None:
         declared = {
-            "schema": "sure.eval.deployment_binding.v1",
+            "schema": "sure.eval.deployment_binding.v2",
+            "runtime_kind": "container",
             "target_image_ref": "registry.example.com/sure/other@sha256:" + "c" * 64,
             "bundle_identity_sha256": "b" * 64,
             "execution_mode": "container_only",
+            "model_integrity": "image_digest",
             "model_mount_read_only": True,
             "result_mount_writable": True,
         }

--- a/sure/skills/sure_eval/scripts/test_python_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_python_deployment_binding.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from deployment_binding import DeploymentBindingError, load_deployment_binding
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from sure.runtime.model.bootstrap import materialize_runtime
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class PythonDeploymentBindingTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.model = self.root / "models" / "demo"
+        self.artifacts = self.model / "artifacts"
+        self.artifacts.mkdir(parents=True)
+        (self.model / "model.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (self.model / "server.py").write_text("print('server')\n", encoding="utf-8")
+        (self.model / "config.yaml").write_text("tools:\n  - name: predict\n", encoding="utf-8")
+        self.lock = self.model / "requirements.lock"
+        self.lock.write_text("", encoding="utf-8")
+        self.runtime_base = self.root / "site-runtime" / "models"
+        contract = materialize_runtime(
+            runtime_root=self.runtime_base,
+            source_python=Path(sys.executable),
+            lock_path=self.lock,
+        )
+        self.runtime_dir = Path(contract["runtime_root"])
+        manifest = {
+            key: value
+            for key, value in contract.items()
+            if key
+            not in {
+                "runtime_root",
+                "manifest_path",
+                "python_executable_resolved",
+                "manifest_sha256",
+                "probe",
+            }
+        }
+        write_json(self.artifacts / "model_runtime_manifest.json", manifest)
+        core_hashes = {
+            relative: sha256(self.model / relative)
+            for relative in ("model.py", "server.py", "config.yaml", "requirements.lock")
+        }
+        inventory = {
+            "schema": "sure.onboard.runtime_inventory.v2",
+            "status": "ready",
+            "model": {"name": "demo", "deployment_type": "local", "bundle_root": "."},
+            "model_runtime": {
+                "required": True,
+                "runtime_type": "model_python",
+                "backend": "uv",
+                "runtime_id": manifest["runtime_id"],
+                "python_executable": "bin/python",
+                "python_version": manifest["python_version"],
+                "python_abi": manifest["python_abi"],
+                "manifest_path": "artifacts/model_runtime_manifest.json",
+                "manifest_sha256": contract["manifest_sha256"],
+                "lockfile_path": "requirements.lock",
+                "lock_sha256": manifest["lock_sha256"],
+                "working_dir": ".",
+                "server_command": ["bin/python", "server.py"],
+                "tool_names": ["predict"],
+                "required_imports": [],
+                "gpu_required": False,
+            },
+            "container_runtime": {"required": False},
+            "policy": {
+                "eval_runtime": "python",
+                "host_python_fallback": False,
+                "image_override_allowed": False,
+                "nfs_models_mutable_by_eval": False,
+            },
+            "evidence": {"model_core_sha256": core_hashes},
+        }
+        package = {
+            "schema": "sure.onboard.package_gate.v2",
+            "status": "passed",
+            "package_profile": "none",
+            "readiness": {
+                "local_ready": True,
+                "container_ready": False,
+                "docker_ready": False,
+                "registry_ready": False,
+                "bundle_ready": True,
+            },
+        }
+        write_json(self.artifacts / "runtime_inventory.json", inventory)
+        write_json(self.artifacts / "package_gate.json", package)
+        hashes = {
+            f"artifacts/{name}": sha256(self.artifacts / name)
+            for name in ("runtime_inventory.json", "package_gate.json", "model_runtime_manifest.json")
+        }
+        marker = {
+            "schema": "sure.onboard.deployment_ready.v2",
+            "status": "ready",
+            "model_name": "demo",
+            "package_profile": "none",
+            "model_runtime": inventory["model_runtime"],
+            "required_artifact_sha256": hashes,
+            "bundle_identity_sha256": hashlib.sha256(
+                json.dumps(hashes, sort_keys=True, separators=(",", ":")).encode()
+            ).hexdigest(),
+            "execution_policy": {
+                "container_only": False,
+                "eval_runtime": "python",
+                "isolation": "trusted_host",
+                "model_integrity": "verify_before_after",
+                "nfs_models_read_only": False,
+                "model_bundle_mutation_allowed": False,
+                "host_python_fallback": False,
+                "approved_image_override": False,
+            },
+        }
+        write_json(self.artifacts / "deployment_ready.json", marker)
+        self.site_policy = self.root / "site.yaml"
+        self.site_policy.write_text(
+            "\n".join(
+                [
+                    "schema: sure.site.policy.v1",
+                    "site_id: test",
+                    "policy_version: 1",
+                    "storage:",
+                    f"  approved_models_roots: [{self.root / 'models'}]",
+                    f"  approved_results_roots: [{self.root / 'results'}]",
+                    f"  forbidden_output_roots: [{self.root / 'forbidden'}]",
+                    f"  runtime_root: {self.root / 'site-runtime'}",
+                    "datasets:",
+                    f"  allowed_source_roots: [{self.root / 'datasets'}]",
+                    "execution:",
+                    "  surfaces: [local]",
+                    "  local_runtimes: [python]",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def load(self) -> dict:
+        with patch.dict(os.environ, {"SURE_SITE_POLICY": str(self.site_policy)}):
+            return load_deployment_binding(self.model, "demo")
+
+    def test_resolves_portable_runtime_id_against_active_site(self) -> None:
+        binding = self.load()
+        self.assertEqual(binding["schema"], "sure.eval.deployment_binding.v2")
+        self.assertEqual(binding["runtime_kind"], "python")
+        self.assertEqual(binding["python"]["runtime_id"], self.runtime_dir.name)
+        self.assertEqual(
+            binding["python"]["python_executable"],
+            str(self.runtime_dir / "bin" / "python"),
+        )
+        self.assertNotIn(str(self.runtime_dir), (self.artifacts / "model_runtime_manifest.json").read_text())
+
+    def test_rejects_model_code_changed_after_promotion(self) -> None:
+        (self.model / "model.py").write_text("VALUE = 2\n", encoding="utf-8")
+        with self.assertRaisesRegex(DeploymentBindingError, "model integrity hash mismatch"):
+            self.load()
+
+    def test_rejects_missing_active_site_runtime(self) -> None:
+        self.runtime_dir.rename(self.runtime_dir.with_name(self.runtime_dir.name + "-missing"))
+        with self.assertRaises(DeploymentBindingError):
+            self.load()
+
+    def test_rejects_python_payload_labeled_as_legacy_v1(self) -> None:
+        marker_path = self.artifacts / "deployment_ready.json"
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["schema"] = "sure.onboard.deployment_ready.v1"
+        write_json(marker_path, marker)
+
+        with self.assertRaisesRegex(DeploymentBindingError, "Python deployment_ready schema"):
+            self.load()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/scripts/test_python_execution.py
+++ b/sure/skills/sure_eval/scripts/test_python_execution.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import python_execution
+import run_local_execution
+
+
+class PythonExecutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.model_dir = self.root / "model"
+        self.model_dir.mkdir()
+        self.model_file = self.model_dir / "model.py"
+        self.model_file.write_text("VALUE = 1\n", encoding="utf-8")
+        self.entrypoint = self.root / "run.sh"
+        self.entrypoint.write_text(
+            "#!/bin/bash\n"
+            "set -eu\n"
+            "test -x \"$MODEL_PYTHON\"\n"
+            "test -n \"$SURE_EVAL_MODEL_RUNTIME_ID\"\n"
+            "test -z \"${OPENAI_API_KEY:-}\"\n"
+            "test -z \"${SSH_AUTH_SOCK:-}\"\n",
+            encoding="utf-8",
+        )
+        self.entrypoint.chmod(0o755)
+        self.harness_python = self.root / "harness" / "bin" / "python"
+        self.harness_python.parent.mkdir(parents=True)
+        self.harness_python.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        self.harness_python.chmod(0o755)
+        self.run_dir = self.root / "run"
+        self.binding = {
+            "schema": "sure.eval.deployment_binding.v2",
+            "runtime_kind": "python",
+            "model_dir": str(self.model_dir),
+            "python": {
+                "runtime_id": "sure-model-python-v1-" + "a" * 24,
+                "python_executable": sys.executable,
+                "working_dir": str(self.model_dir),
+            },
+            "policy": {
+                "execution_mode": "python",
+                "host_python_fallback": False,
+            },
+            "evidence": {
+                "model_core_sha256": {
+                    "model.py": python_execution._sha256(self.model_file),
+                }
+            },
+        }
+        self.eval_input = {
+            "model": {"deployment_binding": self.binding},
+            "runtime": {"run_dir": str(self.run_dir)},
+        }
+
+    def test_builds_sanitized_environment_for_approved_python(self) -> None:
+        harness = {
+            "runtime_id": "sure-harness-test",
+            "python_executable": str(self.harness_python),
+            "lock_sha256": "b" * 64,
+            "manifest_path": str(self.root / "harness" / "runtime-manifest.json"),
+            "runtime_root": str(self.root / "harness"),
+        }
+        surface = {
+            "generation_method": "harness_template",
+            "source_provenance": {},
+            "env": {
+                "TOOL_NAME": "predict",
+                "OPENAI_API_KEY": "declared-secret",
+                "SURE_EVAL_API_TOKEN": "also-secret",
+            },
+        }
+        repo_root = Path(__file__).resolve().parents[4]
+        with (
+            patch.object(python_execution, "harness_runtime_from_eval_input", return_value=harness),
+            patch.object(python_execution, "evaluation_runtime_from_eval_input", return_value=None),
+            patch.dict(
+                os.environ,
+                {"OPENAI_API_KEY": "host-secret", "SSH_AUTH_SOCK": "/tmp/agent.sock"},
+                clear=False,
+            ),
+        ):
+            command, environment, provenance = python_execution.build_local_python_command(
+                surface=surface,
+                eval_input=self.eval_input,
+                entrypoint=self.entrypoint,
+                repo_root=repo_root,
+            )
+
+        self.assertEqual(command, ["bash", str(self.entrypoint)])
+        self.assertNotIn("OPENAI_API_KEY", environment)
+        self.assertNotIn("SURE_EVAL_API_TOKEN", environment)
+        self.assertNotIn("SSH_AUTH_SOCK", environment)
+        self.assertEqual(environment["MODEL_PYTHON"], sys.executable)
+        self.assertEqual(environment["HARNESS_PYTHON_BIN"], str(self.harness_python))
+        self.assertNotEqual(environment["MODEL_PYTHON"], environment["HARNESS_PYTHON_BIN"])
+        self.assertEqual(provenance["runtime_kind"], "python")
+        completed = subprocess.run(command, env=environment, check=False)
+        self.assertEqual(completed.returncode, 0)
+
+    def test_model_integrity_is_checked_again_after_execution(self) -> None:
+        python_execution.verify_model_integrity(self.binding)
+        self.model_file.write_text("VALUE = 2\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "changed after onboarding"):
+            python_execution.verify_model_integrity(self.binding)
+
+    def test_local_python_route_never_builds_a_container_command(self) -> None:
+        artifacts = self.run_dir / "artifacts"
+        artifacts.mkdir(parents=True)
+        surface = {
+            "entrypoint_path": str(self.entrypoint),
+            "execution": {"requested": "local", "planned": "local", "path_planned": "local_python"},
+        }
+        (artifacts / "execution_surface.json").write_text(json.dumps(surface), encoding="utf-8")
+        (artifacts / "eval_input_resolved.json").write_text(
+            json.dumps({**self.eval_input, "runtime": {"run_dir": str(self.run_dir), "model_runtime": "python"}}),
+            encoding="utf-8",
+        )
+        launch = {
+            "runtime_kind": "python",
+            "model_runtime": {"runtime_id": self.binding["python"]["runtime_id"]},
+            "harness_runtime": {},
+        }
+        argv = ["run_local_execution.py", "--run-dir", str(self.run_dir)]
+        with (
+            patch.object(run_local_execution, "_vc_available", return_value=False),
+            patch.object(
+                run_local_execution,
+                "build_local_python_command",
+                return_value=(["bash", "-c", "exit 0"], os.environ.copy(), launch),
+            ),
+            patch.object(
+                run_local_execution,
+                "build_local_container_command",
+                side_effect=AssertionError("Docker route must not be used"),
+            ),
+            patch.object(run_local_execution, "verify_model_integrity", return_value={}),
+            patch.object(sys, "argv", argv),
+        ):
+            self.assertEqual(run_local_execution.main(), 0)
+        submit = json.loads((artifacts / "submit_result.json").read_text(encoding="utf-8"))
+        self.assertEqual(submit["execution_path"], "local_python")
+        self.assertEqual(submit["runtime_kind"], "python")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_eval/scripts/vc_check.py
+++ b/sure/skills/sure_eval/scripts/vc_check.py
@@ -4,7 +4,7 @@
 Probes vc availability (`which vc && vc info`) and validates that the produced
 submit_result.json matches the user-requested execution surface:
 - execution=vc must submit through vc.
-- execution=local must run through the approved local Docker binding.
+- execution=local must run through the approved local runtime binding.
 - execution=auto prefers vc when available; local auto fallback must explain why.
 The environment-derived vc_available field is stamped into the artifact.
 
@@ -66,7 +66,7 @@ def _execution_requested(data: dict, run_dir: Path) -> str:
     execution_path = str(data.get("execution_path") or "")
     if execution_path == "vc_submit":
         return "vc"
-    if execution_path in {"local_bash", "local_docker"}:
+    if execution_path in {"local_bash", "local_docker", "local_python"}:
         return "local"
     return "auto"
 
@@ -101,7 +101,7 @@ def main() -> int:
 
     execution_path = data.get("execution_path", "")
     requested = _execution_requested(data, run_dir)
-    local_paths = {"local_docker"}
+    local_paths = {"local_docker", "local_python"}
 
     if execution_path == "vc_submit":
         required = ("vc_job_id", "submission_token", "terminal_status_path")
@@ -133,7 +133,8 @@ def main() -> int:
         return 1
     if requested == "local" and execution_path not in local_paths:
         print(
-            "SUBMIT_EXECUTION gate: user requested execution=local, so execution_path must be local_docker.",
+            "SUBMIT_EXECUTION gate: user requested execution=local, so execution_path must be "
+            "the approved local_docker or local_python route.",
             file=sys.stderr,
         )
         return 1

--- a/sure/skills/sure_eval/sure.skill.json
+++ b/sure/skills/sure_eval/sure.skill.json
@@ -1,7 +1,7 @@
 {
 	"name": "sure_eval",
 	"command": "/sure_eval",
-	"description": "Orchestrate a SURE-EVAL evaluation run for an already-onboarded audio model: classify the task, route to deterministic scripts, materialize and gate the execution surface, run locally or via vc according to policy, assess results, and write the run report.",
+	"description": "Orchestrate a SURE-EVAL run for an already-onboarded model: verify its sealed runtime binding, route deterministic evaluation scripts, execute locally or via VC according to policy, and write the run report.",
 	"prompt": "SKILL.md",
 	"hooks": {
 		"pre_start": [{ "module": "hooks/index.ts", "handler": "preStart" }],

--- a/sure/skills/sure_onboard/SKILL.md
+++ b/sure/skills/sure_onboard/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: sure-onboard
-description: Adapt an audio model, validate it locally and in Docker, publish a digest-pinned image, and seal a container-only deployment bundle for SURE Eval.
+description: Adapt and validate a model, then seal either the default digest-pinned container or an explicitly approved local Python runtime for SURE Eval.
 ---
 
 # /sure_onboard
 
-Onboard or repair an audio model into a reproducible, container-delivered inference unit. The state machine lives in `hooks/state-machine.ts`; this document is what the agent reads to drive each unit.
+Onboard or repair a model into a reproducible inference unit. The state machine lives in `hooks/state-machine.ts`; this document is what the agent reads to drive each unit.
 
 **Prerequisite**: run `/sure_init` first to select an agent, configure auth, and validate the environment for this project.
 
-Control principle: **agent decides scope, scripts enforce format and execution.** Local validation may use a model-local environment, but a local model is Eval-ready only after Docker build, container validation, registry push, digest-pinned pull verification, and final bundle sealing. API models are the only exception.
+Control principle: **agent decides scope, scripts enforce format and execution.** Docker registry delivery remains the default. An explicit `package=none` may instead become Eval-ready only when the site permits Python, the backend is `uv`, and a hash-locked Model Runtime is materialized and sealed. A model-local `.venv` by itself is validation evidence, never an Eval runtime.
 
 ## Parameters
 
@@ -25,7 +25,7 @@ Control principle: **agent decides scope, scripts enforce format and execution.*
 | `preferred_backend` | — | `uv \| pip \| conda \| pixi \| docker \| api` (overrides auto-selection). |
 | `python_version` | — | Pin a Python version. |
 | `weights_source` | — | Weights URL / local path. |
-| `package` | — | Local models default to and require `docker-registry` for success. `none` is API/local-diagnostic only; `docker-local` cannot produce an Eval-ready local bundle. |
+| `package` | — | Local models default to `docker-registry`. Explicit `none` selects a sealed local Python runtime when site policy permits `python` and backend=`uv`; API also uses `none`. `docker-local` is diagnostic-only. |
 | `package_profile` | — | Alias for `package`; use only one. |
 | `weights_link_policy` | — | `auto` (default), `copy`, `symlink`, `reuse-existing`, or `no-reuse`. |
 | `skip_download` | — | bool — use existing local weights only. |
@@ -76,7 +76,7 @@ This helper emits only `model_input_resolved.json` and `context_selection.json`.
 
 There are two command families and they must not be mixed:
 
-1. **Harness scripts** (`scripts/check_*.py`, `scripts/run_validate.py`, `scripts/materialize_onboard_inputs.py`, `scripts/prepare_fixture.py`, `scripts/stage_model_artifacts.py`) run from the skill package with harness Python:
+1. **Harness scripts** (`scripts/check_*.py`, `scripts/run_validate.py`, `scripts/materialize_onboard_inputs.py`, `scripts/materialize_model_runtime.py`, `scripts/prepare_fixture.py`, `scripts/stage_model_artifacts.py`) run from the skill package with harness Python:
 
 ```bash
 cd sure/skills/sure_onboard
@@ -117,6 +117,17 @@ There are two Python scopes:
 
 The boundary is strict: `discover` researches evidence; `prepare_fixture` stages the task payload; `build_env` creates the isolated runtime; `generate_wrapper` creates the model-local executable adapter; `validate_import/load/infer/contract` executes model code through that wrapper and runtime.
 
+For explicit local `package=none`, write the normal build result first as `<run_dir>/artifacts/build_env_draft.json`, then seal it with:
+
+```bash
+"$HARNESS_PYTHON_BIN" scripts/materialize_model_runtime.py \
+  --run-dir <run_dir> \
+  --input <run_dir>/artifacts/build_env_draft.json \
+  --produces <run_dir>/artifacts/build_env_result.json
+```
+
+The draft must use backend=`uv`, point to an executable validation Python, and name a `--generate-hashes` lock inside `model_dir`. The generated result replaces its Python path with the active site's content-addressed Model Python. Do not copy that absolute path into portable bundle files.
+
 ### Device Policy
 
 Default device policy is **CUDA-first** for local deployment:
@@ -146,11 +157,11 @@ Isolation rule: `sure/models/<model_name>/` itself must be a real harness-owned 
 
 Advance happens **only** when the current unit's `produces` is compliant. Linear units are agent self-driven; gate units additionally run a Python semantic check. Produce the current unit's artifact, then call `sure_update_state`.
 
-Default target for local models is **registry-backed container-ready**:
+Default target for local models is **registry-backed container-ready**. Local Python is an explicit site-controlled alternative:
 
-- `package=docker-registry`: required for local-model success; build, validate, push, resolve the immutable digest, and pull-verify that exact digest.
+- `package=docker-registry`: default; build, validate, push, resolve the immutable digest, and pull-verify that exact digest.
 - `package=docker-local`: diagnostic only; it may prove a local image but cannot produce an Eval-ready bundle.
-- `package=none`: accepted for API deployments and explicit local diagnostics only; it cannot produce a successful local verdict.
+- `package=none`: API delivery, or local Python when `execution.local_runtimes` includes `python`, backend=`uv`, and the Model Runtime is sealed from a hash-locked requirements file. It never enables VC execution.
 
 VC/HPC submission is not part of this core skill. If needed later, implement it as a separate deployment skill/command.
 
@@ -188,21 +199,21 @@ VC/HPC submission is not part of this core skill. If needed later, implement it 
 - **discover**: Inputs = resolved `repo_url`, `model_dir`, and optional handoff artifacts. Output = `repo_summary.json` with only these top-level fields: `repo_url` (string, required), `timestamp` (string), `model_id` (string), `model_name` (string), `task_type` (string), `deployment_type` (string), `commit` (string|null), `repo_commit` (string|null), `discovery_strategy` (string), `model_dir` (string|null), `model_dir_exists` (boolean), `handoff_artifacts_dir` (string|null), `local_path` (string|null), `evidence_sources` (array of string or object), `file_inventory` (array of strings, or object), `model_card_info` (object), `entrypoints` (object), `dependency_hints` (object), `fixture_hints` (object), `language` (string), `notes` (string); the schema has `additionalProperties:false`. Prefer existing `model_dir` and handoff artifacts before network clone/search. Must Not Do: unbounded filesystem search, full checkpoint download, safetensors/bin transfer, long sleep polling, current-shell/base-Python runtime dependency probes, model load/infer probes, `verdict_status`, `wrapper_path` (later units).
 - **classify**: Output exactly `classification.json` with only these top-level fields: `task_type`, `deployment_type`, `sub_task`, `input_modality`, `output_modality`, `rationale`. Do not include metadata fields such as `timestamp`, `model_id`, `model_name`, or `task_type_reason`; the schema has `additionalProperties:false`. Allowed `task_type` ∈ {asr,s2tt,sd,ser,tts,vc,kws,slu,gr,speech_understanding,sa-asr,sa_asr}.
 - **plan**: Output = `backend_choice.json` {backend, choice_reason, ...}. Allowed: backend ∈ {uv,pip,conda,pixi,docker,api}. See `references/policies/backend_selection.md` + `references/playbooks/env_ROUTING.md`.
-- **build_plan**: Output = `build_plan.json` {model_id, model_dir, backend, package_profile, steps, ...}. It must be executable and must not include required VC/HPC submission steps.
+- **build_plan**: Output = `build_plan.json` {model_id, model_dir, backend, package_profile, steps, ...}. It must be executable and must not include required VC/HPC submission steps. Local `package=none` must select backend=`uv` and include `materialize_model_runtime.py` after producing a hash-locked dependency file.
 - **validate_spec**: Output = `spec_validation.json` {checks, status}. All seven checks (spec_completeness/evidence_sufficiency/conflict_resolution/build_plan_executable/fixture_availability/io_contract_sufficient/preflight_compatible) must pass; status=passed. This unit proves that a task fixture source has been identified; it does not stage the model-local fixture. See `references/contracts/spec_validation.md`.
 - **prepare_fixture**: Output = `fixture_manifest.json` {model_id, model_name, model_dir, task_type, source_dir, staged_dir, gt_jsonl, samples, sample_count, link_policy}. Use `scripts/prepare_fixture.py --run-dir <run_dir> --produces <run_dir>/artifacts/fixture_manifest.json` unless a custom source needs `--source-dir`. The helper selects the fixture source from `spec_validation.checks.fixture_availability.fixture_path` or `fixtures/tasks/<task>/...`, then copies it under `sure/models/<model_name>/fixture/<task>/<fixture_name>/` (`link_policy=copy`). `gt.jsonl` rows must reference relative audio paths inside the fixture directory and carry task annotations; `sa_asr` requires speaker-attributed `segments`; sample_count must be 1-5. This gate exists because `validate.py` discovers payloads from `model_dir/fixture/**/gt.jsonl` or `SURE_VALIDATE_INPUT_JSON`.
-- **build_env**: Output = `build_env_result.json` {env_ready, backend, python_executable, lockfile_path|docker_image, log_path, runtime_checks, runtime_probe, repairs, ...}. env_ready=true. Declared `lockfile_path` and `log_path` must resolve under `model_dir` or run artifacts; Docker backend must declare `docker_image`. For `uv`, create/use the model-local `.venv` under `sure/models/<model_name>/` and ensure `.venv/bin/python` exists. For `conda`/`pixi`, record the selected env and its model-local evidence instead of opportunistically treating base Python as the runtime. If `model.py` already exists, the gate imports it with the selected runtime. If `runtime_checks.required_imports` is set, every declared import must pass. If the resolved request is `device=cuda`, the build env gate must also prove CUDA is visible in that runtime; do not write `env_ready=true` while the selected Python cannot import required packages or has an incompatible torch/transformers stack. If CUDA/dependency repair was needed, preserve it in `repairs` instead of deleting that evidence.
+- **build_env**: Output = `build_env_result.json` {env_ready, backend, python_executable, lockfile_path|docker_image, log_path, runtime_checks, runtime_probe, repairs, ...}. env_ready=true. Declared `lockfile_path` and `log_path` must resolve under `model_dir` or run artifacts; Docker backend must declare `docker_image`. For `uv`, create/use the model-local `.venv` under `sure/models/<model_name>/` and ensure `.venv/bin/python` exists. For local `package=none`, first write a draft with backend=`uv` and a hash-locked file inside `model_dir`, then run `materialize_model_runtime.py --input <draft> --produces <run_dir>/artifacts/build_env_result.json`. The helper resolves a content-addressed runtime under `<site runtime_root>/models/<runtime_id>` and emits portable `model_runtime_manifest.json`; do not hand-author either binding. For `conda`/`pixi`, record the selected env and its model-local evidence instead of opportunistically treating base Python as the runtime. If `model.py` already exists, the gate imports it with the selected runtime. If `runtime_checks.required_imports` is set, every declared import must pass. If the resolved request is `device=cuda`, the build env gate must also prove CUDA is visible in that runtime; do not write `env_ready=true` while the selected Python cannot import required packages or has an incompatible torch/transformers stack. If CUDA/dependency repair was needed, preserve it in `repairs` instead of deleting that evidence.
 - **fetch_weights**: Output = `weights_manifest.json` {weights_ready|status=fetched, source, resolved_local_model_path, ...}. If `weights.required=true`, non-API/non-PyPI sources must resolve to an existing local checkpoint path. Prefer model-local `.runtime/` or `checkpoints/`; if the declared load path is outside `model_dir`, record `fallback_to_host_global=true` and a non-empty `fallback_reason`. For HuggingFace in restricted networks, first try direct metadata with timeout, then retry with `HF_ENDPOINT=https://hf-mirror.com`; if large files redirect to Xet/CAS (`cas-bridge.xethub.hf.co`) and that host times out, record the CAS/Xet failure in `source_attempts` and fail this unit with a user-actionable repair instead of looping. Rich upstream-style fields such as `required`, `repo_id`, `dependencies`, `checkpoint_root`, and `source_attempts` are accepted but must point to existing paths. See `references/contracts/model_local_checkpoint_rule.md`.
 - **validate_env_compat**: Output = `env_compat_result.json` {compat_ok, device, requested_device, python_executable, python_version_match, adapter_protocol_supported, weights_loadable, runtime, weights, adapter, ...}. compat_ok=true must not contradict explicit false checks for python version, adapter protocol, or weights loadability. For local `device=auto`, visible host CUDA forces CUDA-first; CPU fallback must record `cuda_available`, `cuda_attempts`, `cuda_failures`, `cuda_repair_attempts`, and `fallback_reason`.
 - **generate_wrapper**: Output = `wrapper_manifest.json` {wrapper_path, model_py, server_py, ...}. The wrapper set lands in `sure/models/<model_name>/` (model.py, server.py, __init__.py, validate.py). Generated `validate.py` must preserve the template CLI: `--stage import|load|infer|contract|all`, write `artifacts/<stage>_result.json`, write `artifacts/sample_output.json` during infer, and validate contract from `io_contract`. Templates live in `scripts/templates/`. `config.yaml` may enable `protocols.strict_core` only when every conservative parameter (`temperature`, `do_sample`, `num_beams`, `num_return_sequences`, `seed`) maps to a property declared by the selected MCP tool `input_schema`, or is explicitly marked `model_param: null`, `status: not_applicable` with an architecture-specific reason. Omit/disable `strict_core` when that proof is unavailable; `/sure_eval` will still use `standard_system` by default.
 - **metric enrichment reference**: Metric reports are optional enrichment, not a deployment gate. Reuse existing `sample_output.json` / generated audio whenever possible; do not rerun inference only to repair metric semantics.
 - **validate_import/load/infer/contract**: Output = `{*_passed, error, run_command|validate_py, log_path, ...}`. The gate executes `run_command` or `validate_py`; a boolean alone is not accepted. `validate_infer` is additionally Hook-guarded: `fixture_manifest.json` must exist, point to `model_dir/fixture/<task>/.../gt.jsonl`, and declare 1-5 samples before inference can run. `validate_infer` must also leave a non-empty `sample_output.json` under the run or model artifacts directory. `validate_contract` re-reads that sample output and checks it against `MODEL_INPUT.io_contract` (`required_fields`, `nonempty_fields`, `primary_field`, and audio-output evidence).
-- **package_container**: First run `"$HARNESS_PYTHON_BIN" scripts/describe_harness_runtime.py`. Add its exact named build context and `COPY --from=sure_harness_runtime` line to the model Docker build. Output `docker_registry_result.json` plus `docker_build_result.json` and `docker_validation.json`. For local models, evidence must name one target image, its registry digest, the resulting `<image>@sha256:...` reference, the Dockerfile/sample hashes, distinct `model_runtime` and `harness_runtime` bindings, both groups of passing checks, and passing push/pull verification. The gate independently executes both Python roles in the digest-pinned image.
-- **save_artifacts**: Output = `artifact_manifest.json` {model_dir, artifacts.{required,conditional,optional}}. Gate checks model-local files exist and stages the Docker evidence; it does not create runtime readiness.
-- **package_gate**: Output schema v2 = `package_gate.json` {status, package_profile, readiness, bundle_ready, model_dir, artifact_manifest_path}. A local `passed` result requires `docker-registry`, all local validations, and exact Docker tag/digest/ref agreement. `none` and `docker-local` stay non-Eval-ready.
-- **write_runtime_inventory**: Output schema v2 = `runtime_inventory.json`. Local models explicitly separate `model_runtime` and the common `harness_runtime`, and expose only `execution_mode=container_only`, the digest-pinned image, server command/tool names, and read-only model/write-separated result mount policy. Host Model Python is evidence only and is never an Eval fallback.
-- **verdict**: Output = `verdict.json` {status, instance_id, package, readiness, build, validation, artifacts}. A local success requires `package_profile=docker-registry` and `bundle_ready=true`; local-only profiles must remain `partial` or failed.
-- **finalize_model_bundle**: Copies terminal evidence to the model directory, rewrites manifest/package paths to be portable, verifies hashes, and atomically writes `deployment_ready.json`. This file is the only terminal readiness marker consumed by `/sure_eval`.
+- **package_container**: For `docker-local` or `docker-registry`, first run `"$HARNESS_PYTHON_BIN" scripts/describe_harness_runtime.py`. Add its exact named build context and `COPY --from=sure_harness_runtime` line to the model Docker build. Output `docker_registry_result.json` plus `docker_build_result.json` and `docker_validation.json`. Container evidence must bind the image digest and distinct model/harness runtimes; registry delivery also requires passing push/pull verification. For `package=none`, emit `status=skipped` with a reason and do not create Docker evidence.
+- **save_artifacts**: Output = `artifact_manifest.json` {model_dir, artifacts.{required,conditional,optional}}. Gate checks model-local files exist and stages the selected delivery evidence. Local `package=none` requires the exact generated `model_runtime_manifest.json`; it does not infer one from `.venv`.
+- **package_gate**: Output schema v2 = `package_gate.json` {status, package_profile, readiness, bundle_ready, model_dir, artifact_manifest_path}. `docker-registry` requires exact Docker tag/digest/ref agreement. Local `none` requires all local validations, `bundle_ready=true`, all Docker readiness flags false, a byte-identical staged Model Runtime manifest, and a live site-runtime verification. `docker-local` remains non-Eval-ready.
+- **write_runtime_inventory**: Output schema v2 = `runtime_inventory.json`. Container delivery records the digest-pinned image and read-only model mount. Local Python records only the portable Model Runtime ID, manifest/lock hashes, server command, tools, and model-core hashes; `/sure_eval` resolves the current site's absolute runtime root by ID. In both cases Model Python and Harness Python remain separate roles.
+- **verdict**: Output = `verdict.json` {status, instance_id, package, readiness, build, validation, artifacts}. A local success requires `bundle_ready=true` and either verified `docker-registry` delivery or sealed `package=none` Python delivery. `docker-local` must remain partial or failed.
+- **finalize_model_bundle**: Copies terminal evidence to the model directory, rewrites manifest/package paths to be portable, verifies hashes, and atomically writes `deployment_ready.json`. This file is the only terminal readiness marker consumed by `/sure_eval`. Docker and API deliveries retain `sure.onboard.deployment_ready.v1`; an approved `package=none` Python delivery uses `sure.onboard.deployment_ready.v2`.
 
 ## Backend Routing Rules (Phase 1)
 
@@ -237,7 +248,8 @@ sure/models/<model_name>/
 │   ├── docker_registry_result.json
 │   ├── package_gate.json / verdict.json
 │   ├── artifact_manifest.json
-│   ├── runtime_inventory.json                     # container-only Eval binding
+│   ├── model_runtime_manifest.json                # package=none only; portable runtime identity
+│   ├── runtime_inventory.json                     # selected container or Python Eval binding
 │   └── deployment_ready.json                      # terminal immutable readiness marker
 ├── fixture/<task>/                                      # test audio + gt.jsonl (2–3 samples, max 5)
 ├── .runtime/ checkpoints/                               # weights convergence
@@ -246,7 +258,7 @@ sure/models/<model_name>/
 
 ## Backend
 
-The deterministic backend is bundled in `scripts/`. Gate scripts validate each unit. `stage_model_artifacts.py` stages existing run evidence; `write_runtime_inventory.py` writes runtime provenance only after the package gate; `finalize_model_bundle.py` seals the portable bundle. No helper may infer an Eval runtime from `.venv`, host Python, a Dockerfile, or an image name alone.
+The deterministic backend is bundled in `scripts/`. Gate scripts validate each unit. `materialize_model_runtime.py` is the only local-Python runtime materializer; `stage_model_artifacts.py` stages existing run evidence; `write_runtime_inventory.py` writes runtime provenance only after the package gate; `finalize_model_bundle.py` seals the portable bundle. No helper may infer an Eval runtime from `.venv`, host Python, a Dockerfile, or an image name alone.
 
 ```bash
 "$HARNESS_PYTHON_BIN" scripts/<script>.py <args>   # cwd = skill package dir
@@ -260,4 +272,4 @@ If the same hook/gate blocks three consecutive attempts, stop and ask the user t
 
 ## Success Criteria
 
-The `pre_finish` hook enforces that the state machine reached `finalize_model_bundle` and that `deployment_ready.json` passes its hash, portability, package, and execution-policy checks. A local model cannot finish successfully without immutable registry evidence.
+The `pre_finish` hook enforces that the state machine reached `finalize_model_bundle` and that `deployment_ready.json` passes its hash, portability, package, and execution-policy checks. A local model can finish successfully with either immutable registry evidence or an explicitly permitted, sealed Python Model Runtime.

--- a/sure/skills/sure_onboard/hooks/index.ts
+++ b/sure/skills/sure_onboard/hooks/index.ts
@@ -4,6 +4,7 @@ import { delimiter, dirname, isAbsolute, join, relative, resolve } from "node:pa
 import type { SureHookContext, SureHookResult } from "@earendil-works/pi-coding-agent/hooks";
 import { resolveHarnessPython } from "../../../runtime/harness/resolve.ts";
 import { invokedSkillScripts } from "../../../runtime/script-guard.ts";
+import { requireSitePolicy } from "../../../site/loader.ts";
 import {
 	advance,
 	artifactPath,
@@ -534,9 +535,31 @@ export function preStart(ctx: SureHookContext): SureHookResult {
 	}
 	if (!PACKAGE_PROFILES.includes(args.package_profile)) {
 		return failure(
-			`package "${args.package_profile}" is not one of ${JSON.stringify(PACKAGE_PROFILES)}. Local models default to package=docker-registry; package=none is diagnostic/local-only and cannot produce an Eval-ready bundle.`,
+			`package "${args.package_profile}" is not one of ${JSON.stringify(PACKAGE_PROFILES)}. Local models default to package=docker-registry; package=none selects an explicitly approved local Python runtime.`,
 			"Invalid package profile.",
 		);
+	}
+	if (args.deployment_type === "local" && args.package_profile === "none") {
+		try {
+			const policy = requireSitePolicy({ repositoryRoot: ctx.cwd }).policy;
+			if (!policy.execution.surfaces.includes("local")) {
+				return failure(
+					"package=none requires local in execution.surfaces because Python runtimes cannot run on VC.",
+					"Local execution is disabled by site policy.",
+				);
+			}
+			if (!policy.execution.local_runtimes.includes("python")) {
+				return failure(
+					"package=none requires python in execution.local_runtimes. Enable it in the active site policy or use package=docker-registry.",
+					"Local Python runtime is disabled by site policy.",
+				);
+			}
+		} catch (error) {
+			return failure(
+				error instanceof Error ? error.message : String(error),
+				"Local Python site policy is unavailable.",
+			);
+		}
 	}
 	const runtime = resolveHarnessPython(ctx.packageDir);
 	if (!runtime.ok || !runtime.contract) {

--- a/sure/skills/sure_onboard/hooks/state-machine.ts
+++ b/sure/skills/sure_onboard/hooks/state-machine.ts
@@ -4,7 +4,7 @@ import type { GateResult } from "./checkpoints.ts";
 // SURE-EVAL model-tool agent state machine, ported from the upstream
 // SURE-EVAL model_tool_agent AGENTS.md (now bundled in references/).
 //
-// Onboards or repairs an audio model into a reproducible local inference unit
+// Onboards or repairs a model into a reproducible local inference unit
 // (wrapper set + spec + verdict) under sure/models/<model_name>/. Linear units
 // are LLM self-driven (advance when produces is compliant); gate units run
 // validateProduces + a Python semantic gate script and block on failure.
@@ -158,6 +158,7 @@ export const MODEL_TOOL_UNITS: Unit[] = [
 		schemaRef: "build_env_result.schema.json",
 		requiredFields: ["env_ready"],
 		gateScript: "check_env.py",
+		helperScripts: ["materialize_model_runtime.py"],
 	},
 	{
 		id: "fetch_weights",
@@ -277,7 +278,7 @@ export const MODEL_TOOL_UNITS: Unit[] = [
 		label: "Finalize model bundle",
 		kind: "gate",
 		produces: "deployment_ready.json",
-		schemaRef: "deployment_ready.schema.json",
+		schemaRef: "deployment_ready_output.schema.json",
 		requiredFields: ["schema", "status", "model_name", "package_profile", "execution_policy"],
 		gateScript: "check_finalized_bundle.py",
 		helperScripts: ["finalize_model_bundle.py"],

--- a/sure/skills/sure_onboard/references/AGENTS.md
+++ b/sure/skills/sure_onboard/references/AGENTS.md
@@ -1,8 +1,8 @@
 # SURE-EVAL 模型接入 Harness 规范 (第一阶段)
 
 **版本**: v1.0  
-**目标**: 将语音模型仓库接入为**本地验证、容器交付的可复现推理单元**
-**范围**: 环境适配、最小推理验证、镜像发布与不可变运行时绑定
+**目标**: 将模型仓库接入为**本地验证、可复现交付的推理单元**
+**范围**: 环境适配、最小推理验证、容器或受控本地 Python 运行时绑定
 
 ---
 
@@ -14,14 +14,14 @@
 
 ### 1.0 Harness 分支边界覆盖规则
 
-本 `sure_onboard` harness 版本以 **registry-backed container-ready** 为本地模型默认成功条件：
+本 `sure_onboard` harness 版本以 **registry-backed container-ready** 为本地模型默认成功条件，同时提供显式、站点受控的 Python 交付路径：
 
-- `package=docker-registry`：本地模型默认且唯一可成功交付的路径，要求 Docker build、容器验证、push、digest 解析与 pull verify。
+- `package=docker-registry`：本地模型默认成功路径，要求 Docker build、容器验证、push、digest 解析与 pull verify。
 - `package=docker-local`：仅诊断，不能产生 Eval-ready 成功产物。
-- `package=none`：用于 API 或显式本地诊断；本地模型不得产出 success verdict。
+- `package=none`：用于 API，或在站点允许 Python、backend=`uv` 且哈希锁定的 Model Runtime 已物化和封存时用于本地模型；不能用于 VC。
 - VC/HPC submit/validate 不属于核心 `/sure_onboard` 成功条件；如需支持，应作为独立 deployment plugin 或独立 slash command。
 
-当本文档后续历史段落与以上边界冲突时，以本节和 `SKILL.md` 状态机为准。本地适配环境只用于验证和制作镜像，不能成为 `/sure_eval` 的 host fallback。
+当本文档后续历史段落与以上边界冲突时，以本节和 `SKILL.md` 状态机为准。本地适配环境不能被隐式当作 `/sure_eval` 的 host fallback；Python 路径只能解析封存的 Model Runtime。
 
 本文档定义第一阶段模型接入的标准 workflow，确保：
 
@@ -595,13 +595,13 @@ sure/models/{model}/checkpoints/                # 显式本地权重（如有）
 
 ---
 
-## 8. 必选 Docker 镜像制作与可选集群提交
+## 8. Docker 镜像制作与可选集群提交
 
-本节定义本地模型 onboarding 的必选 Docker 交付步骤。Docker registry readiness 属于 `/sure_onboard` 成功条件；VC/HPC submit 仍然是外部部署能力。
+本节定义默认 `package=docker-registry` 和诊断型 `package=docker-local` 的 Docker 交付步骤。显式 `package=none` 按 `SKILL.md` 与 `playbooks/env_uv.md` 的 Model Runtime 契约执行，不进入本节。VC/HPC submit 仍然是外部部署能力。
 
 ### 8.1 适用范围
 
-**本地模型需要制作独立 Docker 镜像**:
+**以下 profile 需要制作独立 Docker 镜像**:
 - `/sure_onboard package=docker-registry`（默认成功路径）
 - `/sure_onboard package=docker-local`（仅诊断）
 - 需要本地 Python/系统依赖、模型权重、GPU/CPU runtime 的模型
@@ -609,8 +609,9 @@ sure/models/{model}/checkpoints/                # 显式本地权重（如有）
 
 **可以跳过**:
 - 纯 API 模型，且运行时只需要远程 endpoint/token
+- 站点允许 Python 且满足封存条件的显式 `package=none` 本地模型
 
-本地模型无法完成 Docker registry 交付时只能记录为 partial/blocked，不能写入 Eval-ready 成功标记。
+选择 `package=docker-registry` 后无法完成 registry 交付时只能记录为 partial/blocked，不能写入 Eval-ready 成功标记；不能静默改成 Python profile。
 
 ### 8.2 镜像命名规则
 

--- a/sure/skills/sure_onboard/references/experience_loss_register.md
+++ b/sure/skills/sure_onboard/references/experience_loss_register.md
@@ -3,8 +3,9 @@
 This register tracks experience assets from the original
 `docs/agents/model_tool_agent` that must stay active in the harness port.
 It focuses on task, fixture, metric, environment, and failure-handling
-knowledge. Docker/registry delivery is required for local-model success; only
-VC submission remains outside this skill.
+knowledge. Docker/registry delivery remains the default for local-model success;
+an explicit site-approved sealed Python profile is also valid. VC submission
+remains outside this skill.
 
 ## P0 Restores
 
@@ -30,5 +31,5 @@ VC submission remains outside this skill.
 
 | Source experience | Harness decision |
 | --- | --- |
-| `deployment_type == local` must finish Docker and registry pull verification before final passed/tool_ready. | Restored as the default `package=docker-registry` gate. VC/HPC remains an external deployment skill. |
+| `deployment_type == local` must finish the selected delivery gate before final passed/tool_ready. | `package=docker-registry` remains the default and requires registry pull verification. Explicit `package=none` instead requires a sealed, site-approved uv Model Runtime. VC/HPC remains an external deployment skill. |
 | Company-specific VC command examples. | Keep as external deployment notes; do not add VC submission to `/sure_onboard`. |

--- a/sure/skills/sure_onboard/references/memory/COMMON.md
+++ b/sure/skills/sure_onboard/references/memory/COMMON.md
@@ -12,8 +12,9 @@ routed files.
   explicitly requires shared harness changes. `model_name` must be the
   single-segment normalized id derived from the provider id by replacing `/`
   with `__`; never derive it from task prefixes or informal aliases.
-- Docker image tags must align with the same repo id slug; local-model success
-  requires registry push and immutable digest pull verification.
+- Docker image tags must align with the same repo id slug. The default
+  `docker-registry` profile requires registry push and immutable digest pull
+  verification; an explicit `package=none` follows the sealed Python policy.
 - Validate `model.spec.yaml` before building the runtime.
 - Keep weights and provider caches model-local by default.
 - Validate the four minimum checks: import, load, infer, output contract.
@@ -23,8 +24,9 @@ routed files.
 - Save structured artifacts: `backend_choice.json`, `build.log`,
   `validation.log`, `sample_output.json`, `verdict.json`, and
   `artifact_manifest.json`.
-- For every local model, build and validate a model-specific Docker image and
-  publish a digest-pinned container-only runtime binding.
+- For every local model, finish the selected delivery profile: publish a
+  digest-pinned container binding by default, or materialize and seal the exact
+  site-approved uv Model Runtime for explicit `package=none`.
 
 ## Context Selection Rule
 

--- a/sure/skills/sure_onboard/references/playbooks/env_uv.md
+++ b/sure/skills/sure_onboard/references/playbooks/env_uv.md
@@ -50,12 +50,25 @@ uv pip install -e .
 ## Lock/Sync 约定
 
 ```bash
-# 导出精确依赖
-uv pip freeze > requirements.lock
+# 从项目依赖生成带哈希的可复现锁文件
+uv pip compile \
+  --python .venv/bin/python \
+  --generate-hashes \
+  requirements.txt \
+  -o requirements.lock
 
-# 从 lock 恢复
-uv pip install -r requirements.lock
+# 严格按 lock 恢复，删除未声明包并校验每个分发包哈希
+uv pip sync \
+  --python .venv/bin/python \
+  --require-hashes \
+  --strict \
+  requirements.lock
 ```
+
+若项目以 `pyproject.toml` 声明依赖，将 `requirements.txt` 换成
+`pyproject.toml`。`uv pip freeze` 只记录已安装版本，不记录分发包哈希，不能作为
+`package=none` 的可提升锁文件。完成模型本地验证后，由 Harness Python 运行
+`scripts/materialize_model_runtime.py`；不要把 `.venv` 本身当作 Eval runtime。
 
 ## 常见失败和修复
 

--- a/sure/skills/sure_onboard/references/policies/backend_selection.md
+++ b/sure/skills/sure_onboard/references/policies/backend_selection.md
@@ -7,7 +7,7 @@
 
 `backend_choice.json.backend` selects the environment used to adapt and validate the model locally. It may be `uv`, `pip`, `conda`, `pixi`, or `docker`. `package_profile` selects the delivered Eval runtime.
 
-For every local model, these decisions converge as follows:
+Docker registry delivery remains the default. For that profile, the decisions converge as follows:
 
 1. Adapt with the repository-compatible backend.
 2. Run import, load, inference, and contract checks in that environment.
@@ -16,7 +16,7 @@ For every local model, these decisions converge as follows:
 5. Push the image and pull-verify its immutable registry digest.
 6. Publish `runtime_inventory.json` with `execution_mode=container_only`.
 
-The local backend is evidence used to create the image. It is not an Eval fallback.
+The local backend is evidence used to create the image. It is not an implicit Eval fallback. An explicit `package=none` follows the separate sealed Python policy below.
 
 ## Local backend routing
 
@@ -27,15 +27,15 @@ The local backend is evidence used to create the image. It is not an Eval fallba
 | Conda metadata or packages | `pixi` or `conda` |
 | Pure Python packaging | `uv` or `pip` |
 
-Record repository evidence, executable availability, selected version, and any fallback in `backend_choice.json`. A fallback may change the adaptation backend, but may not waive Docker registry delivery for a local model.
+Record repository evidence, executable availability, selected version, and any fallback in `backend_choice.json`. A fallback may change the adaptation backend, but may not silently change the selected package profile.
 
 ## Package policy
 
-- `docker-registry`: default and only successful local-model profile.
+- `docker-registry`: default successful local-model profile.
 - `docker-local`: diagnostic; final verdict must not claim Eval readiness.
-- `none`: API or explicit local diagnostic; final local verdict must not be success.
+- `none`: API delivery, or an explicit local Python profile when the site permits Python, backend=`uv`, and a hash-locked Model Runtime has been materialized and sealed. It never enables VC execution.
 
-If Docker, registry push, digest resolution, or digest pull verification is unavailable, stop with a repairable partial/blocked result. Do not convert host `.venv`, base Python, or a locally guessed image tag into deployment readiness.
+If the selected profile's required delivery checks are unavailable, stop with a repairable partial/blocked result. Do not convert a model-local `.venv`, arbitrary base Python, or a locally guessed image tag into deployment readiness.
 
 ## Device policy
 

--- a/sure/skills/sure_onboard/schemas/build_env_result.schema.json
+++ b/sure/skills/sure_onboard/schemas/build_env_result.schema.json
@@ -42,6 +42,19 @@
 			},
 			"additionalProperties": true
 		},
+		"model_runtime": {
+			"type": "object",
+			"required": ["schema", "runtime_id", "backend", "python_executable", "manifest_sha256", "lock_sha256"],
+			"properties": {
+				"schema": { "const": "sure.model.runtime.manifest.v1" },
+				"runtime_id": { "type": "string", "pattern": "^sure-model-python-v1-[0-9a-f]{24}$" },
+				"backend": { "const": "uv" },
+				"python_executable": { "const": "bin/python" },
+				"manifest_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+				"lock_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+			},
+			"additionalProperties": false
+		},
 		"repairs": {
 			"type": "array",
 			"items": {

--- a/sure/skills/sure_onboard/schemas/deployment_ready_output.schema.json
+++ b/sure/skills/sure_onboard/schemas/deployment_ready_output.schema.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "deployment_ready_output.schema.json",
+	"title": "SURE finalized deployment output envelope",
+	"type": "object",
+	"required": ["schema", "generated_at", "status", "model_name", "package_profile", "execution_policy", "required_artifact_sha256", "bundle_identity_sha256"],
+	"properties": {
+		"schema": { "enum": ["sure.onboard.deployment_ready.v1", "sure.onboard.deployment_ready.v2"] },
+		"generated_at": { "type": "string" },
+		"status": { "enum": ["ready", "local_only", "api_ready", "blocked"] },
+		"model_name": { "type": "string" },
+		"package_profile": { "enum": ["none", "docker-local", "docker-registry"] },
+		"target_image": { "type": ["string", "null"] },
+		"target_image_digest": { "type": ["string", "null"] },
+		"target_image_ref": { "type": ["string", "null"] },
+		"harness_runtime": { "type": "object" },
+		"model_runtime": { "type": "object" },
+		"runtime_inventory": { "type": "string" },
+		"package_gate": { "type": "string" },
+		"verdict": { "type": "string" },
+		"artifact_manifest": { "type": "string" },
+		"required_artifact_sha256": { "type": "object" },
+		"bundle_identity_sha256": { "type": "string" },
+		"execution_policy": { "type": "object" }
+	},
+	"additionalProperties": false
+}

--- a/sure/skills/sure_onboard/schemas/deployment_ready_v2.schema.json
+++ b/sure/skills/sure_onboard/schemas/deployment_ready_v2.schema.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "deployment_ready_v2.schema.json",
+	"title": "SURE finalized local Python deployment binding",
+	"type": "object",
+	"required": ["schema", "generated_at", "status", "model_name", "package_profile", "model_runtime", "execution_policy", "required_artifact_sha256", "bundle_identity_sha256"],
+	"properties": {
+		"schema": { "const": "sure.onboard.deployment_ready.v2" },
+		"generated_at": { "type": "string" },
+		"status": { "enum": ["ready", "local_only", "blocked"] },
+		"model_name": { "type": "string" },
+		"package_profile": { "const": "none" },
+		"target_image": { "type": "null" },
+		"target_image_digest": { "type": "null" },
+		"target_image_ref": { "type": "null" },
+		"harness_runtime": { "type": "object" },
+		"model_runtime": { "type": "object" },
+		"runtime_inventory": { "type": "string" },
+		"package_gate": { "type": "string" },
+		"verdict": { "type": "string" },
+		"artifact_manifest": { "type": "string" },
+		"required_artifact_sha256": {
+			"type": "object",
+			"additionalProperties": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+		},
+		"bundle_identity_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+		"execution_policy": {
+			"type": "object",
+			"required": ["container_only", "eval_runtime", "isolation", "model_integrity", "nfs_models_read_only", "model_bundle_mutation_allowed", "host_python_fallback", "approved_image_override"],
+			"properties": {
+				"container_only": { "const": false },
+				"eval_runtime": { "const": "python" },
+				"isolation": { "const": "trusted_host" },
+				"model_integrity": { "const": "verify_before_after" },
+				"nfs_models_read_only": { "const": false },
+				"model_bundle_mutation_allowed": { "const": false },
+				"host_python_fallback": { "const": false },
+				"approved_image_override": { "const": false }
+			},
+			"additionalProperties": false
+		}
+	},
+	"additionalProperties": false
+}

--- a/sure/skills/sure_onboard/schemas/package_gate.schema.json
+++ b/sure/skills/sure_onboard/schemas/package_gate.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "package_gate.schema.json",
 	"title": "SURE onboard package gate v2",
-	"description": "Cross-checks local validation and Docker delivery readiness. Local Eval-ready bundles require docker-registry.",
+	"description": "Cross-checks local validation and the selected Docker or sealed Model Python delivery readiness.",
 	"type": "object",
 	"required": ["schema", "status", "package_profile", "readiness", "model_dir"],
 	"properties": {
@@ -26,6 +26,7 @@
 			"additionalProperties": false
 		},
 		"local": { "type": "object" },
+		"model_runtime": { "type": "object" },
 		"docker": {
 			"type": "object",
 			"properties": {

--- a/sure/skills/sure_onboard/schemas/runtime_inventory.schema.json
+++ b/sure/skills/sure_onboard/schemas/runtime_inventory.schema.json
@@ -2,7 +2,7 @@
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"$id": "runtime_inventory.schema.json",
 	"title": "SURE onboard runtime inventory v2",
-	"description": "Portable model runtime contract written after the Docker package gate.",
+	"description": "Portable model runtime contract written after the selected delivery gate.",
 	"type": "object",
 	"required": ["schema", "generated_at", "status", "model", "local_runtime", "model_runtime", "harness_runtime", "container_runtime", "weights", "readiness", "evidence", "policy"],
 	"properties": {
@@ -40,9 +40,23 @@
 			"required": ["required", "runtime_type"],
 			"properties": {
 				"required": { "type": "boolean" },
+				"schema": { "type": "string" },
+				"runtime_id": { "type": "string" },
 				"runtime_type": { "type": "string" },
+				"backend": { "type": "string" },
 				"python_executable": { "type": ["string", "null"] },
 				"python_version": { "type": ["string", "null"] },
+				"python_abi": { "type": ["string", "null"] },
+				"python_platform": { "type": ["string", "null"] },
+				"manifest_path": { "type": "string" },
+				"manifest_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+				"lockfile_path": { "type": "string" },
+				"lock_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+				"working_dir": { "type": "string" },
+				"server_command": { "type": "array", "items": { "type": "string" } },
+				"tool_names": { "type": "array", "items": { "type": "string" } },
+				"required_imports": { "type": "array", "items": { "type": "string" } },
+				"gpu_required": { "type": "boolean" },
 				"checks": { "type": "object" }
 			},
 			"additionalProperties": true
@@ -55,6 +69,7 @@
 				"schema": { "type": "string" },
 				"runtime_id": { "type": "string" },
 				"runtime_type": { "const": "harness_python" },
+				"binding_source": { "type": "string" },
 				"python_executable": { "type": ["string", "null"] },
 				"python_version": { "type": ["string", "null"] },
 				"python_abi": { "type": ["string", "null"] },
@@ -105,7 +120,7 @@
 			"type": "object",
 			"required": ["eval_runtime", "host_python_fallback", "image_override_allowed", "nfs_models_mutable_by_eval"],
 			"properties": {
-				"eval_runtime": { "enum": ["container_only", "api_only", "unavailable"] },
+				"eval_runtime": { "enum": ["container_only", "python", "api_only", "unavailable"] },
 				"host_python_fallback": { "const": false },
 				"image_override_allowed": { "const": false },
 				"nfs_models_mutable_by_eval": { "const": false }

--- a/sure/skills/sure_onboard/scripts/check_build_plan.py
+++ b/sure/skills/sure_onboard/scripts/check_build_plan.py
@@ -79,6 +79,14 @@ def main() -> int:
         print("BUILD_PLAN gate: package_profile disagrees with model_input_resolved.json.", file=sys.stderr)
         return 1
 
+    if deployment_type == "local" and package_profile == "none" and data.get("backend") != "uv":
+        print(
+            "BUILD_PLAN gate: local package=none initially requires backend=uv so the locked "
+            "Model Runtime can be materialized reproducibly.",
+            file=sys.stderr,
+        )
+        return 1
+
     steps = data.get("steps")
     if not isinstance(steps, list) or not steps:
         print("BUILD_PLAN gate: steps must be a non-empty array.", file=sys.stderr)
@@ -141,6 +149,15 @@ def main() -> int:
         missing_steps = [label for label, pattern in requirements.items() if not re.search(pattern, plan_text)]
         if missing_steps:
             print("BUILD_PLAN gate: missing required Docker steps: " + ", ".join(missing_steps), file=sys.stderr)
+            return 1
+    if deployment_type == "local" and package_profile == "none":
+        plan_text = "\n".join(step_text(step) for step in steps)
+        if not re.search(r"materialize_model_runtime|require-hashes|hash.{0,20}lock", plan_text):
+            print(
+                "BUILD_PLAN gate: package=none must plan locked Model Runtime materialization "
+                "with scripts/materialize_model_runtime.py.",
+                file=sys.stderr,
+            )
             return 1
     blockers = data.get("blockers") or []
     if blockers:

--- a/sure/skills/sure_onboard/scripts/check_env.py
+++ b/sure/skills/sure_onboard/scripts/check_env.py
@@ -15,8 +15,12 @@ import sys
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "runtime" / "harness"))
 from model_child_env import model_child_env
+from sure.runtime.model.bootstrap import ModelRuntimeError, manifest_sha256, verify_runtime
+from sure.site.loader import SitePolicyError, load_site_policy
 
 
 LOCAL_RUNTIME_BACKENDS = {"uv", "pip", "conda", "pixi"}
@@ -88,6 +92,48 @@ def string_list(value: object) -> list[str]:
 
 def resolved_model_input(run_dir: Path) -> dict[str, Any] | None:
     return load_json(run_dir / "artifacts" / "model_input_resolved.json")
+
+
+def verify_sealed_model_runtime(
+    data: dict[str, Any],
+    *,
+    run_dir: Path,
+    repo_root: Path,
+) -> tuple[Path, dict[str, Any]]:
+    resolved = resolved_model_input(run_dir) or {}
+    if resolved.get("deployment_type") != "local" or resolved.get("package_profile") != "none":
+        raise ValueError("sealed Model Runtime verification only applies to local package=none")
+    if data.get("backend") != "uv":
+        raise ValueError("local package=none initially requires backend=uv")
+    binding = data.get("model_runtime")
+    if not isinstance(binding, dict):
+        raise ValueError("local package=none requires build_env_result.model_runtime")
+    manifest = load_json(run_dir / "artifacts" / "model_runtime_manifest.json")
+    if not manifest:
+        raise ValueError("local package=none requires model_runtime_manifest.json")
+    if binding.get("runtime_id") != manifest.get("runtime_id"):
+        raise ValueError("build_env_result Model Runtime ID disagrees with its manifest")
+    if binding.get("manifest_sha256") != manifest_sha256(manifest):
+        raise ValueError("build_env_result Model Runtime manifest hash mismatch")
+    try:
+        policy = load_site_policy(repository_root=repo_root, required=True)
+        assert policy is not None
+        if "local" not in policy["policy"]["execution"]["surfaces"]:
+            raise ValueError("local Python runtimes require local in execution.surfaces")
+        if "python" not in policy["policy"]["execution"]["local_runtimes"]:
+            raise ValueError("local Python runtimes are disabled by execution.local_runtimes")
+        contract = verify_runtime(
+            Path(policy["policy"]["storage"]["runtime_root"]) / "models",
+            manifest,
+        )
+    except (ModelRuntimeError, SitePolicyError) as exc:
+        raise ValueError(str(exc)) from exc
+    python = Path(contract["python_executable_resolved"])
+    declared = Path(str(data.get("python_executable") or "")).expanduser()
+    declared_entrypoint = declared.parent.resolve() / declared.name
+    if declared_entrypoint != python:
+        raise ValueError("build_env_result.python_executable is not the sealed site Model Python")
+    return python, contract
 
 
 def resolve_python_executable(
@@ -294,14 +340,22 @@ def main() -> int:
             return 1
 
     if backend in LOCAL_RUNTIME_BACKENDS:
-        python_executable, python_error = resolve_python_executable(
-            data,
-            backend=backend,
-            run_dir=run_dir,
-            artifact_path=path,
-            model_dir=model_dir,
-            repo_root=repo_root,
-        )
+        resolved = resolved_model_input(run_dir) or {}
+        if resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "none":
+            try:
+                python_executable, _ = verify_sealed_model_runtime(data, run_dir=run_dir, repo_root=repo_root)
+                python_error = None
+            except ValueError as exc:
+                python_executable, python_error = None, f"BUILD_ENV gate: {exc}"
+        else:
+            python_executable, python_error = resolve_python_executable(
+                data,
+                backend=backend,
+                run_dir=run_dir,
+                artifact_path=path,
+                model_dir=model_dir,
+                repo_root=repo_root,
+            )
         if python_error:
             print(python_error, file=sys.stderr)
             return 1

--- a/sure/skills/sure_onboard/scripts/check_finalized_bundle.py
+++ b/sure/skills/sure_onboard/scripts/check_finalized_bundle.py
@@ -18,6 +18,10 @@ from deployment_contract import (
     validate_image_and_digest,
 )
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+from sure.runtime.model.bootstrap import ModelRuntimeError, manifest_sha256, verify_runtime
+from sure.site.loader import SitePolicyError, load_site_policy
+
 
 LEGACY_PATH = re.compile(r"/(?:mnt/cloudstorfs|hpc_stor\d+|hpc_\d+)/")
 
@@ -35,11 +39,21 @@ def main() -> int:
         model_copy = model_dir / "artifacts" / "deployment_ready.json"
         if not model_copy.is_file() or model_copy.read_bytes() != path.read_bytes():
             raise ValueError("deployment_ready.json must be written identically to the run and model bundle")
-        if data.get("schema") != "sure.onboard.deployment_ready.v1":
+        python_delivery = resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "none"
+        expected_schema = (
+            "sure.onboard.deployment_ready.v2"
+            if python_delivery
+            else "sure.onboard.deployment_ready.v1"
+        )
+        if data.get("schema") != expected_schema:
             raise ValueError("invalid deployment-ready schema")
         policy = data.get("execution_policy") if isinstance(data.get("execution_policy"), dict) else {}
-        if policy.get("nfs_models_read_only") is not True or policy.get("host_python_fallback") is not False:
-            raise ValueError("final execution policy must keep NFS read-only and disable host Python fallback")
+        if policy.get("host_python_fallback") is not False:
+            raise ValueError("final execution policy must disable host fallback")
+        if python_delivery and policy.get("model_bundle_mutation_allowed") is not False:
+            raise ValueError("Python execution policy must disable model bundle mutation")
+        if not python_delivery and policy.get("nfs_models_read_only") is not True:
+            raise ValueError("legacy deployment policy must keep NFS models read-only")
         for raw, expected in data.get("required_artifact_sha256", {}).items():
             relative = str(raw).removeprefix("artifacts/")
             artifact = model_dir / "artifacts" / relative
@@ -55,7 +69,11 @@ def main() -> int:
         if manifest.get("status") != "finalized" or manifest.get("model_dir") != ".":
             raise ValueError("artifact_manifest.json was not refreshed into portable finalized form")
         if resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "docker-registry":
-            if data.get("status") != "ready" or policy.get("container_only") is not True:
+            if (
+                data.get("status") != "ready"
+                or policy.get("container_only") is not True
+                or policy.get("nfs_models_read_only") is not True
+            ):
                 raise ValueError("local docker-registry bundle must be container-only ready")
             image, digest, image_ref = validate_image_and_digest(
                 data.get("target_image"), data.get("target_image_digest")
@@ -73,13 +91,36 @@ def main() -> int:
             harness = declared
             if harness.get("schema") != "sure.harness.runtime.binding.v1" or not harness.get("runtime_id"):
                 raise ValueError("ready deployment must expose the common Harness Runtime binding")
+        if python_delivery:
+            if (
+                data.get("status") != "ready"
+                or policy.get("container_only") is not False
+                or policy.get("eval_runtime") != "python"
+                or policy.get("isolation") != "trusted_host"
+                or policy.get("model_integrity") != "verify_before_after"
+                or policy.get("nfs_models_read_only") is not False
+            ):
+                raise ValueError("local package=none bundle must declare trusted-host Python readiness")
+            configured = load_site_policy(required=True)
+            assert configured is not None
+            if "local" not in configured["policy"]["execution"]["surfaces"]:
+                raise ValueError("local Python runtimes require local in execution.surfaces")
+            if "python" not in configured["policy"]["execution"]["local_runtimes"]:
+                raise ValueError("local Python runtimes are disabled by execution.local_runtimes")
+            manifest = read_json(model_dir / "artifacts" / "model_runtime_manifest.json")
+            runtime = data.get("model_runtime") if isinstance(data.get("model_runtime"), dict) else {}
+            if runtime.get("runtime_id") != manifest.get("runtime_id"):
+                raise ValueError("deployment Model Runtime ID disagrees with its manifest")
+            if runtime.get("manifest_sha256") != manifest_sha256(manifest):
+                raise ValueError("deployment Model Runtime manifest hash mismatch")
+            verify_runtime(Path(configured["policy"]["storage"]["runtime_root"]) / "models", manifest)
         portable = [
             read_json(model_dir / "artifacts" / name)
             for name in ("runtime_inventory.json", "package_gate.json", "artifact_manifest.json", "deployment_ready.json")
         ]
         if LEGACY_PATH.search(json.dumps(portable, ensure_ascii=False)):
             raise ValueError("finalized deployment sidecars contain legacy host absolute paths")
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, ModelRuntimeError, SitePolicyError) as exc:
         print(f"FINALIZE_MODEL_BUNDLE failed: {exc}", file=sys.stderr)
         return 1
     print(f"check_finalized_bundle OK: status={data.get('status')}, model={data.get('model_name')}")

--- a/sure/skills/sure_onboard/scripts/check_package_gate.py
+++ b/sure/skills/sure_onboard/scripts/check_package_gate.py
@@ -9,12 +9,17 @@ import sys
 from pathlib import Path
 from typing import Any
 
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
 from deployment_contract import (
     load_artifact,
     resolve_model_dir,
     sha256_file,
     validate_container_documents,
 )
+from sure.runtime.model.bootstrap import ModelRuntimeError, verify_runtime
+from sure.site.loader import SitePolicyError, load_site_policy
 
 PACKAGE_PROFILES = {"none", "docker-local", "docker-registry"}
 STAGE_RESULTS = {
@@ -129,6 +134,22 @@ def validation_results_pass(run_dir: Path, model_dir: Path | None) -> tuple[bool
     except ValueError as exc:
         return False, str(exc)
     return True, "validation artifacts passed"
+
+
+def validate_model_runtime(run_dir: Path, model_dir: Path) -> None:
+    run_manifest = load_json(run_dir / "artifacts" / "model_runtime_manifest.json")
+    model_manifest_path = model_dir / "artifacts" / "model_runtime_manifest.json"
+    if not model_manifest_path.is_file() or model_manifest_path.read_bytes() != (
+        run_dir / "artifacts" / "model_runtime_manifest.json"
+    ).read_bytes():
+        raise ValueError("model_runtime_manifest.json must be staged identically into the model bundle")
+    policy = load_site_policy(repository_root=REPO_ROOT, required=True)
+    assert policy is not None
+    if "local" not in policy["policy"]["execution"]["surfaces"]:
+        raise ValueError("local Python runtimes require local in execution.surfaces")
+    if "python" not in policy["policy"]["execution"]["local_runtimes"]:
+        raise ValueError("local Python runtimes are disabled by execution.local_runtimes")
+    verify_runtime(Path(policy["policy"]["storage"]["runtime_root"]) / "models", run_manifest)
 
 
 def main() -> int:
@@ -249,8 +270,20 @@ def main() -> int:
         if readiness.get("container_ready") is not True or readiness.get("bundle_ready") is not True:
             print("PACKAGE_GATE failed: docker-registry requires container_ready=true and bundle_ready=true.", file=sys.stderr)
             return 1
-    if deployment_type == "local" and package_profile != "docker-registry" and readiness.get("bundle_ready") is not False:
-        print("PACKAGE_GATE failed: non-registry local package must declare bundle_ready=false.", file=sys.stderr)
+    if deployment_type == "local" and package_profile == "none":
+        if any(readiness.get(key) is not False for key in ("container_ready", "docker_ready", "registry_ready")):
+            print("PACKAGE_GATE failed: package=none must keep container/docker/registry readiness false.", file=sys.stderr)
+            return 1
+        if readiness.get("bundle_ready") is not True:
+            print("PACKAGE_GATE failed: package=none requires bundle_ready=true after Model Runtime sealing.", file=sys.stderr)
+            return 1
+        try:
+            validate_model_runtime(run_dir, model_dir)
+        except (OSError, ValueError, ModelRuntimeError, SitePolicyError) as exc:
+            print(f"PACKAGE_GATE failed: {exc}", file=sys.stderr)
+            return 1
+    if deployment_type == "local" and package_profile == "docker-local" and readiness.get("bundle_ready") is not False:
+        print("PACKAGE_GATE failed: package=docker-local must declare bundle_ready=false.", file=sys.stderr)
         return 1
 
     print(

--- a/sure/skills/sure_onboard/scripts/check_runtime_inventory.py
+++ b/sure/skills/sure_onboard/scripts/check_runtime_inventory.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -11,6 +12,10 @@ import sys
 from pathlib import Path
 
 from deployment_contract import normalize_harness_runtime, read_json, resolve_model_dir, validate_image_and_digest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+from sure.runtime.model.bootstrap import ModelRuntimeError, manifest_sha256, verify_runtime
+from sure.site.loader import SitePolicyError, load_site_policy
 
 
 LEGACY_PATH = re.compile(r"/(?:mnt/cloudstorfs|hpc_stor\d+|hpc_\d+)/")
@@ -68,9 +73,40 @@ def main() -> int:
                 raise ValueError("inventory Harness Runtime ID differs from the active common runtime")
             if expected_lock and harness_runtime.get("lock_sha256") != expected_lock:
                 raise ValueError("inventory Harness Runtime lock differs from the active common runtime")
+        elif deployment_type == "local" and resolved.get("package_profile") == "none":
+            if data.get("status") != "ready" or policy.get("eval_runtime") != "python":
+                raise ValueError("package=none local model must emit a Python-ready inventory")
+            configured = load_site_policy(required=True)
+            assert configured is not None
+            if "local" not in configured["policy"]["execution"]["surfaces"]:
+                raise ValueError("local Python runtimes require local in execution.surfaces")
+            if "python" not in configured["policy"]["execution"]["local_runtimes"]:
+                raise ValueError("local Python runtimes are disabled by execution.local_runtimes")
+            manifest_path = model_dir / "artifacts" / "model_runtime_manifest.json"
+            manifest = read_json(manifest_path)
+            runtime = data.get("model_runtime") if isinstance(data.get("model_runtime"), dict) else {}
+            if runtime.get("required") is not True or runtime.get("runtime_id") != manifest.get("runtime_id"):
+                raise ValueError("Python-ready inventory Model Runtime ID mismatch")
+            if runtime.get("manifest_sha256") != manifest_sha256(manifest):
+                raise ValueError("Python-ready inventory Model Runtime manifest hash mismatch")
+            verify_runtime(Path(configured["policy"]["storage"]["runtime_root"]) / "models", manifest)
+            lockfile = model_dir / str(runtime.get("lockfile_path") or "")
+            if not lockfile.is_file() or runtime.get("lock_sha256") != hashlib.sha256(lockfile.read_bytes()).hexdigest():
+                raise ValueError("Python-ready inventory lockfile hash mismatch")
+            command = runtime.get("server_command")
+            if not isinstance(command, list) or not command or command[0] != runtime.get("python_executable"):
+                raise ValueError("Python-ready inventory server_command must start with the bound Model Python")
+            if not runtime.get("tool_names"):
+                raise ValueError("Python-ready inventory must declare tool_names")
+            container = data.get("container_runtime") if isinstance(data.get("container_runtime"), dict) else {}
+            if container.get("required") is not False:
+                raise ValueError("package=none must not require a container runtime")
+            harness = data.get("harness_runtime") if isinstance(data.get("harness_runtime"), dict) else {}
+            if harness.get("required") is not True or harness.get("binding_source") != "active_eval_site":
+                raise ValueError("Python Eval must resolve the common Harness Runtime from the active site")
         elif deployment_type == "local" and data.get("status") not in {"local_only", "partial"}:
             raise ValueError("non-registry local model cannot claim Eval-ready status")
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, ModelRuntimeError, SitePolicyError) as exc:
         print(f"RUNTIME_INVENTORY failed: {exc}", file=sys.stderr)
         return 1
     print(f"check_runtime_inventory OK: status={data.get('status')}")

--- a/sure/skills/sure_onboard/scripts/check_verdict.py
+++ b/sure/skills/sure_onboard/scripts/check_verdict.py
@@ -6,7 +6,8 @@ requires build.success, all four validation tests passed, and readiness that
 matches the selected package profile:
 
   - local package=docker-registry: local/docker/registry/bundle readiness
-  - local package=none or docker-local: terminal status must remain partial
+  - local package=none: sealed Model Runtime plus local/bundle readiness
+  - local package=docker-local: terminal status must remain partial
   - API package=none: local client readiness is sufficient
 
 VC/HPC readiness is intentionally not part of this core /sure_onboard gate.
@@ -234,10 +235,10 @@ def main() -> int:
         except (OSError, ValueError) as exc:
             print(f"VERDICT gate: cannot read model_input_resolved.json: {exc}", file=sys.stderr)
             return 1
-        if resolved.get("deployment_type") == "local" and profile != "docker-registry":
+        if resolved.get("deployment_type") == "local" and profile == "docker-local":
             print(
-                "VERDICT gate: local package=none/docker-local is local_only and cannot use a success status; "
-                "emit status=partial or complete docker-registry delivery.",
+                "VERDICT gate: local package=docker-local is diagnostic-only and cannot use a success status; "
+                "use package=none with a sealed Model Runtime or complete docker-registry delivery.",
                 file=sys.stderr,
             )
             return 1

--- a/sure/skills/sure_onboard/scripts/finalize_model_bundle.py
+++ b/sure/skills/sure_onboard/scripts/finalize_model_bundle.py
@@ -20,6 +20,7 @@ TERMINAL_ARTIFACTS = (
     "package_gate.json",
     "runtime_inventory.json",
     "verdict.json",
+    "model_runtime_manifest.json",
     "docker_build_result.json",
     "docker_validation.json",
     "docker_registry_result.json",
@@ -44,8 +45,10 @@ def json_bytes(value: dict[str, Any]) -> bytes:
     return (json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode()
 
 
-def copy_terminal_artifacts(run_dir: Path, model_dir: Path) -> None:
+def copy_terminal_artifacts(run_dir: Path, model_dir: Path, profile: str) -> None:
     for name in TERMINAL_ARTIFACTS:
+        if profile == "none" and name.startswith("docker_"):
+            continue
         source = run_dir / "artifacts" / name
         if source.is_file():
             destination = model_dir / "artifacts" / name
@@ -68,7 +71,14 @@ def update_manifest(model_dir: Path, resolved: dict[str, Any]) -> dict[str, Any]
     path = model_dir / "artifacts" / "artifact_manifest.json"
     manifest = read_json(path)
     required = manifest.setdefault("artifacts", {}).setdefault("required", {})
-    for name in (*TERMINAL_ARTIFACTS, "artifact_manifest.json", "deployment_ready.json"):
+    profile = str(resolved.get("package_profile") or "none")
+    finalized = [
+        name
+        for name in TERMINAL_ARTIFACTS
+        if (profile != "none" or not name.startswith("docker_"))
+        and (model_dir / "artifacts" / name).is_file()
+    ]
+    for name in (*finalized, "artifact_manifest.json", "deployment_ready.json"):
         key = name.replace(".", "_").replace("-", "_")
         required[key] = {"path": f"artifacts/{name}", "description": f"Finalized onboard artifact: {name}."}
     manifest.update(
@@ -90,20 +100,22 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
     verdict = read_json(model_dir / "artifacts" / "verdict.json")
     profile = str(package.get("package_profile") or "none")
     deployment_type = str(resolved.get("deployment_type") or "local")
+    python_delivery = deployment_type == "local" and profile == "none"
     success = str(verdict.get("status")) in {"passed", "success", "PASS", "PASSED", "pass"}
     if deployment_type == "local" and profile == "docker-registry" and success and inventory.get("status") == "ready":
         status = "ready"
-        container_only = True
+    elif python_delivery and success and inventory.get("status") == "ready":
+        status = "ready"
     elif deployment_type == "api" and success and inventory.get("status") == "api_ready":
         status = "api_ready"
-        container_only = False
     else:
         status = "local_only"
-        container_only = False
 
     required_names = ["runtime_inventory.json", "package_gate.json", "verdict.json", "artifact_manifest.json"]
-    if status == "ready":
+    if status == "ready" and profile == "docker-registry":
         required_names.extend(["docker_build_result.json", "docker_validation.json", "docker_registry_result.json"])
+    if status == "ready" and python_delivery:
+        required_names.append("model_runtime_manifest.json")
     hashes = {
         f"artifacts/{name}": sha256_file(model_dir / "artifacts" / name)
         for name in required_names
@@ -113,10 +125,34 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
     ).hexdigest()
     container = inventory.get("container_runtime") if isinstance(inventory.get("container_runtime"), dict) else {}
     harness_runtime = inventory.get("harness_runtime") if isinstance(inventory.get("harness_runtime"), dict) else {}
-    if status == "ready":
+    model_runtime = inventory.get("model_runtime") if isinstance(inventory.get("model_runtime"), dict) else {}
+    if status == "ready" and profile == "docker-registry":
         harness_runtime = normalize_harness_runtime(harness_runtime, allow_derive=False)
-    return {
-        "schema": "sure.onboard.deployment_ready.v1",
+    execution_policy = (
+        {
+            "container_only": False,
+            "eval_runtime": "python",
+            "isolation": "trusted_host",
+            "model_integrity": "verify_before_after",
+            "nfs_models_read_only": False,
+            "model_bundle_mutation_allowed": False,
+            "host_python_fallback": False,
+            "approved_image_override": False,
+        }
+        if python_delivery
+        else {
+            "container_only": status != "api_ready" and profile == "docker-registry",
+            "nfs_models_read_only": True,
+            "host_python_fallback": False,
+            "approved_image_override": False,
+        }
+    )
+    deployment = {
+        "schema": (
+            "sure.onboard.deployment_ready.v2"
+            if python_delivery
+            else "sure.onboard.deployment_ready.v1"
+        ),
         "generated_at": now_iso(),
         "status": status,
         "model_name": str(resolved.get("model_name") or model_dir.name),
@@ -146,18 +182,16 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
         "artifact_manifest": "artifacts/artifact_manifest.json",
         "required_artifact_sha256": hashes,
         "bundle_identity_sha256": bundle_identity,
-        "execution_policy": {
-            "container_only": container_only,
-            "nfs_models_read_only": True,
-            "host_python_fallback": False,
-            "approved_image_override": False,
-        },
+        "execution_policy": execution_policy,
     }
+    if python_delivery:
+        deployment["model_runtime"] = model_runtime if status == "ready" else {}
+    return deployment
 
 
 def finalize(run_dir: Path, produces: Path) -> dict[str, Any]:
     model_dir, resolved = resolve_model_dir(run_dir)
-    copy_terminal_artifacts(run_dir, model_dir)
+    copy_terminal_artifacts(run_dir, model_dir, str(resolved.get("package_profile") or "none"))
     package = update_package_gate(run_dir, model_dir)
     update_manifest(model_dir, resolved)
     deployment = build_deployment_ready(run_dir, model_dir, resolved, package)

--- a/sure/skills/sure_onboard/scripts/materialize_model_runtime.py
+++ b/sure/skills/sure_onboard/scripts/materialize_model_runtime.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Seal a local package=none build environment into the site Model Runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(REPO_ROOT))
+
+from sure.runtime.model.bootstrap import ModelRuntimeError, materialize_runtime
+from sure.site.loader import SitePolicyError, load_site_policy
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid JSON input {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON input must be an object: {path}")
+    return value
+
+
+def repo_root_for(run_dir: Path) -> Path:
+    if run_dir.parent.name == "runs" and run_dir.parent.parent.name == ".sure":
+        return run_dir.parent.parent.parent
+    return Path.cwd().resolve()
+
+
+def resolve_model_path(raw: object, model_dir: Path, repo_root: Path) -> Path:
+    path = Path(str(raw or "")).expanduser()
+    candidates = [path] if path.is_absolute() else [model_dir / path, repo_root / path]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate.resolve()
+    return candidates[0].resolve()
+
+
+def atomic_json(path: Path, value: dict[str, Any]) -> None:
+    content = json.dumps(value, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    temporary.write_text(content, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def materialize(run_dir: Path, draft_path: Path, produces: Path) -> dict[str, Any]:
+    repo_root = repo_root_for(run_dir)
+    resolved = read_json(run_dir / "artifacts" / "model_input_resolved.json")
+    if resolved.get("deployment_type") != "local" or resolved.get("package_profile") != "none":
+        raise ValueError("materialize_model_runtime.py is only for local package=none onboarding")
+    policy = load_site_policy(repository_root=repo_root, required=True)
+    assert policy is not None
+    if "local" not in policy["policy"]["execution"]["surfaces"]:
+        raise ValueError("local Python runtimes require local in execution.surfaces")
+    if "python" not in policy["policy"]["execution"]["local_runtimes"]:
+        raise ValueError("local Python runtimes are disabled by execution.local_runtimes")
+
+    draft = read_json(draft_path)
+    if draft.get("backend") != "uv":
+        raise ValueError("local package=none initially supports backend=uv only")
+    if draft.get("env_ready") is not True:
+        raise ValueError("build environment draft must declare env_ready=true")
+    model_dir = Path(str(draft.get("model_dir") or resolved.get("model_dir") or "")).expanduser().resolve()
+    if not model_dir.is_dir():
+        raise ValueError(f"model_dir does not exist: {model_dir}")
+    source_python = resolve_model_path(draft.get("python_executable"), model_dir, repo_root)
+    lock_path = resolve_model_path(draft.get("lockfile_path"), model_dir, repo_root)
+    try:
+        lock_relative = str(lock_path.relative_to(model_dir))
+    except ValueError as exc:
+        raise ValueError("package=none lockfile_path must be inside model_dir for promotion") from exc
+
+    contract = materialize_runtime(
+        runtime_root=Path(policy["policy"]["storage"]["runtime_root"]) / "models",
+        source_python=source_python,
+        lock_path=lock_path,
+    )
+    manifest = {
+        key: value
+        for key, value in contract.items()
+        if key
+        not in {
+            "runtime_root",
+            "manifest_path",
+            "python_executable_resolved",
+            "manifest_sha256",
+            "probe",
+        }
+    }
+    manifest_path = run_dir / "artifacts" / "model_runtime_manifest.json"
+    atomic_json(manifest_path, manifest)
+    result = dict(draft)
+    result.update(
+        {
+            "model_dir": str(model_dir),
+            "python_executable": contract["python_executable_resolved"],
+            "python_version": contract["python_version"],
+            "lockfile_path": lock_relative,
+            "model_runtime": {
+                "schema": manifest["schema"],
+                "runtime_id": manifest["runtime_id"],
+                "backend": manifest["backend"],
+                "python_executable": manifest["python_executable"],
+                "manifest_sha256": contract["manifest_sha256"],
+                "lock_sha256": manifest["lock_sha256"],
+            },
+            "runtime_probe": contract["probe"],
+        }
+    )
+    atomic_json(produces, result)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True, type=Path)
+    parser.add_argument("--input", required=True, type=Path)
+    parser.add_argument("--produces", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        result = materialize(
+            args.run_dir.expanduser().resolve(),
+            args.input.expanduser().resolve(),
+            args.produces.expanduser().resolve(),
+        )
+    except (OSError, ValueError, ModelRuntimeError, SitePolicyError) as exc:
+        print(f"materialize_model_runtime failed: {exc}", file=sys.stderr)
+        return 1
+    print(
+        "materialize_model_runtime OK: "
+        f"runtime_id={result['model_runtime']['runtime_id']}, backend={result['backend']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sure/skills/sure_onboard/scripts/stage_model_artifacts.py
+++ b/sure/skills/sure_onboard/scripts/stage_model_artifacts.py
@@ -55,6 +55,7 @@ OPTIONAL_RUN_ARTIFACTS = [
     "package_gate.json",
     "verdict.json",
 ]
+MODEL_RUNTIME_ARTIFACT = "model_runtime_manifest.json"
 
 
 def now_iso() -> str:
@@ -180,7 +181,10 @@ def main_with_args(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    missing_required = [name for name in REQUIRED_RUN_ARTIFACTS if not (run_artifacts / name).exists()]
+    required_run_artifacts = list(REQUIRED_RUN_ARTIFACTS)
+    if resolved.get("deployment_type") == "local" and resolved.get("package_profile") == "none":
+        required_run_artifacts.append(MODEL_RUNTIME_ARTIFACT)
+    missing_required = [name for name in required_run_artifacts if not (run_artifacts / name).exists()]
     if missing_required and not args.allow_missing_run_artifacts:
         print(
             "stage_model_artifacts failed: run artifacts missing required state-machine outputs: "
@@ -191,12 +195,14 @@ def main_with_args(argv: list[str] | None = None) -> int:
 
     copied_required: list[str] = []
     copied_optional: list[str] = []
-    for name in REQUIRED_RUN_ARTIFACTS:
+    for name in required_run_artifacts:
         source = run_artifacts / name
         if source.exists():
             copy_artifact(source, model_artifacts / name)
             copied_required.append(name)
     for name in OPTIONAL_RUN_ARTIFACTS:
+        if resolved.get("package_profile") == "none" and name.startswith("docker_"):
+            continue
         source = run_artifacts / name
         if source.exists():
             copy_artifact(source, model_artifacts / name)

--- a/sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py
+++ b/sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py
@@ -239,6 +239,17 @@ class DockerDeliveryContractTests(unittest.TestCase):
         output = self.run_artifacts / "deployment_ready.json"
         deployment = finalize(self.run_dir, output)
         self.assertEqual(deployment["status"], "ready")
+        self.assertEqual(deployment["schema"], "sure.onboard.deployment_ready.v1")
+        self.assertEqual(
+            deployment["execution_policy"],
+            {
+                "container_only": True,
+                "nfs_models_read_only": True,
+                "host_python_fallback": False,
+                "approved_image_override": False,
+            },
+        )
+        self.assertNotIn("model_runtime", deployment)
         self.assertEqual(deployment["harness_runtime"]["runtime_id"], "sure-harness-test")
         self.assertEqual(read_json(self.model_artifacts / "artifact_manifest.json")["model_dir"], ".")
         proc = self.run_script("check_finalized_bundle.py", output)

--- a/sure/skills/sure_onboard/scripts/test_model_runtime.py
+++ b/sure/skills/sure_onboard/scripts/test_model_runtime.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from materialize_model_runtime import materialize
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+class ModelRuntimeOnboardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.run_dir = self.root / ".sure" / "runs" / "test"
+        self.artifacts = self.run_dir / "artifacts"
+        self.model_dir = self.root / "sure" / "models" / "demo"
+        (self.model_dir / ".venv" / "bin").mkdir(parents=True)
+        (self.model_dir / ".venv" / "bin" / "python").symlink_to(sys.executable)
+        (self.model_dir / "requirements.lock").write_text("", encoding="utf-8")
+        self.artifacts.mkdir(parents=True)
+        self.policy = self.root / "config" / "site.local.yaml"
+        self.policy.parent.mkdir(parents=True)
+        self.policy.write_text(
+            "\n".join(
+                [
+                    "schema: sure.site.policy.v1",
+                    "site_id: test",
+                    "policy_version: 1",
+                    "storage:",
+                    f"  approved_models_roots: [{self.root / 'approved-models'}]",
+                    f"  approved_results_roots: [{self.root / 'approved-results'}]",
+                    f"  forbidden_output_roots: [{self.root / 'forbidden'}]",
+                    f"  runtime_root: {self.root / 'runtime'}",
+                    "datasets:",
+                    f"  allowed_source_roots: [{self.root / 'datasets'}]",
+                    "execution:",
+                    "  surfaces: [local]",
+                    "  local_runtimes: [python]",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_json(
+            self.artifacts / "model_input_resolved.json",
+            {
+                "model_id": "demo/model",
+                "model_name": "demo",
+                "model_dir": str(self.model_dir),
+                "deployment_type": "local",
+                "package_profile": "none",
+                "device": "cpu",
+            },
+        )
+        self.draft = self.artifacts / "build_env_draft.json"
+        write_json(
+            self.draft,
+            {
+                "env_ready": True,
+                "backend": "uv",
+                "model_dir": str(self.model_dir),
+                "python_executable": ".venv/bin/python",
+                "lockfile_path": "requirements.lock",
+                "runtime_checks": {"required_imports": []},
+            },
+        )
+
+    def test_materializer_emits_gate_ready_runtime_binding(self) -> None:
+        output = self.artifacts / "build_env_result.json"
+        result = materialize(self.run_dir, self.draft, output)
+
+        self.assertTrue(result["model_runtime"]["runtime_id"].startswith("sure-model-python-v1-"))
+        self.assertEqual(result["lockfile_path"], "requirements.lock")
+        self.assertNotIn(str(self.root), (self.artifacts / "model_runtime_manifest.json").read_text())
+        environment = os.environ.copy()
+        environment["SURE_SITE_POLICY"] = str(self.policy)
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(Path(__file__).with_name("check_env.py")),
+                "--run-dir",
+                str(self.run_dir),
+                "--produces",
+                str(output),
+            ],
+            cwd=self.root,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_onboard/scripts/test_python_delivery_contract.py
+++ b/sure/skills/sure_onboard/scripts/test_python_delivery_contract.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import stage_model_artifacts
+from finalize_model_bundle import finalize
+from materialize_model_runtime import materialize
+from write_runtime_inventory import write_inventory
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+def write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+class PythonDeliveryContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.run_dir = self.root / ".sure" / "runs" / "python-ready"
+        self.run_artifacts = self.run_dir / "artifacts"
+        self.model_dir = self.root / "sure" / "models" / "demo"
+        self.model_artifacts = self.model_dir / "artifacts"
+        self.run_artifacts.mkdir(parents=True)
+        self.model_dir.mkdir(parents=True)
+        for name in stage_model_artifacts.CORE_FILES:
+            (self.model_dir / name).write_text("# test\n", encoding="utf-8")
+        (self.model_dir / "model.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (self.model_dir / "server.py").write_text("print('server')\n", encoding="utf-8")
+        (self.model_dir / "config.yaml").write_text(
+            "task: asr\n"
+            "server:\n  command: [.venv/bin/python, server.py]\n  working_dir: .\n"
+            "tools:\n  - name: predict\n"
+            "resources:\n  gpu: false\n",
+            encoding="utf-8",
+        )
+        (self.model_dir / ".venv" / "bin").mkdir(parents=True)
+        (self.model_dir / ".venv" / "bin" / "python").symlink_to(sys.executable)
+        (self.model_dir / "requirements.lock").write_text("", encoding="utf-8")
+        self.site_policy = self.root / "config" / "site.local.yaml"
+        self.site_policy.parent.mkdir(parents=True)
+        self.site_policy.write_text(
+            "\n".join(
+                [
+                    "schema: sure.site.policy.v1",
+                    "site_id: test",
+                    "policy_version: 1",
+                    "storage:",
+                    f"  approved_models_roots: [{self.root / 'sure' / 'models'}]",
+                    f"  approved_results_roots: [{self.root / 'results'}]",
+                    f"  forbidden_output_roots: [{self.root / 'forbidden'}]",
+                    f"  runtime_root: {self.root / 'runtime'}",
+                    "datasets:",
+                    f"  allowed_source_roots: [{self.root / 'datasets'}]",
+                    "execution:",
+                    "  surfaces: [local]",
+                    "  local_runtimes: [python]",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self.environment = os.environ.copy()
+        self.environment["SURE_SITE_POLICY"] = str(self.site_policy)
+        self.resolved = {
+            "model_id": "demo/model",
+            "model_name": "demo",
+            "model_dir": str(self.model_dir),
+            "repo_url": "https://example.com/demo.git",
+            "task_type": "asr",
+            "deployment_type": "local",
+            "package_profile": "none",
+            "device": "cpu",
+        }
+        write_json(self.run_artifacts / "model_input_resolved.json", self.resolved)
+
+    def run_gate(self, name: str, produces: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_DIR / name), "--run-dir", str(self.run_dir), "--produces", str(produces)],
+            cwd=self.root,
+            env=self.environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_package_none_reaches_eval_ready_without_docker_evidence(self) -> None:
+        draft = self.run_artifacts / "build_env_draft.json"
+        write_json(
+            draft,
+            {
+                "env_ready": True,
+                "backend": "uv",
+                "model_dir": str(self.model_dir),
+                "python_executable": ".venv/bin/python",
+                "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+                "lockfile_path": "requirements.lock",
+                "runtime_checks": {"required_imports": []},
+            },
+        )
+        with patch.dict(os.environ, {"SURE_SITE_POLICY": str(self.site_policy)}):
+            materialize(self.run_dir, draft, self.run_artifacts / "build_env_result.json")
+
+        passing_artifacts = {
+            "context_selection.json": {"task_type": "asr", "selected_references": []},
+            "repo_summary.json": {"repo_url": "https://example.com/demo.git"},
+            "classification.json": {"task_type": "asr"},
+            "backend_choice.json": {"backend": "uv"},
+            "build_plan.json": {"model_id": "demo/model", "model_dir": str(self.model_dir), "backend": "uv", "steps": [], "package_profile": "none"},
+            "spec_validation.json": {"checks": {}, "status": "passed"},
+            "fixture_manifest.json": {"model_dir": str(self.model_dir), "task_type": "asr", "staged_dir": str(self.root), "gt_jsonl": str(self.root / "gt.jsonl"), "samples": [], "sample_count": 0},
+            "weights_manifest.json": {"weights_ready": True},
+            "env_compat_result.json": {"compat_ok": True},
+            "import_result.json": {"import_passed": True},
+            "load_result.json": {"load_passed": True},
+            "infer_result.json": {"infer_passed": True},
+            "contract_result.json": {"contract_passed": True},
+            "wrapper_manifest.json": {"wrapper_path": "model.py"},
+            "sample_output.json": {"prediction": "ok"},
+        }
+        for name, value in passing_artifacts.items():
+            write_json(self.run_artifacts / name, value)
+
+        stage_result = stage_model_artifacts.main_with_args(
+            ["--run-dir", str(self.run_dir), "--produces", str(self.run_artifacts / "artifact_manifest.json")]
+        )
+        self.assertEqual(stage_result, 0)
+        package = {
+            "schema": "sure.onboard.package_gate.v2",
+            "status": "passed",
+            "package_profile": "none",
+            "model_name": "demo",
+            "model_dir": str(self.model_dir),
+            "artifact_manifest_path": str(self.run_artifacts / "artifact_manifest.json"),
+            "readiness": {
+                "local_ready": True,
+                "container_ready": False,
+                "docker_ready": False,
+                "registry_ready": False,
+                "bundle_ready": True,
+            },
+            "local": {"validation_passed": True, "artifacts_complete": True},
+        }
+        write_json(self.run_artifacts / "package_gate.json", package)
+        package_check = self.run_gate("check_package_gate.py", self.run_artifacts / "package_gate.json")
+        self.assertEqual(package_check.returncode, 0, package_check.stderr)
+
+        with patch.dict(os.environ, {"SURE_SITE_POLICY": str(self.site_policy)}):
+            inventory = write_inventory(
+                self.model_dir,
+                self.run_artifacts / "runtime_inventory.json",
+                self.run_dir,
+            )
+        self.assertEqual(inventory["status"], "ready")
+        self.assertEqual(inventory["policy"]["eval_runtime"], "python")
+        self.assertFalse(inventory["container_runtime"]["required"])
+        inventory_check = self.run_gate("check_runtime_inventory.py", self.run_artifacts / "runtime_inventory.json")
+        self.assertEqual(inventory_check.returncode, 0, inventory_check.stderr)
+
+        verdict = {
+            "status": "passed",
+            "package_profile": "none",
+            "build": {"success": True},
+            "validation": {
+                name: {"passed": True}
+                for name in ("import_test", "load_test", "infer_test", "contract_test")
+            },
+            "readiness": package["readiness"],
+        }
+        write_json(self.run_artifacts / "verdict.json", verdict)
+        verdict_check = self.run_gate("check_verdict.py", self.run_artifacts / "verdict.json")
+        self.assertEqual(verdict_check.returncode, 0, verdict_check.stderr)
+
+        with patch.dict(os.environ, {"SURE_SITE_POLICY": str(self.site_policy)}):
+            deployment = finalize(self.run_dir, self.run_artifacts / "deployment_ready.json")
+        self.assertEqual(deployment["status"], "ready")
+        self.assertEqual(deployment["schema"], "sure.onboard.deployment_ready.v2")
+        self.assertEqual(deployment["execution_policy"]["eval_runtime"], "python")
+        self.assertEqual(deployment["execution_policy"]["isolation"], "trusted_host")
+        final_check = self.run_gate("check_finalized_bundle.py", self.run_artifacts / "deployment_ready.json")
+        self.assertEqual(final_check.returncode, 0, final_check.stderr)
+        self.assertFalse(any(self.model_artifacts.glob("docker_*.json")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sure/skills/sure_onboard/scripts/write_runtime_inventory.py
+++ b/sure/skills/sure_onboard/scripts/write_runtime_inventory.py
@@ -26,6 +26,9 @@ from deployment_contract import (
     validate_runtime_roles,
 )
 
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+from sure.runtime.model.bootstrap import manifest_sha256
+
 
 SCHEMA = "sure.onboard.runtime_inventory.v2"
 CORE_FILES = ("model.spec.yaml", "model.py", "server.py", "__init__.py", "validate.py", "config.yaml", "Dockerfile")
@@ -58,19 +61,13 @@ def load_config(model_dir: Path) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def core_identity(model_dir: Path) -> tuple[dict[str, str], str]:
+def core_identity(model_dir: Path, extra_files: tuple[str, ...] = ()) -> tuple[dict[str, str], str]:
     hashes: dict[str, str] = {}
     for name in CORE_FILES:
         path = model_dir / name
         if path.is_file():
             hashes[name] = sha256_file(path)
-    for name in (
-        "artifacts/weights_manifest.json",
-        "artifacts/docker_build_result.json",
-        "artifacts/docker_validation.json",
-        "artifacts/docker_registry_result.json",
-        "artifacts/package_gate.json",
-    ):
+    for name in ("artifacts/weights_manifest.json", *extra_files):
         path = model_dir / name
         if path.is_file():
             hashes[name] = sha256_file(path)
@@ -82,6 +79,24 @@ def normalize_command(value: object) -> list[str]:
     return [str(item) for item in value] if isinstance(value, list) else []
 
 
+def model_runtime_command(config: dict[str, Any], python_executable: str) -> tuple[list[str], list[str]]:
+    server = config.get("server") if isinstance(config.get("server"), dict) else {}
+    command = normalize_command(server.get("command")) or [python_executable, "server.py"]
+    first = command[0]
+    if first in {"python", "python3"} or first.endswith("/python"):
+        command[0] = python_executable
+    else:
+        raise ValueError("package=none server.command must start with a Python executable")
+    tools = [
+        str(tool["name"])
+        for tool in config.get("tools", [])
+        if isinstance(tool, dict) and isinstance(tool.get("name"), str) and tool["name"]
+    ]
+    if not tools:
+        raise ValueError("package=none config.yaml must declare at least one tool name")
+    return command, tools
+
+
 def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
     resolved = read_json(run_dir / "artifacts" / "model_input_resolved.json")
     package = load_artifact(run_dir, model_dir, "package_gate.json")
@@ -91,10 +106,14 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
     deployment_type = str(resolved.get("deployment_type") or "local")
     profile = str(package.get("package_profile") or resolved.get("package_profile") or "none")
     readiness = package.get("readiness") if isinstance(package.get("readiness"), dict) else {}
-    hashes, bundle_identity = core_identity(model_dir)
-
     local_python = relative_existing(build_env.get("python_executable"), model_dir)
     lockfile = relative_existing(build_env.get("lockfile_path"), model_dir)
+    identity_files = tuple(
+        name
+        for name in (lockfile, "artifacts/model_runtime_manifest.json" if profile == "none" else None)
+        if name
+    )
+    hashes, bundle_identity = core_identity(model_dir, identity_files)
     local_runtime = {
         "purpose": "onboard_validation_evidence_only",
         "eligible_for_eval": False,
@@ -168,6 +187,47 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
         }
         status = "ready"
         eval_runtime = "container_only"
+    elif profile == "none" and readiness.get("bundle_ready") is True:
+        manifest = load_artifact(run_dir, model_dir, "model_runtime_manifest.json")
+        command, tool_names = model_runtime_command(config, str(manifest.get("python_executable") or ""))
+        lockfile = relative_existing(build_env.get("lockfile_path"), model_dir)
+        if not lockfile or sha256_file(model_dir / lockfile) != manifest.get("lock_sha256"):
+            raise ValueError("sealed Model Runtime lock does not match the promoted model lockfile")
+        runtime_checks = build_env.get("runtime_checks") if isinstance(build_env.get("runtime_checks"), dict) else {}
+        model_runtime = {
+            "required": True,
+            "schema": manifest.get("schema"),
+            "runtime_id": manifest.get("runtime_id"),
+            "runtime_type": "model_python",
+            "backend": manifest.get("backend"),
+            "python_executable": manifest.get("python_executable"),
+            "python_version": manifest.get("python_version"),
+            "python_abi": manifest.get("python_abi"),
+            "python_platform": manifest.get("python_platform"),
+            "manifest_path": "artifacts/model_runtime_manifest.json",
+            "manifest_sha256": manifest_sha256(manifest),
+            "lockfile_path": lockfile,
+            "lock_sha256": manifest.get("lock_sha256"),
+            "working_dir": ".",
+            "server_command": command,
+            "tool_names": tool_names,
+            "required_imports": [
+                str(item)
+                for item in runtime_checks.get("required_imports", [])
+                if isinstance(item, str) and item
+            ],
+            "gpu_required": bool((config.get("resources") or {}).get("gpu", True))
+            if isinstance(config.get("resources"), dict)
+            else True,
+        }
+        harness_runtime = {
+            "required": True,
+            "runtime_type": "harness_python",
+            "binding_source": "active_eval_site",
+        }
+        container_runtime = {"required": False}
+        status = "ready"
+        eval_runtime = "python"
     else:
         status = "local_only" if readiness.get("local_ready") is True else "partial"
         container_runtime = {"required": profile != "none"}
@@ -200,10 +260,16 @@ def build_inventory(model_dir: Path, run_dir: Path) -> dict[str, Any]:
         "readiness": readiness,
         "evidence": {
             "package_gate": "artifacts/package_gate.json",
-            "docker_build": "artifacts/docker_build_result.json" if deployment_type == "local" else None,
-            "docker_validation": "artifacts/docker_validation.json" if deployment_type == "local" else None,
-            "docker_registry": "artifacts/docker_registry_result.json" if deployment_type == "local" else None,
+            "docker_build": "artifacts/docker_build_result.json" if profile in {"docker-local", "docker-registry"} else None,
+            "docker_validation": "artifacts/docker_validation.json" if profile in {"docker-local", "docker-registry"} else None,
+            "docker_registry": "artifacts/docker_registry_result.json" if profile == "docker-registry" else None,
             "core_sha256": hashes,
+            "model_core_sha256": {
+                name: digest
+                for name, digest in hashes.items()
+                if name in CORE_FILES or name == "artifacts/weights_manifest.json"
+            },
+            "model_runtime_manifest": "artifacts/model_runtime_manifest.json" if profile == "none" else None,
         },
         "policy": {
             "eval_runtime": eval_runtime,

--- a/sure/skills/sure_onboard/sure.skill.json
+++ b/sure/skills/sure_onboard/sure.skill.json
@@ -1,7 +1,7 @@
 {
 	"name": "sure_onboard",
 	"command": "/sure_onboard",
-	"description": "Onboard or repair an audio model, validate it locally and in Docker, publish a digest-pinned image, and seal a container-only Eval deployment bundle.",
+	"description": "Onboard or repair a model, validate its inference contract, and seal either a digest-pinned container or a site-approved local Python Eval binding.",
 	"prompt": "SKILL.md",
 	"hooks": {
 		"pre_start": [{ "module": "hooks/index.ts", "handler": "preStart" }],
@@ -44,19 +44,19 @@
 			"type": "package_gate",
 			"path": "artifacts/package_gate.json",
 			"required": false,
-			"description": "Docker registry package readiness gate result."
+			"description": "Selected package profile readiness gate result."
 		},
 		{
 			"type": "runtime_inventory",
 			"path": "artifacts/runtime_inventory.json",
 			"required": true,
-			"description": "Container-only Eval runtime binding."
+			"description": "Sealed container or local Python Eval runtime binding."
 		},
 		{
 			"type": "deployment_ready",
 			"path": "artifacts/deployment_ready.json",
 			"required": true,
-			"description": "Terminal portable bundle and immutable image readiness marker."
+			"description": "Terminal portable bundle and approved runtime readiness marker."
 		}
 	],
 	"ui": {


### PR DESCRIPTION
## Authoritative source

- GitLab branch: `harness-tui-agent`
- GitLab source commit: `4e058840e661c6347094e0eb5af89152999d021f`
- Public projection manifest: `sure.public_export_manifest.v1`, `source_dirty=false`
- Replaces the stale implementation in #12 while leaving that PR untouched for comparison.

## Behavior

- Allows a site policy to opt into local `python` and/or `container` runtimes.
- Adds `package=none` onboarding backed by a sealed, content-addressed `uv` Model Python runtime.
- Resolves and verifies the sealed runtime plus model-core hashes before local evaluation.
- Keeps `docker-registry` as the default package profile and keeps VC execution container-only.
- Preserves the existing v1 Docker/API readiness contract while using versioned v2 contracts for local Python bindings.

## Public projection boundary

- Excludes `.gitlab-ci.yml`, the bundled site policy, and `private/aispeech/**`.
- Preserves the GitHub-only animated README assets and folds only the new local-Python usage into the public README.
- All exported entries other than that documented README overlay match the GitLab export byte-for-byte.

## Validation

- `npm run check`: 11/11
- Site compatibility rules: 7/7
- Python: 234 sure_eval + 128 sure_trans + 22 sure_onboard + 18 sure_feed + 10 site
- TypeScript SURE suite: 379 passed, 2 skipped
- Public export: two 1610-entry trees, byte-identical
- Public startup: unconfigured policy fails closed; configured `sure:site-check` and `sure:doctor` pass
