### PR TITLE
fix(agent): unify the public approval root

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 *One discover, onboard, evaluate session, replayed as a self-contained SVG animation. Regenerate with `node scripts/generate-readme-terminal.mjs`.*
 
-SURE is an agent-based, system-level reproducible evaluation harness built on [Pi](https://github.com/badlogic/pi-mono), with an interactive terminal UI. It turns model discovery, local deployment, environment adaptation, inference, evaluation, and re-evaluation into integrated workflows instead of leaving users to connect them by hand.
+SURE is an agent-based, system-level reproducible evaluation harness built on [Pi](https://github.com/badlogic/pi-mono), with an interactive terminal UI. It turns model discovery, local deployment, environment adaptation, approval, inference, evaluation, and re-evaluation into integrated workflows instead of leaving users to connect them by hand.
 
 SURE works with coding agents including OpenAI Codex, Kimi Code, GitHub Copilot, Anthropic Claude, OpenAI, and custom OpenAI-compatible gateways such as DeepSeek.
 
@@ -31,21 +31,23 @@ The central promise is simple: SURE reduces deployment and evaluation work witho
 ## From Model to Result
 
 ```text
-Model repository       Runnable deployment       Predictions + metrics       New evaluation route
-       |                        |                         |                            |
-  /sure_feed  ---------->  /sure_onboard  ---------->  /sure_eval  ---------->  /sure_reval
+Model source          Runnable bundle          Approved model        Predictions + metrics       New evaluation route
+     |                      |                        |                         |                            |
+ /sure_feed  ->  /sure_onboard or /sure_trans  ->  /sure_approve  ->  /sure_eval  ->  /sure_reval
 ```
 
 | Workflow | What the agent does | Reproducible product |
 | --- | --- | --- |
 | Discover | Researches a Hugging Face, ModelScope, or GitHub model and resolves its capabilities, runtime, fixtures, and I/O contract | Canonical `model_input.yaml` plus source evidence |
 | Onboard | Adapts and validates the model, generates a runnable inference package when needed, and seals local models as a digest-pinned OCI image or content-addressed Python runtime | Portable model bundle plus `deployment_ready.json` |
+| Transform | Converts an existing Dockerfile, model, and inference entrypoint into the standard runtime contract | Adapter wrapper, digest-pinned image, and `deployment_ready.json` |
+| Approve | Audits a completed bundle, binds an explicit human decision, and publishes it atomically | Review packet, approval decision, and `approval_ready.json` |
 | Evaluate | Runs approved inference, resolves a deterministic evaluation route, and computes metrics | Predictions, protocol, reports, metrics, and sample-level evidence |
 | Re-evaluate | Reuses approved predictions with an explicit pipeline | A new evaluation batch without repeating inference |
 
 For common PyTorch and Transformers models, the onboarding agent can synthesize missing load and inference adapters from upstream documentation and source evidence. Every generated path must still pass environment, selected-runtime, interface, and artifact-contract gates before it can be marked ready.
 
-Promotion is intentionally human-reviewed. SURE stages model bundles and evaluation results, but it never silently copies them into configured approved storage. This keeps convenience from weakening the experiment's trust boundary.
+Model publication is intentionally human-reviewed. `/sure_approve` separates an immutable audit from the explicit approval decision; only that workflow can publish a model into configured approved storage. Evaluation-result promotion remains a separate human-reviewed operation. This keeps convenience from weakening the experiment's trust boundary.
 
 ## Choose How to Run SURE
 
@@ -129,6 +131,8 @@ npm run sure:doctor
 
 `sure:site-info` should report `configured: true` and `source: local`; `sure:site-check` must pass. Before provider and dataset setup, `sure:doctor` may warn about missing Pi authentication or evaluation data.
 
+Configure `storage.approved_models_roots[0]` once. `/sure_approve` publishes verified model packages only to this root, and `/sure_eval model=<name>` resolves the exact child directory from the same root. There is no command-level approval-root override.
+
 Before using the default `docker-registry` profile, replace the registry and repository namespace placeholders. `container_delivery.repository_template` is site configuration; SURE resolves it before building an image and does not invent a registry destination. API-only onboarding and local `package=none` Python execution do not use these fields.
 
 For shared storage or additional execution surfaces, start from [`config/site.example.yaml`](./config/site.example.yaml) and read the [site configuration guide](./docs/site-configuration.md). Keep `config/site.local.yaml` local, or set `SURE_SITE_POLICY` to an absolute policy path outside the repository.
@@ -184,7 +188,7 @@ For a local model, SURE researches the upstream implementation, materializes an 
 sure/models/Qwen__Qwen3-ASR-1.7B/artifacts/deployment_ready.json
 ```
 
-`deployment_ready.json` is a readiness marker, not an approval. Review the complete model directory, then copy that directory into one of the configured `approved_models_roots`. `/sure_eval` only accepts the exact directory name below an approved root.
+`deployment_ready.json` is a readiness marker, not an approval. Do not copy the model directory into approved storage manually; use `/sure_approve` after reviewing the complete bundle. `/sure_eval` only accepts the exact directory name below the configured approved root.
 
 Omitting `package` keeps the default `docker-registry` profile. For a self-hosted local evaluation that does not need Docker, select the Python profile explicitly:
 
@@ -192,7 +196,23 @@ Omitting `package` keeps the default `docker-registry` profile. For a self-hoste
 /sure_onboard model=Qwen__Qwen3-ASR-1.7B package=none
 ```
 
-The Python profile requires the `uv` backend, a hash-locked requirements file, and `python` in the site's `execution.local_runtimes`. SURE seals a portable runtime identity into the promoted model bundle and resolves the matching runtime below `storage.runtime_root` during `/sure_eval`. It never accepts an arbitrary host Python or model-local `.venv`, and Python deployments cannot be submitted to VC. See [`/sure_onboard`](./sure/skills/sure_onboard/SKILL.md) for API models, explicit handoff paths, device selection, and repair flows.
+The Python profile requires the `uv` backend, a hash-locked requirements file, and `python` in the site's `execution.local_runtimes`. SURE seals a portable runtime identity into the approved model bundle and resolves the matching runtime below `storage.runtime_root` during `/sure_eval`. It never accepts an arbitrary host Python or model-local `.venv`, and Python deployments cannot be submitted to VC. See [`/sure_onboard`](./sure/skills/sure_onboard/SKILL.md) for API models, explicit handoff paths, device selection, and repair flows.
+
+### Review and publish a model with `/sure_approve`
+
+Audit a completed `/sure_onboard` or `/sure_trans` bundle first:
+
+```text
+/sure_approve model_dir=sure/models/Qwen__Qwen3-ASR-1.7B
+```
+
+The audit keeps the producer bundle read-only, creates an isolated candidate, verifies its terminal evidence and runtime, and emits a `review_packet.json` in `awaiting_approval`. Read that packet, decide explicitly, then start a separate approval run:
+
+```text
+/sure_approve mode=approve review_manifest=/absolute/path/to/review_packet.json decision=approve
+```
+
+SURE never infers the human decision. A successful approval atomically publishes to `storage.approved_models_roots[0]`, verifies the published deployment binding, and emits `approval_ready.json`. See [`/sure_approve`](./sure/skills/sure_approve/SKILL.md) for rejection, bounded repair, replacement, and artifact details.
 
 ### Evaluate an approved model with `/sure_eval`
 

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -40,7 +40,7 @@ The machine-readable contract is [sure/site/policy.schema.json](../sure/site/pol
 | `schema` | yes | Must be `sure.site.policy.v1` |
 | `site_id` | yes | Stable lowercase deployment identifier |
 | `policy_version` | yes | Must be `1` |
-| `storage.approved_models_roots` | yes | Read-only roots containing human-approved model packages |
+| `storage.approved_models_roots` | yes | Protected model root written only by `/sure_approve` and read by `/sure_eval` |
 | `storage.approved_results_roots` | yes | Read-only roots containing human-approved evaluation results |
 | `storage.forbidden_output_roots` | yes | Roots where automated `output_dir` writes are forbidden |
 | `storage.runtime_root` | yes | Site-owned cache root for content-addressed Model Python runtimes and adapters |
@@ -51,11 +51,14 @@ The machine-readable contract is [sure/site/policy.schema.json](../sure/site/pol
 | `execution.vc_partitions` | when needed | Declared VC partitions for adapters and deployment documentation |
 | `execution.vc_partition_priority` | optional | Numeric priority map used by automatic VC selection |
 | `network` | optional | Non-secret site endpoints used by private adapters and documentation |
+| `network.container_registry` | for `docker-registry` | Registry host or host/path prefix, without a URL scheme |
 | `container_delivery.repository_template` | for `docker-registry` | Repository template using `{registry}`, optional `{task}`, and `{model_name}` |
 
 Unknown fields, duplicate list values, unsupported surfaces, and relative paths are rejected. Policy files may contain credential environment-variable names, but never credential values.
 
 Policy v1 accepts exactly one path in each root list. The list shape leaves room for a future multi-root contract, but the current workflow preserves its historical single-root selection semantics.
+
+`storage.approved_models_roots[0]` is the single approval-root setting. `/sure_approve` publishes a verified model package only to `<approved_models_roots[0]>/<model>`, and `/sure_eval model=<model>` resolves that exact child directory from the same root. Neither command accepts a per-run approval-root override, so a deployment configures this location once rather than keeping publication and discovery settings in sync manually.
 
 `execution.surfaces` constrains automatic and explicit execution selection. `execution.vc_partitions` documents site choices but does not replace the existing live `vc info -u` authorization check; changing partition authorization semantics is outside this separation phase.
 
@@ -64,7 +67,7 @@ Policy v1 accepts exactly one path in each root list. The list shape leaves room
 ## Path Semantics
 
 - Every configured root is absolute.
-- Approved model and result roots must be protected by a configured forbidden output root.
+- Approved model and result roots must be protected by a configured forbidden output root. Ordinary `output_dir` writes remain forbidden there; model publication enters the approved model root only through `/sure_approve`.
 - The declared runtime root must stay outside forbidden output roots.
 - A configured dataset projection root must stay outside forbidden output roots and must not overlap an allowed source root.
 - Path authorization resolves existing symlinks before comparison, so alternate names cannot bypass a protected root.
@@ -110,7 +113,9 @@ container_delivery:
 
 For shared storage, replace these placeholders with roots visible to every host and container that executes a workflow. The projection root is the only writable dataset workspace; source roots are mounted read-only. For a local-only fixture, create temporary model, result, dataset, projection, and runtime roots and point the local policy at them.
 
-`container_delivery.repository_template` is site data, not an agent decision. Registry-backed workflows resolve it before downloading model weights or building an image. The template must start with `{registry}/`, must include `{model_name}`, and may include `{task}`. Credentials remain in the Docker credential store and must not appear in this policy.
+`container_delivery.repository_template` is site data, not an agent decision. Registry-backed workflows resolve it before downloading model weights or building an image. The template must start with `{registry}/`, must include `{model_name}`, and may include `{task}`. `/sure_onboard` uses the resolved repository as its delivery target; `/sure_trans` uses the same target and appends `-source` for its source-image repository.
+
+When `image_version` is omitted, the workflow queries the relevant Registry V2 tag lists, considers only `major.minor.patch` tags, and selects the next patch after the highest existing version; an empty repository starts at `0.1.0`. A query failure blocks instead of guessing a tag. The resolved repositories, version, observed tags, and site-policy identity are recorded in `model_input_resolved.json` or `trans_input_resolved.json`; credentials remain in the Docker credential store and never enter either artifact or the policy.
 
 ## Diagnostics
 
@@ -126,5 +131,7 @@ Common repairs:
 - `unknown field`: remove the field or update the policy to the current schema.
 - `must be protected by a forbidden output root`: add the approved root's parent to `forbidden_output_roots`.
 - `site policy is not configured`: copy the example to `config/site.local.yaml`, edit it, and rerun `sure:site-check`.
+- `site policy is missing network.container_registry` or `container_delivery.repository_template`: configure both fields before selecting `docker-registry` delivery.
+- `registry tag query failed`: verify registry reachability, Docker login state, and the resolved repository; do not bypass automatic versioning with a guessed tag.
 
 Custom execution surfaces and site integrations belong in a private adapter that depends on public interfaces. Public core code must never import a private adapter. In this phase all site differences are expressed as `sure.site.policy.v1` data, so no adapter code ships; a provider interface will be introduced as a separately reviewed design change when a behavior cannot be expressed as policy data.

--- a/packages/coding-agent/test/suite/sure-approve-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-approve-state-machine.test.ts
@@ -4,7 +4,7 @@ import {
 	initialCheckpoint,
 	retryExhausted,
 } from "../../../../sure/skills/sure_approve/hooks/checkpoints.ts";
-import { modeFromArgs } from "../../../../sure/skills/sure_approve/hooks/index.ts";
+import { modeFromArgs, preStart } from "../../../../sure/skills/sure_approve/hooks/index.ts";
 import {
 	APPROVE_UNITS,
 	AUDIT_UNITS,
@@ -13,6 +13,7 @@ import {
 	unitsForMode,
 } from "../../../../sure/skills/sure_approve/hooks/state-machine.ts";
 import { validateProduces } from "../../../../sure/skills/sure_approve/hooks/validate.ts";
+import type { SureHookContext } from "../../src/core/sure/types.ts";
 
 describe("sure_approve state machine", () => {
 	it("keeps audit and human approval in separate runs", () => {
@@ -26,6 +27,14 @@ describe("sure_approve state machine", () => {
 	it("infers approval mode from the prior review and explicit decision", () => {
 		expect(modeFromArgs("review_manifest=/tmp/review.json decision=approve")).toBe("approve");
 		expect(modeFromArgs("model_dir=/tmp/model")).toBe("audit");
+	});
+
+	it("rejects command-level approval root overrides", () => {
+		const result = preStart({
+			args: "model_dir=/tmp/model approve_dir=/tmp/custom",
+		} as SureHookContext);
+		expect(result.ok).toBe(false);
+		expect(result.repair).toContain("storage.approved_models_roots[0]");
 	});
 
 	it("orders publication only after an explicit decision", () => {

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,8 +1,8 @@
 {
   "schema": "sure.public_export_manifest.v1",
-  "source_commit": "66b7108d6bc2cc92b9e4387590fea70a2abdb554",
+  "source_commit": "0798d32a17247c827d47d28b254995bfa8012590",
   "source_dirty": false,
-  "tree_sha256": "f16199f91e6af9f3be7fd64ef9ed384dc8a3bfcc918605394f8cb12afbebe327",
+  "tree_sha256": "e1eea13c813e7f86980e532341bcdfc7d8de11db60b1159038a81a96448d3a18",
   "files": [
     {
       "path": ".github/workflows/public-ci.yml",
@@ -47,7 +47,7 @@
     {
       "path": "README.md",
       "type": "file",
-      "sha256": "74dccbff690567d5ea4546cfc686064b802efed8121092a75cf350fa60f1d606"
+      "sha256": "7785c5a9889fdb4e46410ecca1608c7d6058de3e7674bf0a8c6003fc8ddd799e"
     },
     {
       "path": "SECURITY.md",
@@ -72,7 +72,7 @@
     {
       "path": "docs/site-configuration.md",
       "type": "file",
-      "sha256": "4fecca684046d29d59f75905ca718e5dd19d00cdb775b5543c121a9761db1d60"
+      "sha256": "80f42e4838f705f9261ff68f79bbb7462da5c18310a02fbf18e5ee0eae8a236f"
     },
     {
       "path": "fixtures/README.md",
@@ -4617,7 +4617,7 @@
     {
       "path": "packages/coding-agent/test/suite/sure-approve-state-machine.test.ts",
       "type": "file",
-      "sha256": "72c62a23b6b474efaa846f2a7d1172bfae22a610be90419b23f777e9d6ca2037"
+      "sha256": "b5351c8a49ffdd377c40b183616511b6aab9cc376e6cfd0fdec6eb10ec116bae"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-eval-red-lines.test.ts",
@@ -5677,7 +5677,7 @@
     {
       "path": "sure/skills/sure_approve/SKILL.md",
       "type": "file",
-      "sha256": "e66a787ac4159b588e7b0c4caf8863a8764ab83ffd844e80f13a5bb3ec393c21"
+      "sha256": "9e840d8eaa4de854b18c3d37830651c221096675bfe4e9eb9150dd1b82d5712c"
     },
     {
       "path": "sure/skills/sure_approve/examples/minimal-input.json",
@@ -5692,7 +5692,7 @@
     {
       "path": "sure/skills/sure_approve/hooks/index.ts",
       "type": "file",
-      "sha256": "ba2f75b6c9812c42279cae933b73ed3c304e23e7bf5ed9a7e9c065363f425ed3"
+      "sha256": "4614267148593c708714eaaed39834ee48ec62ae18c02755d5dfa86754ea8ba4"
     },
     {
       "path": "sure/skills/sure_approve/hooks/state-machine.ts",
@@ -5777,7 +5777,7 @@
     {
       "path": "sure/skills/sure_approve/scripts/approval_core.py",
       "type": "file",
-      "sha256": "df722bbff92109d7b2c487a672a3d619b3fcf25453084c6f936531e6eed0eb79"
+      "sha256": "752785732f05ad3022ba6e9b4fb74f1bdd5d92f85986739538b5fbb797cd13dd"
     },
     {
       "path": "sure/skills/sure_approve/scripts/audit_bundle.py",
@@ -5807,7 +5807,7 @@
     {
       "path": "sure/skills/sure_approve/scripts/test_approval_flow.py",
       "type": "file",
-      "sha256": "1483cb7cae04382e044acbe8a458dd30a821e62b06189dd629a653be0446a75d"
+      "sha256": "27c9113b9b5c644e99a015420ba6b8ed8d865f035cb52a7522df70b0281ce22b"
     },
     {
       "path": "sure/skills/sure_approve/scripts/verify_candidate_runtime.py",
@@ -7932,7 +7932,7 @@
     {
       "path": "sure/skills/sure_trans/README.md",
       "type": "file",
-      "sha256": "68dd37fbf67811ce2a11abbfc1102e1d4ef59c743b8bfa0dac33fe05faa2e369"
+      "sha256": "bcdd10fc3f525c2314c927dd4c69fef979276816a71e56a04dd1cd02be227905"
     },
     {
       "path": "sure/skills/sure_trans/SKILL.md",

--- a/sure/skills/sure_approve/SKILL.md
+++ b/sure/skills/sure_approve/SKILL.md
@@ -12,7 +12,6 @@ Audit a completed `/sure_onboard` or `/sure_trans` bundle without mutating it, b
 | Parameter | Required | Meaning |
 | --- | --- | --- |
 | `model_dir` | audit mode | Explicit readable producer bundle. Absolute paths and paths relative to the invocation directory are accepted. |
-| `approve_dir` | no | Publication root. Defaults to the active site's approved model root. |
 | `mode` | no | `audit` (default) or `approve`. |
 | `repair` | no | `safe` (default) or `none`. Safe repair never changes executable behavior. |
 | `review_manifest` | approve mode | `review_packet.json` emitted by a completed audit. |
@@ -38,7 +37,7 @@ Read the review packet, make the decision yourself, then start a separate approv
 
 Approval verifies that the packet and candidate are unchanged. A positive decision publishes through a hidden same-filesystem sibling and atomic rename. A rejection records the decision and does not publish.
 
-Use `approve_dir=/custom/root` only for a deliberate non-default publication. Such a result records `eval_visible=false`; current `/sure_eval` discovery sees only the active site's configured approved model root.
+The publication root is always `storage.approved_models_roots[0]` from the active site policy. `/sure_eval` discovers approved model names below that same root, so the deployment configures it once and no command-level publication-root override exists.
 
 ## Boundaries
 
@@ -49,6 +48,7 @@ Use `approve_dir=/custom/root` only for a deliberate non-default publication. Su
 - Require passing original, adapter, MCP, and equivalence evidence for `/sure_trans`.
 - Restrict safe repair to derived paths, publication permissions, and excluded caches. Never repair wrappers, configs, weights, payloads, locks, runtimes, images, provenance, or failed validation.
 - Reject source/destination overlap, escaping links, special files, and destination collisions.
+- Reject review packets whose destination does not match the active site's configured approved model root.
 - Never create the human decision. Require the user-supplied `decision` parameter.
 
 Read [producer-contracts.md](references/producer-contracts.md) when classifying the producer or diagnosing a failed audit. Read [repair-policy.md](references/repair-policy.md) before accepting or describing a repair.

--- a/sure/skills/sure_approve/hooks/index.ts
+++ b/sure/skills/sure_approve/hooks/index.ts
@@ -57,6 +57,10 @@ function maxRetriesFromArgs(raw: string): number {
 export function preStart(ctx: SureHookContext): SureHookResult {
 	const args = parseArgs(ctx.args);
 	const mode = modeFromArgs(ctx.args);
+	if (args.approve_dir || args["approve-dir"])
+		return failure(
+			"approve_dir is not supported. Configure storage.approved_models_roots[0] once in the active site policy; /sure_approve and /sure_eval use that root.",
+		);
 	if (args.mode && args.mode !== "audit" && args.mode !== "approve") return failure("mode must be audit or approve.");
 	if (mode === "audit" && !args.model_dir)
 		return failure("Audit mode requires model_dir=<completed onboard/trans bundle>.");

--- a/sure/skills/sure_approve/scripts/approval_core.py
+++ b/sure/skills/sure_approve/scripts/approval_core.py
@@ -152,14 +152,8 @@ def resolve_input(args: argparse.Namespace) -> dict[str, Any]:
     configured = load_active_policy()
     policy = configured["policy"]
     configured_root = Path(policy["storage"]["approved_models_roots"][0]).resolve()
-    approve_supplied = args.approve_dir or str(configured_root)
-    _, approve_root = _relative_supplied(approve_supplied, invocation_cwd)
-    for raw_forbidden in policy["storage"]["forbidden_output_roots"]:
-        forbidden = Path(str(raw_forbidden)).resolve()
-        if approve_root != configured_root and is_inside(approve_root, forbidden):
-            raise ApprovalError(f"approval root is under a forbidden output root: {approve_root}")
     model_name = _resolved_model_name(source)
-    destination = approve_root / model_name
+    destination = configured_root / model_name
     if paths_overlap(source, destination):
         raise ApprovalError(f"source and destination overlap: {source} <-> {destination}")
     review_manifest = None
@@ -173,11 +167,10 @@ def resolve_input(args: argparse.Namespace) -> dict[str, Any]:
         "repair": args.repair,
         "source": {"supplied": supplied, "canonical": str(source)},
         "approval": {
-            "supplied_root": approve_supplied,
-            "root": str(approve_root),
+            "root": str(configured_root),
             "destination": str(destination),
             "configured_root": str(configured_root),
-            "eval_visible": approve_root == configured_root,
+            "eval_visible": True,
             "replace": args.replace,
         },
         "review_manifest": review_manifest,
@@ -748,7 +741,15 @@ def publish(run_dir: Path, replace: bool) -> dict[str, Any]:
     approval = packet.get("approval") if isinstance(packet.get("approval"), dict) else {}
     root = Path(str(approval.get("root") or "")).resolve()
     destination = Path(str(approval.get("destination") or "")).resolve()
-    if destination.parent != root or destination.name != packet.get("model_name"):
+    configured_root = Path(policy["policy"]["storage"]["approved_models_roots"][0]).resolve()
+    declared_configured_root = Path(str(approval.get("configured_root") or "")).resolve()
+    if (
+        root != configured_root
+        or declared_configured_root != configured_root
+        or destination.parent != configured_root
+        or destination.name != packet.get("model_name")
+        or approval.get("eval_visible") is not True
+    ):
         raise ApprovalError("review packet contains an invalid publication destination")
     if paths_overlap(candidate, destination):
         raise ApprovalError("candidate and destination overlap")
@@ -836,6 +837,9 @@ def verify_publication(run_dir: Path) -> dict[str, Any]:
         policy = load_active_policy()
         if policy["sha256"] != packet.get("site_policy_sha256"):
             raise ApprovalError("active site policy changed before publication verification")
+        configured_root = Path(policy["policy"]["storage"]["approved_models_roots"][0]).resolve()
+        if destination.parent != configured_root or publication.get("eval_visible") is not True:
+            raise ApprovalError("published bundle is outside the active site's approved model root")
         binding = load_deployment_binding(destination, str(packet["model_name"]))
     except DeploymentBindingError as exc:
         raise ApprovalError(f"published bundle is not consumable by sure_eval: {exc}") from exc
@@ -888,7 +892,6 @@ def _write_result(path: Path, producer: Any, nonzero_statuses: frozenset[str] = 
 def main_resolve() -> int:
     parser = _common_parser()
     parser.add_argument("--model-dir", required=False)
-    parser.add_argument("--approve-dir")
     parser.add_argument("--mode", choices=("audit", "approve"), default="audit")
     parser.add_argument("--repair", choices=("safe", "none"), default="safe")
     parser.add_argument("--review-manifest")

--- a/sure/skills/sure_approve/scripts/test_approval_flow.py
+++ b/sure/skills/sure_approve/scripts/test_approval_flow.py
@@ -176,13 +176,12 @@ class ApprovalFlowTests(unittest.TestCase):
         }
         write_json(artifacts / "deployment_ready.json", deployment)
 
-    def audit(self, run_dir: Path, approve_dir: Path | None = None) -> dict:
+    def audit(self, run_dir: Path) -> dict:
         run_artifacts = run_dir / "artifacts"
         run_artifacts.mkdir(parents=True)
         args = argparse.Namespace(
             invocation_cwd=str(self.root),
             model_dir=str(self.source),
-            approve_dir=str(approve_dir) if approve_dir else None,
             mode="audit",
             repair="safe",
             review_manifest=None,
@@ -235,26 +234,47 @@ class ApprovalFlowTests(unittest.TestCase):
         write_json(self.source / "artifacts" / "model_input_resolved.json", {"model_name": "demo-model"})
         run = self.root / "runs" / "incomplete"
         (run / "artifacts").mkdir(parents=True)
-        args = argparse.Namespace(invocation_cwd=str(self.root), model_dir=str(self.source), approve_dir=None, mode="audit", repair="safe", review_manifest=None, decision=None, replace=False)
+        args = argparse.Namespace(invocation_cwd=str(self.root), model_dir=str(self.source), mode="audit", repair="safe", review_manifest=None, decision=None, replace=False)
         write_json(run / "artifacts" / "approve_input_resolved.json", approval_core.resolve_input(args))
         report = approval_core.classify_producer(run)
         self.assertEqual(report["status"], "failed")
         self.assertIn("TERMINAL_EVIDENCE_MISSING", {item["code"] for item in report["findings"]})
 
-    def test_forbidden_custom_approval_root_is_rejected(self) -> None:
+    def test_approval_root_comes_from_active_site_policy(self) -> None:
         self.build_python_bundle()
         args = argparse.Namespace(
             invocation_cwd=str(self.root),
             model_dir=str(self.source),
-            approve_dir=str(self.root / "forbidden" / "models"),
             mode="audit",
             repair="safe",
             review_manifest=None,
             decision=None,
             replace=False,
         )
-        with self.assertRaisesRegex(approval_core.ApprovalError, "forbidden output root"):
-            approval_core.resolve_input(args)
+        resolved = approval_core.resolve_input(args)
+        self.assertEqual(resolved["approval"]["root"], str(self.approved))
+        self.assertEqual(resolved["approval"]["configured_root"], str(self.approved))
+        self.assertEqual(resolved["approval"]["destination"], str(self.approved / "demo-model"))
+        self.assertTrue(resolved["approval"]["eval_visible"])
+
+    def test_publication_rejects_review_packet_with_nonconfigured_root(self) -> None:
+        self.build_python_bundle()
+        audit_run = self.root / "runs" / "legacy-root-audit"
+        review = self.audit(audit_run)
+        custom_root = self.root / "custom-approved"
+        review["approval"]["root"] = str(custom_root)
+        review["approval"]["destination"] = str(custom_root / "demo-model")
+        review["packet_digest"] = approval_core._packet_digest(review)
+        review_path = audit_run / "artifacts" / "review_packet.json"
+        write_json(review_path, review)
+
+        approve_run = self.root / "runs" / "legacy-root-approve"
+        approve_artifacts = approve_run / "artifacts"
+        approve_artifacts.mkdir(parents=True)
+        decision = approval_core.verify_decision(review_path, "approve", "validated in test")
+        write_json(approve_artifacts / "approval_decision.json", decision)
+        with self.assertRaisesRegex(approval_core.ApprovalError, "invalid publication destination"):
+            approval_core.publish(approve_run, replace=False)
 
     def test_repair_none_does_not_silently_change_the_candidate(self) -> None:
         self.build_python_bundle()
@@ -266,7 +286,6 @@ class ApprovalFlowTests(unittest.TestCase):
         args = argparse.Namespace(
             invocation_cwd=str(self.root),
             model_dir=str(self.source),
-            approve_dir=None,
             mode="audit",
             repair="none",
             review_manifest=None,
@@ -347,7 +366,7 @@ class ApprovalFlowTests(unittest.TestCase):
         (self.source / "checkpoints" / "external.bin").symlink_to(outside)
         run = self.root / "runs" / "link"
         (run / "artifacts").mkdir(parents=True)
-        args = argparse.Namespace(invocation_cwd=str(self.root), model_dir=str(self.source), approve_dir=None, mode="audit", repair="safe", review_manifest=None, decision=None, replace=False)
+        args = argparse.Namespace(invocation_cwd=str(self.root), model_dir=str(self.source), mode="audit", repair="safe", review_manifest=None, decision=None, replace=False)
         write_json(run / "artifacts" / "approve_input_resolved.json", approval_core.resolve_input(args))
         write_json(run / "artifacts" / "producer_contract_report.json", approval_core.classify_producer(run))
         integrity = approval_core.audit_integrity(run)

--- a/sure/skills/sure_trans/README.md
+++ b/sure/skills/sure_trans/README.md
@@ -9,6 +9,7 @@
 | Source image | 由交付物还原出的原版运行镜像:优先 `docker load` build context 内的镜像 tar,失败则回退 `docker build` 原 Dockerfile。 |
 | Adapter image | 在 source image 之上叠加 `/opt/sure_trans/`(`model.py` + `server.py` + `config.yaml` + `model.spec.yaml` + `__init__.py` + `validate.py`)生成的新镜像,实现 `ModelWrapper` 与 MCP 协议,并携带模型本地验证入口 `validate.py`。 |
 | Digest 固定 | 所有交接引用使用 `image@sha256:...`,禁止可变 tag;registry push 后必须按 digest 精确 pull 并复验。 |
+| 站点解析交付 | source/adapter 仓库由活动站点策略统一解析,agent 不拼接 namespace;解析结果和策略身份写入 `trans_input_resolved.json`。 |
 | Container-only | Eval 运行时完全在容器内:`host_python_fallback=false`、`image_override_allowed=false`,模型 payload 以只读方式挂载。 |
 | IO contract | `input_type=audio_path` 到 `output_type=json`,`primary_field=text`,`required_fields=["text"]`、`nonempty_fields=["text"]`、`json_serializable=true`,由 `validate.py --stage contract` 对 `sample_output.json` 校验。 |
 | 模型 bundle | 最终交接目录 `sure/models/<model_name>/`:wrapper 五件套 + `Dockerfile.sure` + 模型 payload + `fixture/<task>/` + `artifacts/` terminal sidecar。`/sure_eval` 只挂载该目录,外部绝对路径不是可执行交接。 |
@@ -28,10 +29,12 @@
 | `image_tar` | 否 | 显式指定镜像 tar,必须位于 `build_context` 内。 |
 | `model_name` | 是 | 必须使用 `<组织>__<模型名称>` 格式；后续 bundle、镜像和 registry 命名均使用此值。 |
 | `fixture` | 否 | 冒烟输入绝对路径,否则自动选择 build context 下无歧义的 `examples/smoke.*`。 |
-| `device` | 否 | `auto`(默认)/`cuda`/`cpu`。核心转换目前只用本地 Docker 验证。 |
+| `device` | 否 | `auto`(默认)/`cuda`/`cpu`。`cpu` 只用本地 Docker;`cuda` 和 `auto` 先通过 VC 做 GPU 验证,符合条件的 `auto` 才可回退本地 CPU。 |
+| `vc_partition` | 否 | GPU 验证分区;默认取活动站点策略的 `execution.vc_default_partition`。 |
+| `vc_memory_gb` / `vc_gpus` | 否 | GPU 验证资源覆盖;默认 32 GiB、1 GPU。 |
 | `model_mount_target` | 否 | 默认 `/models/<model_name>`。 |
 | `model_stage_policy` | 否 | `auto`(默认)/`copy`/`hardlink`。 |
-| `image_version` | 否 | 显式 registry tag 覆盖项。省略时查询 source/adapter 仓库已有的三段数字版本，选择最高版本的下一个 patch；空仓库从 `0.1.0` 开始。 |
+| `image_version` | 否 | 显式 registry tag 覆盖项。省略时查询站点解析出的 source/adapter 仓库，选择已有三段数字版本的下一个 patch；空仓库从 `0.1.0` 开始。 |
 | `max_retries` | 否 | 默认 3。 |
 
 启动示例:
@@ -44,7 +47,7 @@
 
 框架检测只把 PyTorch 作为硬门槛。`model_framework=transformers` 是推荐路径；若申报其他模型框架，或静态分析发现 PyTorch 实现未使用 Transformers，流程继续运行，并在 `framework_detection.json` 和最终 `verdict.json.framework` 中记录申报值、检测分类、架构线索与澄清。后续原始推理、adapter 推理和等价性 gate 仍必须全部通过。
 
-自动版本解析结果记录在 `trans_input_resolved.json.image_version_resolution`。查询复用 Docker 登录凭据但不把凭据写入 artifact；registry 查询失败会阻断，不会猜测可能重复的版本。并发运行仍可能同时选中同一版本，最终由 registry 的不可覆盖策略阻止冲突，失败的一方重新解析版本后再提交。
+source/adapter 仓库分别由 `network.container_registry` 和 `container_delivery.repository_template` 解析;source 仓库在目标仓库名后追加 `-source`。自动版本解析结果记录在 `trans_input_resolved.json.image_version_resolution`。查询复用 Docker 登录凭据但不把凭据写入 artifact；registry 查询失败会阻断，不会猜测可能重复的版本。并发运行仍可能同时选中同一版本，最终由 registry 的不可覆盖策略阻止冲突，失败的一方重新解析版本后再提交。
 
 source 镜像构建会自动追加一层：若基础镜像没有 `git`，按镜像内可用的 apt/apk/dnf/yum/microdnf 安装 `git` 和 `ca-certificates`；原始 Dockerfile 不会被改写，最终 `USER` 会恢复。这样 adapter 镜像继承该工具，避免 `/sure_eval` 运行时缺少 `git`。
 
@@ -138,7 +141,8 @@ sure/models/<model_name>/
 | `uv` | Harness Runtime 引导必需,可用 `SURE_UV_BIN` 指定。 |
 | Python 3.11 | 引导复制 host CPython 3.11 的 stdlib 与共享库。conda 版 `INSTSONAME=libpython3.11.a` 但只带 `.so`,会报 "standard library or shared library is missing",需用 python-build-standalone 等正牌 CPython。 |
 | Docker | source 与 adapter 镜像的 load、build、运行、push/pull 全部依赖本地 Docker daemon。部分站点的 `docker` 是包装脚本,容器内进程失败时仍可能返回 0,gate 不能只信退出码。 |
-| GPU | 视模型规格而定,7B BF16 模型约需 14 GiB 空闲显存。 |
+| VC | `device=cuda` 和 `auto` 必须能调用 `vc`;分区和默认资源来自站点策略与命令参数。 |
+| GPU | 视模型规格而定,7B BF16 模型约需 14 GiB 空闲显存;GPU smoke 在 VC 作业内执行,不占用登录节点本地 GPU。 |
 | PyPI 网络 | 首次运行从 PyPI 物化 Harness Runtime 依赖,可通过 `UV_DEFAULT_INDEX` 指定镜像源。 |
 
 确认是 `CUDA out of memory` 时,验证 gate 会在当前 VC partition 自动重新提交最多 8 次,让调度器重新分配 GPU;每次尝试保留独立日志。VC 接口不能指定物理卡,因此不保证 8 次对应 8 张不同 GPU。8 次都失败后才报告显存修复建议。


### PR DESCRIPTION
## Summary

- project the public state of GitLab commit `0798d32a17247c827d47d28b254995bfa8012590`
- make `storage.approved_models_roots[0]` the single publication and discovery root for `/sure_approve` and `/sure_eval`
- reject command-level approval-root overrides and legacy review packets that target a different root
- update the public product README and site guidance for approval, Python runtimes, registry delivery, and current `/sure_trans` behavior

## Projection boundary

- the authoritative export contains 1,643 files with `source_dirty=false`
- GitLab-only CI, private site material, bundled policy, and internal agent-flow references remain excluded
- the GitHub-specific product README, terminal SVG assets, and README generator remain controlled public overrides
- the committed GitHub tree exports deterministically to 1,647 files with `source_dirty=false`

## Validation

- repository checks: 11/11 (Biome run in Debian because the host glibc is older than the pinned binary requires)
- site compatibility: passed, including 7 rule tests
- Python: 431 passed across eval, trans, onboard, approve, feed, and site
- coding-agent SURE tests: 390 passed, 2 skipped
- public export: two byte-identical exports; no private tree, bundled site policy, or GitLab CI
- public startup: fail-closed without site policy; configured site check, doctor, and offline help passed

Source: `sure/sure@0798d32a17247c827d47d28b254995bfa8012590`
