### PR TITLE
docs: add /sure_approve to the README terminal session

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ SURE Harness is an agent-based, system-level harness for reproducible model onbo
 
 SURE turns model deployment, environment adaptation, inference-code generation, and dataset evaluation into one auditable workflow. The resulting runtime identity, dependency locks, parameters, model binding, predictions, metric route, and reports remain available as structured evidence, so an experiment is easier to reproduce, compare, and trust than an undocumented sequence of shell commands.
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/harness-terminal-dark.svg">
+  <img src="docs/assets/harness-terminal.svg" alt="One SURE session in the interactive terminal: /sure_init, /sure_feed, /sure_onboard, /sure_approve, then /sure_eval ending in a persisted run report" width="100%">
+</picture>
+
+*One discover, onboard, approve, evaluate session, replayed as a self-contained SVG animation. Regenerate with `node scripts/generate-readme-terminal.mjs`.*
+
 ## Distribution
 
 This repository supports two distributions from one codebase:

--- a/docs/assets/harness-terminal-dark.svg
+++ b/docs/assets/harness-terminal-dark.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 402" role="img" aria-label="SURE harness terminal session"><title>SURE harness: one /sure_feed → /sure_onboard → /sure_approve → /sure_eval session in the interactive terminal</title><style>.t{font-family:ui-monospace,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12.5px;white-space:pre}
+.line{opacity:0}
+.fade{animation:fade 33.88s linear infinite}
+@keyframes fade{0%,97.344%{opacity:1}99.070%,100%{opacity:0}}
+.a0{animation:ka0 33.88s linear infinite}
+@keyframes ka0{0%,1.771%{opacity:0}1.800%,100%{opacity:1}}
+.c1{animation:kc1 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc1{0%,1.712%{opacity:0;transform:translateX(0)}1.771%{opacity:1;transform:translateX(0);animation-timing-function:steps(10)}2.774%{opacity:1;transform:translateX(76.0px)}3.512%,100%{opacity:0;transform:translateX(76.0px)}}
+.a2{animation:ka2 33.88s linear infinite}
+@keyframes ka2{0%,4.398%{opacity:0;transform:translateY(3px)}5.047%,100%{opacity:1;transform:translateY(0)}}
+.a3{animation:ka3 33.88s linear infinite}
+@keyframes ka3{0%,5.874%{opacity:0}5.903%,100%{opacity:1}}
+.c4{animation:kc4 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc4{0%,5.815%{opacity:0;transform:translateX(0)}5.874%{opacity:1;transform:translateX(0);animation-timing-function:steps(56)}11.494%{opacity:1;transform:translateX(425.6px)}12.231%,100%{opacity:0;transform:translateX(425.6px)}}
+.a5{animation:ka5 33.88s linear infinite}
+@keyframes ka5{0%,13.117%{opacity:0;transform:translateY(3px)}13.766%{opacity:1;transform:translateY(0)}18.135%{opacity:1}18.489%,100%{opacity:0}}
+.a6{animation:ka6 33.88s linear infinite}
+@keyframes ka6{0%,18.135%{opacity:0;transform:translateY(3px)}18.784%,100%{opacity:1;transform:translateY(0)}}
+.a7{animation:ka7 33.88s linear infinite}
+@keyframes ka7{0%,19.610%{opacity:0;transform:translateY(3px)}20.260%,100%{opacity:1;transform:translateY(0)}}
+.a8{animation:ka8 33.88s linear infinite}
+@keyframes ka8{0%,21.086%{opacity:0}21.116%,100%{opacity:1}}
+.c9{animation:kc9 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc9{0%,21.027%{opacity:0;transform:translateX(0)}21.086%{opacity:1;transform:translateX(0);animation-timing-function:steps(68)}27.910%{opacity:1;transform:translateX(516.8px)}28.648%,100%{opacity:0;transform:translateX(516.8px)}}
+.a10{animation:ka10 33.88s linear infinite}
+@keyframes ka10{0%,29.534%{opacity:0;transform:translateY(3px)}30.183%{opacity:1;transform:translateY(0)}35.142%{opacity:1}35.496%,100%{opacity:0}}
+.a11{animation:ka11 33.88s linear infinite}
+@keyframes ka11{0%,35.142%{opacity:0;transform:translateY(3px)}35.791%,100%{opacity:1;transform:translateY(0)}}
+.a12{animation:ka12 33.88s linear infinite}
+@keyframes ka12{0%,36.617%{opacity:0}36.647%,100%{opacity:1}}
+.c13{animation:kc13 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc13{0%,36.558%{opacity:0;transform:translateX(0)}36.617%{opacity:1;transform:translateX(0);animation-timing-function:steps(60)}42.639%{opacity:1;transform:translateX(456.0px)}43.377%,100%{opacity:0;transform:translateX(456.0px)}}
+.a14{animation:ka14 33.88s linear infinite}
+@keyframes ka14{0%,44.262%{opacity:0;transform:translateY(3px)}44.911%{opacity:1;transform:translateY(0)}49.575%{opacity:1}49.929%,100%{opacity:0}}
+.a15{animation:ka15 33.88s linear infinite}
+@keyframes ka15{0%,49.575%{opacity:0;transform:translateY(3px)}50.224%,100%{opacity:1;transform:translateY(0)}}
+.a16{animation:ka16 33.88s linear infinite}
+@keyframes ka16{0%,51.051%{opacity:0}51.080%,100%{opacity:1}}
+.c17{animation:kc17 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc17{0%,50.992%{opacity:0;transform:translateX(0)}51.051%{opacity:1;transform:translateX(0);animation-timing-function:steps(78)}58.878%{opacity:1;transform:translateX(592.8px)}59.616%,100%{opacity:0;transform:translateX(592.8px)}}
+.a18{animation:ka18 33.88s linear infinite}
+@keyframes ka18{0%,60.502%{opacity:0;transform:translateY(3px)}61.151%,100%{opacity:1;transform:translateY(0)}}
+.a19{animation:ka19 33.88s linear infinite}
+@keyframes ka19{0%,61.978%{opacity:0}62.007%,100%{opacity:1}}
+.c20{animation:kc20 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc20{0%,61.919%{opacity:0;transform:translateX(0)}61.978%{opacity:1;transform:translateX(0);animation-timing-function:steps(98)}71.812%{opacity:1;transform:translateX(744.8px)}72.550%,100%{opacity:0;transform:translateX(744.8px)}}
+.a21{animation:ka21 33.88s linear infinite}
+@keyframes ka21{0%,73.436%{opacity:0;transform:translateY(3px)}74.085%,100%{opacity:1;transform:translateY(0)}}
+.a22{animation:ka22 33.88s linear infinite}
+@keyframes ka22{0%,74.911%{opacity:0;transform:translateY(3px)}75.561%{opacity:1;transform:translateY(0)}81.110%{opacity:1}81.464%,100%{opacity:0}}
+.a23{animation:ka23 33.88s linear infinite}
+@keyframes ka23{0%,81.110%{opacity:0;transform:translateY(3px)}81.759%,100%{opacity:1;transform:translateY(0)}}
+.a24{animation:ka24 33.88s linear infinite}
+@keyframes ka24{0%,82.586%{opacity:0}82.615%,100%{opacity:1}}
+.b25{animation:blink 1.06s linear infinite}
+@keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+@media (prefers-reduced-motion:reduce){
+*{animation:none!important}
+.line{opacity:1!important;transform:none!important}
+.st,.cover{opacity:0!important}
+}</style><rect x="1" y="1" width="858" height="400" rx="12" fill="#141716" stroke="#343b39" stroke-width="1.5"/><path d="M 1 40 H 859" stroke="#343b39" stroke-width="1"/><circle cx="26" cy="20" r="5.2" fill="#e8615a"/><circle cx="44" cy="20" r="5.2" fill="#f5bd4f"/><circle cx="62" cy="20" r="5.2" fill="#61c454"/><text class="t" x="384.4" y="24.5" textLength="91.2" fill="#7d7b73">sure-harness</text><g class="fade"><g class="line a0"><text class="t " x="26.0" y="69.5" textLength="15.2" fill="#8abeb7">› </text><text class="t " x="41.2" y="69.5" textLength="76.0" font-weight="600" fill="#8abeb7">/sure_init</text></g><g class="cover c1"><rect x="41.2" y="57.0" width="80.0" height="18.8" fill="#141716"/><rect x="41.2" y="58.0" width="7.6" height="16.3" fill="#8abeb7"/></g><g class="line a2"><text class="t " x="26.0" y="91.5" textLength="15.2" fill="#7fd1a7">✓ </text><text class="t " x="41.2" y="91.5" textLength="524.4" fill="#7fd1a7">provider linked · auth ok · skills discovered · backend checks passed</text></g><g class="line a3"><text class="t " x="26.0" y="113.5" textLength="15.2" fill="#8abeb7">› </text><text class="t " x="41.2" y="113.5" textLength="76.0" font-weight="600" fill="#8abeb7">/sure_feed</text><text class="t " x="117.2" y="113.5" textLength="349.6" fill="#b5b3a7"> https://huggingface.co/Qwen/Qwen3-ASR-0.6B-hf</text></g><g class="cover c4"><rect x="41.2" y="101.0" width="429.6" height="18.8" fill="#141716"/><rect x="41.2" y="102.0" width="7.6" height="16.3" fill="#8abeb7"/></g><g class="line st a5"><text class="t " x="26.0" y="135.5" textLength="471.2" fill="#6d6b64">⠋ researching model card · resolving runtime and I/O contract…</text></g><g class="line a6"><text class="t " x="41.2" y="135.5" textLength="357.2" fill="#b5b3a7">task=ASR · runtime=transformers · io=audio→text</text></g><g class="line a7"><text class="t " x="26.0" y="157.5" textLength="15.2" fill="#7fd1a7">✓ </text><text class="t " x="41.2" y="157.5" textLength="266.0" fill="#7fd1a7">model_input.yaml · feed_report.json</text></g><g class="line a8"><text class="t " x="26.0" y="179.5" textLength="15.2" fill="#8abeb7">› </text><text class="t " x="41.2" y="179.5" textLength="98.8" font-weight="600" fill="#8abeb7">/sure_onboard</text><text class="t " x="140.0" y="179.5" textLength="418.0" fill="#b5b3a7"> model=Qwen__Qwen3-ASR-0.6B-hf device=auto package=none</text></g><g class="cover c9"><rect x="41.2" y="167.0" width="520.8" height="18.8" fill="#141716"/><rect x="41.2" y="168.0" width="7.6" height="16.3" fill="#8abeb7"/></g><g class="line st a10"><text class="t " x="26.0" y="201.5" textLength="532.0" fill="#6d6b64">⠋ wrapper synthesis · environment plan · fixture smoke · package gate…</text></g><g class="line a11"><text class="t " x="26.0" y="201.5" textLength="15.2" fill="#7fd1a7">✓ </text><text class="t " x="41.2" y="201.5" textLength="402.8" fill="#7fd1a7">verdict.json · image digest pinned · deployment ready</text></g><g class="line a12"><text class="t " x="26.0" y="223.5" textLength="15.2" fill="#8abeb7">› </text><text class="t " x="41.2" y="223.5" textLength="98.8" font-weight="600" fill="#8abeb7">/sure_approve</text><text class="t " x="140.0" y="223.5" textLength="357.2" fill="#b5b3a7"> model_dir=sure/results/Qwen__Qwen3-ASR-0.6B-hf</text></g><g class="cover c13"><rect x="41.2" y="211.0" width="460.0" height="18.8" fill="#141716"/><rect x="41.2" y="212.0" width="7.6" height="16.3" fill="#8abeb7"/></g><g class="line st a14"><text class="t " x="26.0" y="245.5" textLength="509.2" fill="#6d6b64">⠋ audit: producer contract · selected runtime · isolated candidate…</text></g><g class="line a15"><text class="t " x="26.0" y="245.5" textLength="15.2" fill="#7fd1a7">✓ </text><text class="t " x="41.2" y="245.5" textLength="288.8" fill="#7fd1a7">review_packet.json · awaiting_approval</text></g><g class="line a16"><text class="t " x="26.0" y="267.5" textLength="15.2" fill="#8abeb7">› </text><text class="t " x="41.2" y="267.5" textLength="98.8" font-weight="600" fill="#8abeb7">/sure_approve</text><text class="t " x="140.0" y="267.5" textLength="494.0" fill="#b5b3a7"> mode=approve review_manifest=review_packet.json decision=approve</text></g><g class="cover c17"><rect x="41.2" y="255.0" width="596.8" height="18.8" fill="#141716"/><rect x="41.2" y="256.0" width="7.6" height="16.3" fill="#8abeb7"/></g><g class="line a18"><text class="t " x="26.0" y="289.5" textLength="15.2" fill="#7fd1a7">✓ </text><text class="t " x="41.2" y="289.5" textLength="448.4" fill="#7fd1a7">decision bound · published atomically · approval_ready.json</text></g><g class="line a19"><text class="t " x="26.0" y="311.5" textLength="15.2" fill="#8abeb7">› </text><text class="t " x="41.2" y="311.5" textLength="76.0" font-weight="600" fill="#8abeb7">/sure_eval</text><text class="t " x="117.2" y="311.5" textLength="668.8" fill="#b5b3a7"> model=Qwen__Qwen3-ASR-0.6B-hf datasets=aishell1 metrics=cer execution=local device=auto</text></g><g class="cover c20"><rect x="41.2" y="299.0" width="748.8" height="18.8" fill="#141716"/><rect x="41.2" y="300.0" width="7.6" height="16.3" fill="#8abeb7"/></g><g class="line a21"><text class="t " x="41.2" y="333.5" textLength="577.6" fill="#b5b3a7">route asr.zh.cer.aispeech_norm_zh_v1.wenet_cer_v1 · protocol standard_system</text></g><g class="line st a22"><text class="t " x="26.0" y="355.5" textLength="456.0" fill="#6d6b64">⠋ inference 1/1 · deterministic evaluation pipeline running…</text></g><g class="line a23"><text class="t " x="26.0" y="355.5" textLength="15.2" fill="#7fd1a7">✓ </text><text class="t " x="41.2" y="355.5" textLength="744.8" fill="#7fd1a7">run_report · main_agent_run_report.json · report_persisted=true · execution_path_actual=local_bash</text></g><g class="line a24"><text class="t " x="26.0" y="377.5" textLength="15.2" fill="#8abeb7">› </text><g class="b25"><rect x="41.2" y="366.0" width="7.6" height="16.3" fill="#8abeb7"/></g></g></g></svg>

--- a/docs/assets/harness-terminal.svg
+++ b/docs/assets/harness-terminal.svg
@@ -1,0 +1,61 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 402" role="img" aria-label="SURE harness terminal session"><title>SURE harness: one /sure_feed → /sure_onboard → /sure_approve → /sure_eval session in the interactive terminal</title><style>.t{font-family:ui-monospace,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:12.5px;white-space:pre}
+.line{opacity:0}
+.fade{animation:fade 33.88s linear infinite}
+@keyframes fade{0%,97.344%{opacity:1}99.070%,100%{opacity:0}}
+.a0{animation:ka0 33.88s linear infinite}
+@keyframes ka0{0%,1.771%{opacity:0}1.800%,100%{opacity:1}}
+.c1{animation:kc1 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc1{0%,1.712%{opacity:0;transform:translateX(0)}1.771%{opacity:1;transform:translateX(0);animation-timing-function:steps(10)}2.774%{opacity:1;transform:translateX(76.0px)}3.512%,100%{opacity:0;transform:translateX(76.0px)}}
+.a2{animation:ka2 33.88s linear infinite}
+@keyframes ka2{0%,4.398%{opacity:0;transform:translateY(3px)}5.047%,100%{opacity:1;transform:translateY(0)}}
+.a3{animation:ka3 33.88s linear infinite}
+@keyframes ka3{0%,5.874%{opacity:0}5.903%,100%{opacity:1}}
+.c4{animation:kc4 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc4{0%,5.815%{opacity:0;transform:translateX(0)}5.874%{opacity:1;transform:translateX(0);animation-timing-function:steps(56)}11.494%{opacity:1;transform:translateX(425.6px)}12.231%,100%{opacity:0;transform:translateX(425.6px)}}
+.a5{animation:ka5 33.88s linear infinite}
+@keyframes ka5{0%,13.117%{opacity:0;transform:translateY(3px)}13.766%{opacity:1;transform:translateY(0)}18.135%{opacity:1}18.489%,100%{opacity:0}}
+.a6{animation:ka6 33.88s linear infinite}
+@keyframes ka6{0%,18.135%{opacity:0;transform:translateY(3px)}18.784%,100%{opacity:1;transform:translateY(0)}}
+.a7{animation:ka7 33.88s linear infinite}
+@keyframes ka7{0%,19.610%{opacity:0;transform:translateY(3px)}20.260%,100%{opacity:1;transform:translateY(0)}}
+.a8{animation:ka8 33.88s linear infinite}
+@keyframes ka8{0%,21.086%{opacity:0}21.116%,100%{opacity:1}}
+.c9{animation:kc9 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc9{0%,21.027%{opacity:0;transform:translateX(0)}21.086%{opacity:1;transform:translateX(0);animation-timing-function:steps(68)}27.910%{opacity:1;transform:translateX(516.8px)}28.648%,100%{opacity:0;transform:translateX(516.8px)}}
+.a10{animation:ka10 33.88s linear infinite}
+@keyframes ka10{0%,29.534%{opacity:0;transform:translateY(3px)}30.183%{opacity:1;transform:translateY(0)}35.142%{opacity:1}35.496%,100%{opacity:0}}
+.a11{animation:ka11 33.88s linear infinite}
+@keyframes ka11{0%,35.142%{opacity:0;transform:translateY(3px)}35.791%,100%{opacity:1;transform:translateY(0)}}
+.a12{animation:ka12 33.88s linear infinite}
+@keyframes ka12{0%,36.617%{opacity:0}36.647%,100%{opacity:1}}
+.c13{animation:kc13 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc13{0%,36.558%{opacity:0;transform:translateX(0)}36.617%{opacity:1;transform:translateX(0);animation-timing-function:steps(60)}42.639%{opacity:1;transform:translateX(456.0px)}43.377%,100%{opacity:0;transform:translateX(456.0px)}}
+.a14{animation:ka14 33.88s linear infinite}
+@keyframes ka14{0%,44.262%{opacity:0;transform:translateY(3px)}44.911%{opacity:1;transform:translateY(0)}49.575%{opacity:1}49.929%,100%{opacity:0}}
+.a15{animation:ka15 33.88s linear infinite}
+@keyframes ka15{0%,49.575%{opacity:0;transform:translateY(3px)}50.224%,100%{opacity:1;transform:translateY(0)}}
+.a16{animation:ka16 33.88s linear infinite}
+@keyframes ka16{0%,51.051%{opacity:0}51.080%,100%{opacity:1}}
+.c17{animation:kc17 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc17{0%,50.992%{opacity:0;transform:translateX(0)}51.051%{opacity:1;transform:translateX(0);animation-timing-function:steps(78)}58.878%{opacity:1;transform:translateX(592.8px)}59.616%,100%{opacity:0;transform:translateX(592.8px)}}
+.a18{animation:ka18 33.88s linear infinite}
+@keyframes ka18{0%,60.502%{opacity:0;transform:translateY(3px)}61.151%,100%{opacity:1;transform:translateY(0)}}
+.a19{animation:ka19 33.88s linear infinite}
+@keyframes ka19{0%,61.978%{opacity:0}62.007%,100%{opacity:1}}
+.c20{animation:kc20 33.88s linear infinite;transform:translateX(0)}
+@keyframes kc20{0%,61.919%{opacity:0;transform:translateX(0)}61.978%{opacity:1;transform:translateX(0);animation-timing-function:steps(98)}71.812%{opacity:1;transform:translateX(744.8px)}72.550%,100%{opacity:0;transform:translateX(744.8px)}}
+.a21{animation:ka21 33.88s linear infinite}
+@keyframes ka21{0%,73.436%{opacity:0;transform:translateY(3px)}74.085%,100%{opacity:1;transform:translateY(0)}}
+.a22{animation:ka22 33.88s linear infinite}
+@keyframes ka22{0%,74.911%{opacity:0;transform:translateY(3px)}75.561%{opacity:1;transform:translateY(0)}81.110%{opacity:1}81.464%,100%{opacity:0}}
+.a23{animation:ka23 33.88s linear infinite}
+@keyframes ka23{0%,81.110%{opacity:0;transform:translateY(3px)}81.759%,100%{opacity:1;transform:translateY(0)}}
+.a24{animation:ka24 33.88s linear infinite}
+@keyframes ka24{0%,82.586%{opacity:0}82.615%,100%{opacity:1}}
+.b25{animation:blink 1.06s linear infinite}
+@keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+@media (prefers-reduced-motion:reduce){
+*{animation:none!important}
+.line{opacity:1!important;transform:none!important}
+.st,.cover{opacity:0!important}
+}</style><rect x="1" y="1" width="858" height="400" rx="12" fill="#ffffff" stroke="#e0ded8" stroke-width="1.5"/><path d="M 1 40 H 859" stroke="#e0ded8" stroke-width="1"/><circle cx="26" cy="20" r="5.2" fill="#e8615a"/><circle cx="44" cy="20" r="5.2" fill="#f5bd4f"/><circle cx="62" cy="20" r="5.2" fill="#61c454"/><text class="t" x="384.4" y="24.5" textLength="91.2" fill="#8a8a86">sure-harness</text><g class="fade"><g class="line a0"><text class="t " x="26.0" y="69.5" textLength="15.2" fill="#1f6f66">› </text><text class="t " x="41.2" y="69.5" textLength="76.0" font-weight="600" fill="#1f6f66">/sure_init</text></g><g class="cover c1"><rect x="41.2" y="57.0" width="80.0" height="18.8" fill="#ffffff"/><rect x="41.2" y="58.0" width="7.6" height="16.3" fill="#1f6f66"/></g><g class="line a2"><text class="t " x="26.0" y="91.5" textLength="15.2" fill="#047857">✓ </text><text class="t " x="41.2" y="91.5" textLength="524.4" fill="#047857">provider linked · auth ok · skills discovered · backend checks passed</text></g><g class="line a3"><text class="t " x="26.0" y="113.5" textLength="15.2" fill="#1f6f66">› </text><text class="t " x="41.2" y="113.5" textLength="76.0" font-weight="600" fill="#1f6f66">/sure_feed</text><text class="t " x="117.2" y="113.5" textLength="349.6" fill="#52514e"> https://huggingface.co/Qwen/Qwen3-ASR-0.6B-hf</text></g><g class="cover c4"><rect x="41.2" y="101.0" width="429.6" height="18.8" fill="#ffffff"/><rect x="41.2" y="102.0" width="7.6" height="16.3" fill="#1f6f66"/></g><g class="line st a5"><text class="t " x="26.0" y="135.5" textLength="471.2" fill="#98968f">⠋ researching model card · resolving runtime and I/O contract…</text></g><g class="line a6"><text class="t " x="41.2" y="135.5" textLength="357.2" fill="#52514e">task=ASR · runtime=transformers · io=audio→text</text></g><g class="line a7"><text class="t " x="26.0" y="157.5" textLength="15.2" fill="#047857">✓ </text><text class="t " x="41.2" y="157.5" textLength="266.0" fill="#047857">model_input.yaml · feed_report.json</text></g><g class="line a8"><text class="t " x="26.0" y="179.5" textLength="15.2" fill="#1f6f66">› </text><text class="t " x="41.2" y="179.5" textLength="98.8" font-weight="600" fill="#1f6f66">/sure_onboard</text><text class="t " x="140.0" y="179.5" textLength="418.0" fill="#52514e"> model=Qwen__Qwen3-ASR-0.6B-hf device=auto package=none</text></g><g class="cover c9"><rect x="41.2" y="167.0" width="520.8" height="18.8" fill="#ffffff"/><rect x="41.2" y="168.0" width="7.6" height="16.3" fill="#1f6f66"/></g><g class="line st a10"><text class="t " x="26.0" y="201.5" textLength="532.0" fill="#98968f">⠋ wrapper synthesis · environment plan · fixture smoke · package gate…</text></g><g class="line a11"><text class="t " x="26.0" y="201.5" textLength="15.2" fill="#047857">✓ </text><text class="t " x="41.2" y="201.5" textLength="402.8" fill="#047857">verdict.json · image digest pinned · deployment ready</text></g><g class="line a12"><text class="t " x="26.0" y="223.5" textLength="15.2" fill="#1f6f66">› </text><text class="t " x="41.2" y="223.5" textLength="98.8" font-weight="600" fill="#1f6f66">/sure_approve</text><text class="t " x="140.0" y="223.5" textLength="357.2" fill="#52514e"> model_dir=sure/results/Qwen__Qwen3-ASR-0.6B-hf</text></g><g class="cover c13"><rect x="41.2" y="211.0" width="460.0" height="18.8" fill="#ffffff"/><rect x="41.2" y="212.0" width="7.6" height="16.3" fill="#1f6f66"/></g><g class="line st a14"><text class="t " x="26.0" y="245.5" textLength="509.2" fill="#98968f">⠋ audit: producer contract · selected runtime · isolated candidate…</text></g><g class="line a15"><text class="t " x="26.0" y="245.5" textLength="15.2" fill="#047857">✓ </text><text class="t " x="41.2" y="245.5" textLength="288.8" fill="#047857">review_packet.json · awaiting_approval</text></g><g class="line a16"><text class="t " x="26.0" y="267.5" textLength="15.2" fill="#1f6f66">› </text><text class="t " x="41.2" y="267.5" textLength="98.8" font-weight="600" fill="#1f6f66">/sure_approve</text><text class="t " x="140.0" y="267.5" textLength="494.0" fill="#52514e"> mode=approve review_manifest=review_packet.json decision=approve</text></g><g class="cover c17"><rect x="41.2" y="255.0" width="596.8" height="18.8" fill="#ffffff"/><rect x="41.2" y="256.0" width="7.6" height="16.3" fill="#1f6f66"/></g><g class="line a18"><text class="t " x="26.0" y="289.5" textLength="15.2" fill="#047857">✓ </text><text class="t " x="41.2" y="289.5" textLength="448.4" fill="#047857">decision bound · published atomically · approval_ready.json</text></g><g class="line a19"><text class="t " x="26.0" y="311.5" textLength="15.2" fill="#1f6f66">› </text><text class="t " x="41.2" y="311.5" textLength="76.0" font-weight="600" fill="#1f6f66">/sure_eval</text><text class="t " x="117.2" y="311.5" textLength="668.8" fill="#52514e"> model=Qwen__Qwen3-ASR-0.6B-hf datasets=aishell1 metrics=cer execution=local device=auto</text></g><g class="cover c20"><rect x="41.2" y="299.0" width="748.8" height="18.8" fill="#ffffff"/><rect x="41.2" y="300.0" width="7.6" height="16.3" fill="#1f6f66"/></g><g class="line a21"><text class="t " x="41.2" y="333.5" textLength="577.6" fill="#52514e">route asr.zh.cer.aispeech_norm_zh_v1.wenet_cer_v1 · protocol standard_system</text></g><g class="line st a22"><text class="t " x="26.0" y="355.5" textLength="456.0" fill="#98968f">⠋ inference 1/1 · deterministic evaluation pipeline running…</text></g><g class="line a23"><text class="t " x="26.0" y="355.5" textLength="15.2" fill="#047857">✓ </text><text class="t " x="41.2" y="355.5" textLength="744.8" fill="#047857">run_report · main_agent_run_report.json · report_persisted=true · execution_path_actual=local_bash</text></g><g class="line a24"><text class="t " x="26.0" y="377.5" textLength="15.2" fill="#1f6f66">› </text><g class="b25"><rect x="41.2" y="366.0" width="7.6" height="16.3" fill="#1f6f66"/></g></g></g></svg>

--- a/scripts/generate-readme-terminal.mjs
+++ b/scripts/generate-readme-terminal.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+// Generate the animated README terminal (docs/assets/harness-terminal*.svg).
+//
+// The SVG replays one canonical SURE session — /sure_init → /sure_feed →
+// /sure_onboard → /sure_approve → /sure_eval — as a self-contained CSS animation: commands
+// type in behind a block cursor, agent output slides in, transient status
+// lines resolve into results, and the loop restarts. No scripts, no fonts,
+// no network: everything is plain SVG + CSS, so GitHub renders it inside
+// <img>/<picture>. `prefers-reduced-motion` freezes the finished session.
+//
+// Deterministic: same input → byte-identical output. Rerun after changing
+// the scenario below. Layout math relies on textLength, so glyph metrics
+// are identical on every platform.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const outDir = join(repoRoot, "docs", "assets");
+
+// ---------------------------------------------------------------------------
+// Scenario. Kinds: cmd (typed), out (slides in), ok (result), status
+// (transient spinner line that is replaced, in place, by the next row).
+// ---------------------------------------------------------------------------
+const SCENARIO = [
+	{ kind: "cmd", cmd: "/sure_init", args: "" },
+	{ kind: "ok", text: "provider linked · auth ok · skills discovered · backend checks passed" },
+	{ kind: "cmd", cmd: "/sure_feed", args: " https://huggingface.co/Qwen/Qwen3-ASR-0.6B-hf" },
+	{ kind: "status", text: "researching model card · resolving runtime and I/O contract…", holdS: 1.7 },
+	{ kind: "out", text: "task=ASR · runtime=transformers · io=audio→text", replaces: true },
+	{ kind: "ok", text: "model_input.yaml · feed_report.json" },
+	{ kind: "cmd", cmd: "/sure_onboard", args: " model=Qwen__Qwen3-ASR-0.6B-hf device=auto package=none" },
+	{ kind: "status", text: "wrapper synthesis · environment plan · fixture smoke · package gate…", holdS: 1.9 },
+	{ kind: "ok", text: "verdict.json · image digest pinned · deployment ready", replaces: true },
+	{ kind: "cmd", cmd: "/sure_approve", args: " model_dir=sure/results/Qwen__Qwen3-ASR-0.6B-hf" },
+	{ kind: "status", text: "audit: producer contract · selected runtime · isolated candidate…", holdS: 1.8 },
+	{ kind: "ok", text: "review_packet.json · awaiting_approval", replaces: true },
+	{
+		kind: "cmd",
+		cmd: "/sure_approve",
+		args: " mode=approve review_manifest=review_packet.json decision=approve",
+	},
+	{ kind: "ok", text: "decision bound · published atomically · approval_ready.json" },
+	{
+		kind: "cmd",
+		cmd: "/sure_eval",
+		args: " model=Qwen__Qwen3-ASR-0.6B-hf datasets=aishell1 metrics=cer execution=local device=auto",
+	},
+	{ kind: "out", text: "route asr.zh.cer.aispeech_norm_zh_v1.wenet_cer_v1 · protocol standard_system" },
+	{ kind: "status", text: "inference 1/1 · deterministic evaluation pipeline running…", holdS: 2.1 },
+	{
+		kind: "ok",
+		text: "run_report · main_agent_run_report.json · report_persisted=true · execution_path_actual=local_bash",
+		replaces: true,
+	},
+	{ kind: "idle" },
+];
+
+// ---------------------------------------------------------------------------
+// Geometry, timing, palettes.
+// ---------------------------------------------------------------------------
+const CH = 7.6; // forced glyph advance via textLength
+const FONT = 12.5;
+const LINE_H = 22;
+const PAD_X = 26;
+const TITLE_H = 40;
+const PAD_TOP = 14;
+const PAD_BOTTOM = 18;
+const WIDTH = 860;
+const PROMPT = "› ";
+const SPINNER = "⠋ ";
+const OK_MARK = "✓ ";
+
+const TYPE_S_PER_CHAR = 0.034;
+const GAP_AFTER_CMD_S = 0.55;
+const GAP_AFTER_LINE_S = 0.5;
+const IDLE_TAIL_S = 5.0;
+const FADE_S = 0.9;
+
+const THEMES = {
+	light: {
+		bg: "#ffffff",
+		titlebar: "#f4f3f1",
+		border: "#e0ded8",
+		title: "#8a8a86",
+		ink: "#52514e",
+		accent: "#1f6f66",
+		ok: "#047857",
+		muted: "#98968f",
+		cursor: "#1f6f66",
+		dots: ["#e8615a", "#f5bd4f", "#61c454"],
+	},
+	dark: {
+		bg: "#141716",
+		titlebar: "#1d2120",
+		border: "#343b39",
+		title: "#7d7b73",
+		ink: "#b5b3a7",
+		accent: "#8abeb7",
+		ok: "#7fd1a7",
+		muted: "#6d6b64",
+		cursor: "#8abeb7",
+		dots: ["#e8615a", "#f5bd4f", "#61c454"],
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Build rows and the master timeline (seconds; converted to % of the loop).
+// ---------------------------------------------------------------------------
+const rows = [];
+let row = 0;
+let t = 0.6;
+for (const step of SCENARIO) {
+	if (step.kind === "cmd") {
+		const typed = step.cmd + step.args;
+		const typeS = typed.length * TYPE_S_PER_CHAR;
+		rows.push({ ...step, row, tIn: t, typeS });
+		t += typeS + GAP_AFTER_CMD_S;
+		row += 1;
+	} else if (step.kind === "status") {
+		// no row advance: the next step replaces this line in place
+		rows.push({ ...step, row, tIn: t, tOut: t + step.holdS });
+		t += step.holdS;
+	} else if (step.kind === "idle") {
+		rows.push({ ...step, row, tIn: t });
+		row += 1;
+	} else {
+		rows.push({ ...step, row, tIn: t });
+		t += GAP_AFTER_LINE_S;
+		row += 1;
+	}
+}
+const TOTAL_S = t + IDLE_TAIL_S + FADE_S;
+const HEIGHT = TITLE_H + PAD_TOP + row * LINE_H + PAD_BOTTOM;
+const pct = (s) => ((s / TOTAL_S) * 100).toFixed(3);
+
+const esc = (s) =>
+	String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const textEl = (x, y, str, fill, cls = "", weight = "") =>
+	`<text class="t ${cls}" x="${x.toFixed(1)}" y="${y.toFixed(1)}" textLength="${(str.length * CH).toFixed(1)}"` +
+	`${weight ? ` font-weight="${weight}"` : ""} fill="${fill}">${esc(str)}</text>`;
+
+function render(themeName) {
+	const c = THEMES[themeName];
+	const body = [];
+	const css = [];
+	const rowY = (r) => TITLE_H + PAD_TOP + r * LINE_H + LINE_H / 2 + FONT * 0.36;
+
+	css.push(
+		`.t{font-family:ui-monospace,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;font-size:${FONT}px;white-space:pre}`,
+		`.line{opacity:0}`,
+		`.fade{animation:fade ${TOTAL_S.toFixed(2)}s linear infinite}`,
+		`@keyframes fade{0%,${pct(TOTAL_S - FADE_S)}%{opacity:1}${pct(TOTAL_S - FADE_S * 0.35)}%,100%{opacity:0}}`,
+	);
+
+	let anim = 0;
+	for (const r of rows) {
+		const y = rowY(r.row);
+		const id = `a${anim++}`;
+		if (r.kind === "cmd") {
+			const typed = r.cmd + r.args;
+			const x0 = PAD_X;
+			const promptW = PROMPT.length * CH;
+			const typedW = typed.length * CH;
+			body.push(`<g class="line ${id}">`);
+			body.push(textEl(x0, y, PROMPT, c.accent));
+			body.push(textEl(x0 + promptW, y, r.cmd, c.accent, "", "600"));
+			if (r.args) {
+				body.push(textEl(x0 + promptW + r.cmd.length * CH, y, r.args, c.ink));
+			}
+			body.push(`</g>`);
+			css.push(
+				`.${id}{animation:k${id} ${TOTAL_S.toFixed(2)}s linear infinite}`,
+				`@keyframes k${id}{0%,${pct(r.tIn)}%{opacity:0}${pct(r.tIn + 0.01)}%,100%{opacity:1}}`,
+			);
+			// cover slides right in character steps, cursor riding its left edge
+			const cid = `c${anim++}`;
+			const coverX = x0 + promptW;
+			body.push(
+				`<g class="cover ${cid}">` +
+					`<rect x="${coverX.toFixed(1)}" y="${(y - FONT).toFixed(1)}" width="${(typedW + 4).toFixed(1)}" height="${(FONT * 1.5).toFixed(1)}" fill="${c.bg}"/>` +
+					`<rect x="${coverX.toFixed(1)}" y="${(y - FONT + 1).toFixed(1)}" width="${CH.toFixed(1)}" height="${(FONT * 1.3).toFixed(1)}" fill="${c.cursor}"/>` +
+					`</g>`,
+			);
+			css.push(
+				`.${cid}{animation:k${cid} ${TOTAL_S.toFixed(2)}s linear infinite;transform:translateX(0)}`,
+				`@keyframes k${cid}{0%,${pct(Math.max(0, r.tIn - 0.02))}%{opacity:0;transform:translateX(0)}` +
+					`${pct(r.tIn)}%{opacity:1;transform:translateX(0);animation-timing-function:steps(${typed.length})}` +
+					`${pct(r.tIn + r.typeS)}%{opacity:1;transform:translateX(${typedW.toFixed(1)}px)}` +
+					`${pct(r.tIn + r.typeS + 0.25)}%,100%{opacity:0;transform:translateX(${typedW.toFixed(1)}px)}}`,
+			);
+		} else if (r.kind === "status") {
+			body.push(`<g class="line st ${id}">`);
+			body.push(textEl(PAD_X, y, SPINNER + r.text, c.muted));
+			body.push(`</g>`);
+			css.push(
+				`.${id}{animation:k${id} ${TOTAL_S.toFixed(2)}s linear infinite}`,
+				`@keyframes k${id}{0%,${pct(r.tIn)}%{opacity:0;transform:translateY(3px)}` +
+					`${pct(r.tIn + 0.22)}%{opacity:1;transform:translateY(0)}` +
+					`${pct(r.tOut)}%{opacity:1}${pct(r.tOut + 0.12)}%,100%{opacity:0}}`,
+			);
+		} else if (r.kind === "idle") {
+			const bid = `b${anim++}`;
+			body.push(
+				`<g class="line ${id}">` +
+					textEl(PAD_X, y, PROMPT, c.accent) +
+					`<g class="${bid}"><rect x="${(PAD_X + PROMPT.length * CH).toFixed(1)}" y="${(y - FONT + 1).toFixed(1)}" width="${CH.toFixed(1)}" height="${(FONT * 1.3).toFixed(1)}" fill="${c.cursor}"/></g>` +
+					`</g>`,
+			);
+			css.push(
+				`.${id}{animation:k${id} ${TOTAL_S.toFixed(2)}s linear infinite}`,
+				`@keyframes k${id}{0%,${pct(r.tIn)}%{opacity:0}${pct(r.tIn + 0.01)}%,100%{opacity:1}}`,
+				`.${bid}{animation:blink 1.06s linear infinite}`,
+			);
+		} else {
+			const fill = r.kind === "ok" ? c.ok : c.ink;
+			body.push(`<g class="line ${id}">`);
+			if (r.kind === "ok") {
+				body.push(textEl(PAD_X, y, OK_MARK, c.ok));
+			}
+			body.push(textEl(PAD_X + OK_MARK.length * CH, y, r.text, fill));
+			body.push(`</g>`);
+			css.push(
+				`.${id}{animation:k${id} ${TOTAL_S.toFixed(2)}s linear infinite}`,
+				`@keyframes k${id}{0%,${pct(r.tIn)}%{opacity:0;transform:translateY(3px)}` +
+					`${pct(r.tIn + 0.22)}%,100%{opacity:1;transform:translateY(0)}}`,
+			);
+		}
+	}
+
+	css.push(
+		`@keyframes blink{0%,49%{opacity:1}50%,100%{opacity:0}}`,
+		`@media (prefers-reduced-motion:reduce){`,
+		`*{animation:none!important}`,
+		`.line{opacity:1!important;transform:none!important}`,
+		`.st,.cover{opacity:0!important}`,
+		`}`,
+	);
+
+	const dots = c.dots
+		.map((d, i) => `<circle cx="${PAD_X + i * 18}" cy="${TITLE_H / 2}" r="5.2" fill="${d}"/>`)
+		.join("");
+	const title = "sure-harness";
+	return (
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${WIDTH} ${HEIGHT}" role="img" aria-label="SURE harness terminal session">` +
+		`<title>SURE harness: one /sure_feed → /sure_onboard → /sure_approve → /sure_eval session in the interactive terminal</title>` +
+		`<style>${css.join("\n")}</style>` +
+		`<rect x="1" y="1" width="${WIDTH - 2}" height="${HEIGHT - 2}" rx="12" fill="${c.bg}" stroke="${c.border}" stroke-width="1.5"/>` +
+		`<path d="M 1 ${TITLE_H} H ${WIDTH - 1}" stroke="${c.border}" stroke-width="1"/>` +
+		dots +
+		`<text class="t" x="${WIDTH / 2 - (title.length * CH) / 2}" y="${TITLE_H / 2 + FONT * 0.36}" textLength="${(title.length * CH).toFixed(1)}" fill="${c.title}">${title}</text>` +
+		`<g class="fade">${body.join("")}</g>` +
+		`</svg>\n`
+	);
+}
+
+mkdirSync(outDir, { recursive: true });
+const outputs = {
+	"harness-terminal.svg": render("light"),
+	"harness-terminal-dark.svg": render("dark"),
+};
+for (const [name, content] of Object.entries(outputs)) {
+	writeFileSync(join(outDir, name), content);
+	console.log(`wrote docs/assets/${name} (${content.length} bytes, loop ${TOTAL_S.toFixed(1)}s, ${row} rows)`);
+}


### PR DESCRIPTION
Updates the README terminal animation for the new `/sure_approve` workflow.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/xhh678876/sure/refs/heads/docs/terminal-approve/docs/assets/harness-terminal-dark.svg">
  <img src="https://raw.githubusercontent.com/xhh678876/sure/refs/heads/docs/terminal-approve/docs/assets/harness-terminal.svg" alt="Animated SURE terminal session with /sure_approve" width="100%">
</picture>

The session now shows both approval phases between onboard and eval, matching the `sure/skills/sure_approve` contract:

1. `/sure_approve model_dir=...` — audit status line resolves in place into `review_packet.json · awaiting_approval`.
2. `/sure_approve mode=approve review_manifest=review_packet.json decision=approve` — the explicit human decision, ending in `decision bound · published atomically · approval_ready.json`.

Loop grows from 25.3s / 11 rows to 33.9s / 15 rows. README alt text and caption updated to the discover, onboard, approve, evaluate flow. Regenerated with `node scripts/generate-readme-terminal.mjs`; output remains deterministic (two runs byte-identical). Verified light and dark frames at the audit, decision, and settled end states in headless Chromium.

Docs only; no changes under `packages/`, `sure/`, or `config/`.
