### PR TITLE
chore(public): sync GitLab projection through e9950a7

### DIFF
--- a/scripts/export-public.mjs
+++ b/scripts/export-public.mjs
@@ -130,6 +130,13 @@ const forbiddenContent = [...base.forbiddenContent, ...overlay.forbiddenContent]
 	pattern,
 	new RegExp(pattern, "i"),
 ]);
+// The deny rules that matter live in the overlay, inside the excluded tree,
+// so a repository that has something to exclude is exactly the one that
+// cannot run without them. A projection that already contains no private
+// paths (the public copy itself) has nothing to arm and is left alone.
+if (forbiddenContent.length === 0 && indexed.some((entry) => excluded.some((expression) => expression.test(entry.path)))) {
+	fail(`public export excludes private paths but has no forbidden_content rules; add ${overlayPath}`);
+}
 
 const manifestFiles = [];
 const exportEntries = [];

--- a/scripts/export-public.test.mjs
+++ b/scripts/export-public.test.mjs
@@ -152,3 +152,33 @@ test("private overlay blocks restricted public content", () => {
 		rmSync(temporaryRoot, { recursive: true, force: true });
 	}
 });
+
+test("a repository that excludes private paths must carry deny rules", () => {
+	// The overlay is the only place the private deny rules live, and it sits
+	// inside the excluded tree. A missing or renamed overlay must stop the
+	// export, not quietly turn the content scan off.
+	const temporaryRoot = mkdtempSync(resolve(tmpdir(), "sure-public-export-unarmed-test-"));
+	const sourceRoot = resolve(temporaryRoot, "source");
+	mkdirSync(sourceRoot);
+	try {
+		repository(sourceRoot, {
+			"public-export.yaml": [
+				"version: 1",
+				"exclude:",
+				"  - private/site/**",
+				"forbidden_content: []",
+				"forbidden_paths: []",
+				"",
+			].join("\n"),
+			"private/site/secret.txt": "restricted-site-value\n",
+			"visible.txt": "public\n",
+		});
+		const output = resolve(temporaryRoot, "tree");
+		const exported = run("node", [exporter, "--output", output], sourceRoot);
+		assert.notEqual(exported.status, 0);
+		assert.match(exported.stderr, /no forbidden_content rules/);
+		assert.equal(existsSync(output), false);
+	} finally {
+		rmSync(temporaryRoot, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
Two files differ from the branch head after the boundary rework (aacc6fec) was ported upstream and came back with one addition: a repository that excludes private paths but ends up with no `forbidden_content` refuses to export, instead of silently running with the content scan switched off. The new rule has a test in `scripts/export-public.test.mjs`.

Everything else from aacc6fec is now identical on both sides. Still carried here and not yet upstream: 87c3445c and 5980a7a4.