### PR TITLE
chore(public): sync GitLab projection through c1a4f88

### DIFF
--- a/config/site.example.yaml
+++ b/config/site.example.yaml
@@ -27,4 +27,4 @@ network:
   container_registry: registry.example.com
 
 container_delivery:
-  repository_template: "{registry}/example-org/sure-{task}-{model_name}"
+  repository_template: "{registry}/my-org/sure-{task}-{model_name}"

--- a/docs/site-configuration.md
+++ b/docs/site-configuration.md
@@ -61,7 +61,7 @@ Policy v1 accepts exactly one path in each storage root list. The `datasets.allo
 
 `storage.approved_models_roots[0]` is the single approval-root setting. `/sure_approve` publishes a verified model package only to `<approved_models_roots[0]>/<model>`, and `/sure_eval model=<model>` resolves that exact child directory from the same root. Neither command accepts a per-run approval-root override, so a deployment configures this location once rather than keeping publication and discovery settings in sync manually.
 
-`execution.surfaces` constrains automatic and explicit execution selection. When `vc` is enabled, `execution.vc_project` is required and `execution.vc_partitions` is the configured preflight allowlist. A requested partition outside that list is rejected before submission. The backend remains authoritative for project validity, user authorization, capacity, and other admission policy through the result of `vc submit`; the preflight does not infer those decisions from `vc info -u`.
+`execution.surfaces` constrains automatic and explicit execution selection. When `vc` is enabled, `execution.vc_project` is required and carries the submission project the VC backend expects. `execution.vc_partitions` documents site choices but does not replace the existing live `vc info -u` authorization check; changing partition authorization semantics is outside this separation phase.
 
 `execution.local_runtimes` is a permission boundary, not a package-manager choice. Enabling `python` permits an explicitly sealed Model Python runtime; it does not make host execution the default and does not permit Python execution on VC.
 
@@ -109,12 +109,10 @@ network:
   container_registry: registry.example.com
 
 container_delivery:
-  repository_template: "{registry}/example-org/sure-{task}-{model_name}"
+  repository_template: "{registry}/my-org/sure-{task}-{model_name}"
 ```
 
 For shared storage, replace these placeholders with roots visible to every host and container that executes a workflow. The projection root is the only writable dataset workspace; source roots are mounted read-only. For a local-only fixture, create temporary model, result, dataset, projection, and runtime roots and point the local policy at them.
-
-`container_delivery.repository_template` is site data, not an agent decision. Registry-backed workflows resolve it before downloading model weights or building an image. The template must start with `{registry}/`, must include `{model_name}`, and may include `{task}`. `/sure_onboard` uses the resolved repository as its delivery target; `/sure_trans` uses the same target and appends `-source` for its source-image repository.
 
 A VC-enabled deployment adds its backend project and partition allowlist:
 
@@ -128,6 +126,8 @@ execution:
     - gpu-example
   vc_default_partition: gpu-example
 ```
+
+`container_delivery.repository_template` is site data, not an agent decision. Registry-backed workflows resolve it before downloading model weights or building an image. The template must start with `{registry}/`, must include `{model_name}`, and may include `{task}`. `/sure_onboard` uses the resolved repository as its delivery target; `/sure_trans` uses the same target and appends `-source` for its source-image repository.
 
 When `image_version` is omitted, the workflow queries the relevant Registry V2 tag lists, considers only `major.minor.patch` tags, and selects the next patch after the highest existing version; an empty repository starts at `0.1.0`. A query failure blocks instead of guessing a tag. The resolved repositories, version, observed tags, and site-policy identity are recorded in `model_input_resolved.json` or `trans_input_resolved.json`; credentials remain in the Docker credential store and never enter either artifact or the policy.
 

--- a/fixtures/tasks/asr/README.md
+++ b/fixtures/tasks/asr/README.md
@@ -38,6 +38,8 @@ Provenance: qwen3_asr_smoke/asr-ar/provenance.json
 
 | Source | Language | Files | Notes |
 |--------|----------|-------|-------|
+| `src/sure_eval/models/GilgameshWind__X-ASR-zh-en/fixture/asr/asr_zh/` | zh | `sample_*.wav`, `gt.jsonl` | Same structure as Qwen3 ASR Chinese fixture. |
+| `src/sure_eval/models/GilgameshWind__X-ASR-zh-en/fixture/asr/asr_en/` | en | `sample_*.wav`, `gt.jsonl` | Same structure as Qwen3 ASR English fixture. |
 | `src/sure_eval/models/asr_parakeet/fixture/asr/asr_en/` | en | `sample_*.wav`, `gt.jsonl` | English ASR fixture. |
 
 ## Expected Model-Local Layout

--- a/packages/coding-agent/test/suite/sure-feed.test.ts
+++ b/packages/coding-agent/test/suite/sure-feed.test.ts
@@ -426,10 +426,10 @@ describe("sure_feed gate scripts (real python3 spawnSync)", () => {
 	it("check_model_input accepts policy-resolved entrypoints only with runtime_strategy", () => {
 		const runDir = freshRunDir("model-input-runtime-strategy");
 		const envelope = modelInputEnvelope(
-			"example-org/streaming-asr-onnx",
+			"GilgameshWind/X-ASR-zh-en",
 			"huggingface",
 			"huggingface",
-			"https://huggingface.co/example-org/streaming-asr-onnx",
+			"https://huggingface.co/GilgameshWind/X-ASR-zh-en",
 		);
 		const modelInput = envelope.model_input as Record<string, unknown>;
 		modelInput.entrypoints = {

--- a/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
@@ -172,6 +172,9 @@ function seedLocalReadyArtifacts(runDir: string): string {
 
 	const manifest = {
 		model_dir: modelDir,
+		// The gates order package_gate.json, runtime_inventory.json and verdict.json
+		// after this manifest, so every fixture stamp below counts up from here.
+		generated_at: "2026-01-01T00:00:01+00:00",
 		artifacts: {
 			required: {
 				spec: { path: "model.spec.yaml" },
@@ -1178,6 +1181,7 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 
 		const manifest = {
 			model_dir: modelDir,
+			generated_at: "2026-01-01T00:00:01+00:00",
 			instance_id: "rednote-hilab__dots.tts-base-replay",
 			model_id: resolved.model_id,
 			model_name: resolved.model_name,
@@ -1215,6 +1219,9 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 
 		writeArtifact(runDir, "package_gate.json", {
 			schema: "sure.onboard.package_gate.v2",
+			// Later than the manifest above; write_runtime_inventory.py then stamps the
+			// inventory after this gate, so this one has to stay in the past.
+			generated_at: "2026-01-01T00:00:02+00:00",
 			status: "passed",
 			package_profile: "none",
 			model_dir: modelDir,
@@ -1256,10 +1263,14 @@ describe("sure_onboard end-to-end state-machine replay", () => {
 			{ cwd, encoding: "utf-8", env: { ...process.env, SURE_SITE_POLICY: sitePolicy } },
 		);
 		expect(inventory.status, inventory.stderr || inventory.stdout).toBe(0);
+		const inventoryDoc = JSON.parse(readFileSync(join(runDir, "artifacts", "runtime_inventory.json"), "utf-8"));
 		advance("verdict");
 
 		writeArtifact(runDir, "verdict.json", {
 			status: "passed",
+			// The inventory was stamped by the writer script just now, so the verdict has
+			// to be dated from it rather than from a fixed fixture stamp in the past.
+			timestamp: new Date(Date.parse(inventoryDoc.generated_at) + 1_000).toISOString(),
 			model_id: resolved.model_id,
 			model_name: resolved.model_name,
 			package: { profile: "none" },
@@ -2628,6 +2639,7 @@ describe("sure_onboard new alignment gates", () => {
 		});
 		writeArtifact(runDir, "package_gate.json", {
 			schema: "sure.onboard.package_gate.v2",
+			generated_at: "2026-01-01T00:00:02+00:00",
 			status: "passed",
 			package_profile: "none",
 			model_dir: modelDir,
@@ -2829,6 +2841,26 @@ describe("sure_onboard artifact manifest structure compatibility", () => {
 		expect(existsSync(join(targetDir, ".venv"))).toBe(false);
 		expect(existsSync(join(targetDir, "artifacts", "package_gate.json"))).toBe(true);
 
+		// The adoption stamps its manifest and its verdict from the wall clock but leaves
+		// the package gate unstamped, and it writes no runtime inventory at all. Pin the
+		// first two documents into the past and stage the inventory the verdict gate reads,
+		// so the gates below judge the adoption itself and not the missing stamps.
+		const adoptedArtifacts = join(targetDir, "artifacts");
+		const adoptedManifestPath = join(adoptedArtifacts, "artifact_manifest.json");
+		const adoptedGatePath = join(adoptedArtifacts, "package_gate.json");
+		writeJson(adoptedManifestPath, {
+			...JSON.parse(readFileSync(adoptedManifestPath, "utf-8")),
+			timestamp: "2026-01-01T00:00:01+00:00",
+		});
+		writeJson(adoptedGatePath, {
+			...JSON.parse(readFileSync(adoptedGatePath, "utf-8")),
+			generated_at: "2026-01-01T00:00:02+00:00",
+		});
+		writeJson(join(adoptedArtifacts, "runtime_inventory.json"), {
+			schema: "sure.onboard.runtime_inventory.v2",
+			generated_at: "2026-01-01T00:00:03+00:00",
+		});
+
 		for (const [script, artifact] of [
 			["check_artifact_manifest.py", "artifact_manifest.json"],
 			["check_verdict.py", "verdict.json"],
@@ -3025,6 +3057,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		});
 		writeArtifact(runDir, "package_gate.json", {
 			schema: "sure.onboard.package_gate.v2",
+			generated_at: "2026-01-01T00:00:02+00:00",
 			status: "passed",
 			package_profile: "docker-local",
 			model_dir: modelDir,
@@ -3038,8 +3071,14 @@ describe("sure_onboard verdict structure compatibility", () => {
 				vc_ready: null,
 			},
 		});
+		// The verdict gate reads the inventory the preceding unit leaves in the run.
+		writeArtifact(runDir, "runtime_inventory.json", {
+			schema: "sure.onboard.runtime_inventory.v2",
+			generated_at: "2026-01-01T00:00:03+00:00",
+		});
 		writeArtifact(runDir, "verdict.json", {
 			status: "passed",
+			timestamp: "2026-01-01T00:00:04+00:00",
 			package: { profile: "docker-local" },
 			readiness: {
 				local_ready: true,
@@ -3092,6 +3131,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		}
 		writeJson(join(artifactsDir, "package_gate.json"), {
 			schema: "sure.onboard.package_gate.v2",
+			generated_at: "2026-01-01T00:00:02+00:00",
 			status: "passed",
 			package_profile: "none",
 			model_dir: "sure/models/verdict-model",
@@ -3104,9 +3144,14 @@ describe("sure_onboard verdict structure compatibility", () => {
 				bundle_ready: true,
 			},
 		});
+		writeJson(join(artifactsDir, "runtime_inventory.json"), {
+			schema: "sure.onboard.runtime_inventory.v2",
+			generated_at: "2026-01-01T00:00:03+00:00",
+		});
 		const produces = join(artifactsDir, "verdict.json");
 		writeJson(produces, {
 			status: "passed",
+			timestamp: "2026-01-01T00:00:04+00:00",
 			package: { profile: "none" },
 			readiness: { local_ready: true, docker_ready: false, registry_ready: false },
 			build: { success: true },
@@ -3163,6 +3208,7 @@ describe("sure_onboard verdict structure compatibility", () => {
 		});
 		writeArtifact(runDir, "package_gate.json", {
 			schema: "sure.onboard.package_gate.v2",
+			generated_at: "2026-01-01T00:00:02+00:00",
 			status: "passed",
 			package_profile: "none",
 			model_dir: modelDir,
@@ -3176,8 +3222,14 @@ describe("sure_onboard verdict structure compatibility", () => {
 				vc_ready: null,
 			},
 		});
+		// The verdict gate reads the inventory the preceding unit leaves in the run.
+		writeArtifact(runDir, "runtime_inventory.json", {
+			schema: "sure.onboard.runtime_inventory.v2",
+			generated_at: "2026-01-01T00:00:03+00:00",
+		});
 		writeArtifact(runDir, "verdict.json", {
 			status: "passed",
+			timestamp: "2026-01-01T00:00:04+00:00",
 			package: { profile: "none" },
 			readiness: {
 				local_ready: true,

--- a/packages/coding-agent/test/sure/site-loader.test.ts
+++ b/packages/coding-agent/test/sure/site-loader.test.ts
@@ -142,16 +142,16 @@ describe("validateSitePolicy container_delivery", () => {
 		const result = validateSitePolicy(
 			policy({
 				network: { container_registry: "registry.example" },
-				container_delivery: { repository_template: "{registry}/example-org/sure-{task}-{model_name}" },
+				container_delivery: { repository_template: "{registry}/my-org/sure-{task}-{model_name}" },
 			}),
 		);
-		expect(result.container_delivery?.repository_template).toBe("{registry}/example-org/sure-{task}-{model_name}");
+		expect(result.container_delivery?.repository_template).toBe("{registry}/my-org/sure-{task}-{model_name}");
 	});
 
 	it("requires a configured registry", () => {
 		expect(() =>
 			validateSitePolicy(
-				policy({ container_delivery: { repository_template: "{registry}/example-org/sure-{model_name}" } }),
+				policy({ container_delivery: { repository_template: "{registry}/my-org/sure-{model_name}" } }),
 			),
 		).toThrow(/network\.container_registry/);
 	});

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "sure.public_export_manifest.v2",
-  "projection_id": "sha256:a6e8cc5c715916ce3d20d0b71237c5f541b6370e23a96963a45af01e2d00bb28",
-  "tree_sha256": "a6e8cc5c715916ce3d20d0b71237c5f541b6370e23a96963a45af01e2d00bb28",
+  "projection_id": "sha256:e630d5768345f3eda3d95e9a89ff66c4627ae56c4864ce518e9ab61b9923be22",
+  "tree_sha256": "e630d5768345f3eda3d95e9a89ff66c4627ae56c4864ce518e9ab61b9923be22",
   "files": [
     {
       "path": ".gitattributes",
@@ -55,7 +55,7 @@
       "path": "config/site.example.yaml",
       "type": "file",
       "mode": "100644",
-      "sha256": "2068b141bccb3c921c67233d9700bc7a9f62c56a5b93a777d8aab61fbf6f2452"
+      "sha256": "9f795afbbaaac8be173a0dd423d9eea4a33872fde6dd1660fe8e7eff4fcb0436"
     },
     {
       "path": "CONTRIBUTING.md",
@@ -85,7 +85,7 @@
       "path": "docs/site-configuration.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "99d3f14e8f899adbef0533ff29c444f4fd1f4d3170cb44fe2f8de983c31ce551"
+      "sha256": "c0d960733b56f65e8ec34b2f5052dee80c4a8e931395338bede5b9dae6d69d2f"
     },
     {
       "path": "docs/superpowers/plans/2026-08-18-memory-system-e2e-runbook.md",
@@ -199,7 +199,7 @@
       "path": "fixtures/tasks/asr/README.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "7cb042eeffbd8a68956e9c7509e821bd5a5789c387f755694160d705d0ca1758"
+      "sha256": "05c7f1ba90ec69ca6aba1e88d7c67d34a2c50414a23d3846183e0013c5670d57"
     },
     {
       "path": "fixtures/tasks/gr/kimi_audio_gr_smoke/librispeech-test-clean/1580-141083-0040.wav",
@@ -5623,7 +5623,7 @@
       "path": "packages/coding-agent/test/suite/sure-feed.test.ts",
       "type": "file",
       "mode": "100644",
-      "sha256": "4f99946bea98f7ce9877a4f1d9aadbaa22d92e00d2a97b7f605fb43bb95fa60e"
+      "sha256": "6e3e774d6fc120c07e91e2ff01a1a88a2394bb15878fd5ed762027b418aac9eb"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-memory-eval-hooks.test.ts",
@@ -5665,7 +5665,7 @@
       "path": "packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts",
       "type": "file",
       "mode": "100644",
-      "sha256": "aa15a757813114148949fb52a50e46c840785f8274ea64b54672878618576ce0"
+      "sha256": "f9d729fc0b44c084811057f44f10c1f8b137a0ceee15360c31caf44cfd66f698"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-onboard-terminal.test.ts",
@@ -5785,7 +5785,7 @@
       "path": "packages/coding-agent/test/sure/site-loader.test.ts",
       "type": "file",
       "mode": "100644",
-      "sha256": "209a2b30ef714b6e683733d09188c0692286b8c6435708d1fb2d7e6c3d8d0c30"
+      "sha256": "fd250dee4217ba27d5fb7fa8a1a79dcdcc9603c52fa142ec5a8c2b8078c0aee4"
     },
     {
       "path": "packages/coding-agent/test/syntax-highlight.test.ts",
@@ -6571,13 +6571,13 @@
       "path": "scripts/export-public.mjs",
       "type": "file",
       "mode": "100644",
-      "sha256": "a59af74f327f6f098b57a61b6b1b64fcc149d2da076e4fc23ebecb148c976dbe"
+      "sha256": "191a3d1ba4977977c31c9def409f7e67b31d452b878ebc8ac69d30155b5d1c91"
     },
     {
       "path": "scripts/export-public.test.mjs",
       "type": "file",
       "mode": "100644",
-      "sha256": "8a57281d69a9c53e8ab15fa17afd54d53dfc3f972155c56131dadfcc651f5f79"
+      "sha256": "61f805ba911df6641a648d3156aa0617e1b84d137157a2e80bec3d821b851ca1"
     },
     {
       "path": "scripts/generate-coding-agent-install-lock.mjs",
@@ -6769,7 +6769,7 @@
       "path": "sure/runtime/evaluation/runtime.json",
       "type": "file",
       "mode": "100644",
-      "sha256": "a8d234f61f47007900200f53def582264d6d8490bf0d43a7c6a6fc9152e569d1"
+      "sha256": "eb7d6836a8440227599bb497824196f1fed8a8fb91c9ce6918ff7e73a3f26e6b"
     },
     {
       "path": "sure/runtime/harness/bootstrap.py",
@@ -7099,7 +7099,7 @@
       "path": "sure/site/public.example.yaml",
       "type": "file",
       "mode": "100644",
-      "sha256": "2068b141bccb3c921c67233d9700bc7a9f62c56a5b93a777d8aab61fbf6f2452"
+      "sha256": "9f795afbbaaac8be173a0dd423d9eea4a33872fde6dd1660fe8e7eff4fcb0436"
     },
     {
       "path": "sure/site/test_container_delivery.py",
@@ -7117,7 +7117,7 @@
       "path": "sure/site/test_loader.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "2313d27d95747dfae79d60da82eeee141965eb1e3823346844f75b977206df79"
+      "sha256": "e0770ac2d9f40057124de9a20f3793b731709056bcff4c8cd04f55062dec0553"
     },
     {
       "path": "sure/skills/_shared/memory/facts/README.md",
@@ -7285,7 +7285,7 @@
       "path": "sure/skills/sure_approve/scripts/test_approval_flow.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "27c9113b9b5c644e99a015420ba6b8ed8d865f035cb52a7522df70b0281ce22b"
+      "sha256": "324fefef12f02d31a8048e3f7e64102177724f3d6f3b507d0625ebbbf62a0388"
     },
     {
       "path": "sure/skills/sure_approve/scripts/verify_candidate_runtime.py",
@@ -7627,7 +7627,7 @@
       "path": "sure/skills/sure_eval/scripts/check_execution_surface_compliance.py",
       "type": "file",
       "mode": "100755",
-      "sha256": "e9503e9df0ca97ef6c9863eb4a95420eeb38ed6306acd4ba96dd299ef7886a6f"
+      "sha256": "6cc122dfdfe1975ae948d53a76f81d3ddf2394bf2b30d05914a38e1f80c29ebd"
     },
     {
       "path": "sure/skills/sure_eval/scripts/check_main_flow_reference.py",
@@ -7693,7 +7693,7 @@
       "path": "sure/skills/sure_eval/scripts/deployment_binding.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "6593642a9e3c86e92a54563508bd640ded51b8151634219ee0fa8dd9305594ad"
+      "sha256": "af339e408706c0b5e7396c85ca189599bc9b6ff92f9cf2737e60c15c8259a126"
     },
     {
       "path": "sure/skills/sure_eval/scripts/download_sure_data.py",
@@ -7717,7 +7717,7 @@
       "path": "sure/skills/sure_eval/scripts/evaluation_runtime.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "37cc60e57ca91699cd26240be01dcb859ab357f2162865b63428de9d0e1d6081"
+      "sha256": "e67d3a6241fc2c4b92c6e1703e0e71252f818bb06938f55528f1ee1c56aafeaa"
     },
     {
       "path": "sure/skills/sure_eval/scripts/extract_test_samples.py",
@@ -7933,7 +7933,7 @@
       "path": "sure/skills/sure_eval/scripts/sure_eval/agent/vc_submitter.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "91a948e05be028011f4e5c2785bbe320959dd6582401dda769ea282fa54ce740"
+      "sha256": "8fcc992bdaad7980a041380fb48dbdce9076e254553d524a0d18c401d7167444"
     },
     {
       "path": "sure/skills/sure_eval/scripts/sure_eval/cli.py",
@@ -7969,7 +7969,7 @@
       "path": "sure/skills/sure_eval/scripts/sure_eval/datasets/dataset_manager.py",
       "type": "file",
       "mode": "100755",
-      "sha256": "3f97290167bafcd2bbb51a3fad18627c0400e9527297ddf3fa6ef47506840688"
+      "sha256": "11dde0cabc16a976fe96e1a0a95ecba6bcdf8db39416b44350aa53039b293ed6"
     },
     {
       "path": "sure/skills/sure_eval/scripts/sure_eval/datasets/source_resolver.py",
@@ -8563,7 +8563,7 @@
       "path": "sure/skills/sure_eval/scripts/test_deployment_binding.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "24ef3537ab16450b9bc260ee6a99977c0651e1bd8f8b61d6e204604ff781539f"
+      "sha256": "e13f60e25905e85bf54be8c386712eb9d192dc8c3e481d116b34d7bd2ea504d1"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_eval_input_policy.py",
@@ -8581,13 +8581,13 @@
       "path": "sure/skills/sure_eval/scripts/test_evaluation_runtime.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "85b8a3381483d3112053027b7f7fd95bed607485832c3999f27cfb49597a3cb1"
+      "sha256": "96319116acbcbf240b6f24ce8bf9cdc335b9e67026b81ac6ab9f2e00d52b8cc2"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_execution_surface_checks.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "55fb6b5e6f099b320caee25cc04e175ccb570f6441360281f26b1c7a1d9665d0"
+      "sha256": "9a411da1e5fec8db4aa6a9fbc5ef044e8dbe62d614829e71f23c2a6b1898d4f3"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_external_bridge.py",
@@ -8659,7 +8659,7 @@
       "path": "sure/skills/sure_eval/scripts/test_python_deployment_binding.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "e61703c183663c0e96f1fa26923d080f6032084ea32c9cefef3c8fbe92097528"
+      "sha256": "badae8bc3147141e52c9cdb5cf4b2d1681f5f926d6e57f99907c2f212f1cc241"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_python_execution.py",
@@ -8707,13 +8707,13 @@
       "path": "sure/skills/sure_eval/scripts/test_source_naming_flow.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "cd60032f3cd0f50362bdf3122743d15988e1c8bb4d0ba8b0f6ae1052196ec0e2"
+      "sha256": "b664e8d099be23ccdbe8355b7c49ed51b8943abbc8d009e721fc874b9020eeb4"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_source_resolver.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "f407ecf8cbce4518c2d288582fa7aeac0bf439b676ca399d2c7c1609ceae9a27"
+      "sha256": "82d67ed6fba83b1e3b01958537d8f23e16369c70d40d839dc5e171ab6fc7a6d6"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_text_normalization.py",
@@ -8725,7 +8725,7 @@
       "path": "sure/skills/sure_eval/scripts/test_vc_submit_readiness.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "aa0922e74f99a1bd179aebb609dcd2de25ee41155ad9f1d620ed3d5d55dc541a"
+      "sha256": "83f982aff56dd4ae2714e298cd72e34dbdbaee46f1fe9f6a599d794e4106be85"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_verdict_readiness.py",
@@ -8761,7 +8761,7 @@
       "path": "sure/skills/sure_eval/SKILL.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "4d0973da765b7f3f59a4977beba71d5e40f9442a72bc93733f1c9cb06385f642"
+      "sha256": "c1f67df103c51c6e37e3f79c7cb7834ac4db370655e45ff584a0651bc55425d6"
     },
     {
       "path": "sure/skills/sure_eval/sure.skill.json",
@@ -9007,7 +9007,7 @@
       "path": "sure/skills/sure_feed/scripts/test_providers.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "85a1c92608b425e0ced077f17db7573a541182abba6a3e70acee146b93d67d1b"
+      "sha256": "f808e2a26cd9e1b8c5d4bd21848efffc448859302f746d5f186d8cf780701f85"
     },
     {
       "path": "sure/skills/sure_feed/scripts/xforge_collect_dataset.py",
@@ -9139,7 +9139,7 @@
       "path": "sure/skills/sure_onboard/references/memory/bad_cases/asr_metric_bypass.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "3ef79ea19f1bad44ac6e0f1d178731d18a52506619806a6bea90633828c0dffc"
+      "sha256": "6a28ae4121f88fe5db0dbd850d535b9ea24667a22a57f6aa1235184de3933fed"
     },
     {
       "path": "sure/skills/sure_onboard/references/memory/bad_cases/README.md",
@@ -9307,7 +9307,7 @@
       "path": "sure/skills/sure_onboard/references/task_playbooks/ASR.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "abb02d9b0e4a252a19ab41bc837e08cb0fd07532b32666c3d0c2fd090cffdb36"
+      "sha256": "3cd1be21e1e04a24639b8e7de9420997e7d39214bba685b16dbf60dbc4eb0fa4"
     },
     {
       "path": "sure/skills/sure_onboard/references/task_playbooks/KWS.md",
@@ -9319,7 +9319,7 @@
       "path": "sure/skills/sure_onboard/references/task_playbooks/README.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "687730ebf9b3d66202fc1861d8157915ac708683638a47ea51e8dc9b7ee75eab"
+      "sha256": "c36c98f65e802bde14bb6aba10ca03a54db4800020d01dc965dde19bced6da7f"
     },
     {
       "path": "sure/skills/sure_onboard/references/task_playbooks/ROUTING.md",
@@ -9331,7 +9331,7 @@
       "path": "sure/skills/sure_onboard/references/task_playbooks/SPEECH_UNDERSTANDING.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "24e134bbd20631ad1c9fa32b9bc7eb6a01b83d28cf8354ba300c25ad835d9951"
+      "sha256": "9e54d1f96c508a3cddd0fd90e440477709de79018673eff18e4c7d2a123c79f3"
     },
     {
       "path": "sure/skills/sure_onboard/references/task_playbooks/TTS.md",
@@ -9397,19 +9397,19 @@
       "path": "sure/skills/sure_onboard/schemas/deployment_ready_output.schema.json",
       "type": "file",
       "mode": "100644",
-      "sha256": "d50c507d9295cf0cd50cafee639300d5fde9365bc417d69c40c82a3380436571"
+      "sha256": "ee7f39033f62ca332538d2978fc44105647c23b493a2bc71582f3f4060a29bf9"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/deployment_ready_v2.schema.json",
       "type": "file",
       "mode": "100644",
-      "sha256": "e9108f9e24b32f31f6c45fcf1e5273def0c33f470c7c2baffa8cc81b6f157fc2"
+      "sha256": "c20e3dc3ef4c898c177f70d7082be37545062f2ae1dee5236af31e8e0a9b96c9"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/deployment_ready.schema.json",
       "type": "file",
       "mode": "100644",
-      "sha256": "50f5ab7e17b26f5d6fd54c36d78c50c4dad558ede80362c3f6a306b27ac02ee3"
+      "sha256": "abb67395b3894c663b1654d206aed6f5ae7dc19ad48e375516d87baa61baee46"
     },
     {
       "path": "sure/skills/sure_onboard/schemas/docker_build_result.schema.json",
@@ -9565,7 +9565,7 @@
       "path": "sure/skills/sure_onboard/scripts/check_finalized_bundle.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "eb9309892853844ae4d914270c681698c2db21fc5c2c52405bf422bd44545443"
+      "sha256": "d4fba99949dabefa4e0883a9efe1ecaef0eb64a1fba76d95a433bc5f79e9e1bd"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_fixture.py",
@@ -9595,13 +9595,13 @@
       "path": "sure/skills/sure_onboard/scripts/check_package_gate.py",
       "type": "file",
       "mode": "100755",
-      "sha256": "bb5e43380eba39b6d5aa29e43f93752b12248d51f7a464113f98dcc7a0f0185e"
+      "sha256": "151fe42dc3695fd895ea59a1e213e2b37e26c98a1b9f8fdcf7ad6546f72da304"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_runtime_inventory.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "3c19a4d38c1508f8e5d86e5550af0cc7d1b333e74efb06d4f6a357dfc84fcd60"
+      "sha256": "320119aae9a385fa245f65826f706c25ac09f424911c9ca3b382449d4853f60d"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_spec.py",
@@ -9613,7 +9613,7 @@
       "path": "sure/skills/sure_onboard/scripts/check_verdict.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "da17d5c21e003027cd66d225d19327ad796cb1c33d72df2e994c1a0aeebda75b"
+      "sha256": "676229e959217c4427d735075f2fc787ce4b4046801b4e01bb40d7154047655c"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/check_weights.py",
@@ -9637,7 +9637,7 @@
       "path": "sure/skills/sure_onboard/scripts/finalize_model_bundle.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "030d6f42f52866fe8805b37390eb514b6a88e2f6f3bd56443b03cac642c85d56"
+      "sha256": "7888859a4d5c771d313c53ca261d63c95dfd526b672bb4048d9f71fabf7cf325"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/materialize_model_runtime.py",
@@ -9805,7 +9805,7 @@
       "path": "sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "6f1cf8919fa3e74c1f462ed2c7e45ad4b43f4575faf56e53b27ec0bb37b6013d"
+      "sha256": "2af4b99d71c5f8c9d4d83cd4feefd7ad79661760ef51221c4481765b77e602b6"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/test_model_runtime_env.py",
@@ -9847,7 +9847,7 @@
       "path": "sure/skills/sure_onboard/scripts/write_package_gate.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "42bae0ac4f1a777c8f8e270b038157e6eb5889e166d070ba1488583b7c12012a"
+      "sha256": "0c849606006df51271d53d258895d551543fb0cbc70b833fd337493240278508"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/write_runtime_inventory.py",
@@ -9985,7 +9985,7 @@
       "path": "sure/skills/sure_trans/schemas/deployment_ready.schema.json",
       "type": "file",
       "mode": "100644",
-      "sha256": "fa4452de6932e4219dba062e1f355efea79e858e2fe39a136a8ce223145dc747"
+      "sha256": "05936895870d4209b5d070521a61bc447d291d516c8bb1d6779b7d184116c497"
     },
     {
       "path": "sure/skills/sure_trans/schemas/docker_registry_result.schema.json",
@@ -10099,7 +10099,7 @@
       "path": "sure/skills/sure_trans/scripts/check_artifact.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "4bc0b6410cbb989b7d66a789aaf0db8839f77b6efe2ec8f6b6efda4d93335d73"
+      "sha256": "cb716d3fcd424b79886a702f1436457d598c7dc4f811042ce43956c5153f8838"
     },
     {
       "path": "sure/skills/sure_trans/scripts/check_memory_extraction.py",
@@ -10123,7 +10123,7 @@
       "path": "sure/skills/sure_trans/scripts/finalize_trans_bundle.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "7046b9ff0ca482cff046a7c8b55a658aec55a1ddf3c85d4aca0ce6fd266c5738"
+      "sha256": "be0e9606c54585dd8d4635bba0c13ab5e3e7ccb03a8bfb6af0d15fb93d040a61"
     },
     {
       "path": "sure/skills/sure_trans/scripts/inspect_dependencies.py",
@@ -10141,19 +10141,25 @@
       "path": "sure/skills/sure_trans/scripts/mcp_smoke.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "f6e6ebb674e2c33bebc51b57abd587f51f04bbe6ad0d5d7b2a7a5891a88e18db"
+      "sha256": "eb0b3da10f826a9e582f58ae5a34e7c54ac0b02fab7002c617bd738250a5bb24"
     },
     {
       "path": "sure/skills/sure_trans/scripts/prepare_fixture.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "be71a3bd98a5796161eb50fc595f5b45fd7d11faa115f93f45123587ba1dbea7"
+      "sha256": "db86aabcf17ff165ffee06d4d4621ec204de61d9564ee9c766e1e89daf4bc566"
     },
     {
       "path": "sure/skills/sure_trans/scripts/publish_memory.py",
       "type": "file",
       "mode": "100644",
       "sha256": "dc87f446772a5b8cee6ddb73066fb9fc8199e450211138ad46c5a956c8afe7be"
+    },
+    {
+      "path": "sure/skills/sure_trans/scripts/pyproject.toml",
+      "type": "file",
+      "mode": "100644",
+      "sha256": "919ba63a125198672b35d4ca1979e466d8ad1a0d1fb623abc2f007468474893e"
     },
     {
       "path": "sure/skills/sure_trans/scripts/run_docker_build.py",
@@ -10171,13 +10177,13 @@
       "path": "sure/skills/sure_trans/scripts/run_trans_validate.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "e07bd527dc91007f768fbd89066c5c81c51226a36a4229a130bbbaae57bbea0a"
+      "sha256": "1570a6da88ee8364fa74865f85f48e9f7c121777c9015164fd7ab37e6e5dea67"
     },
     {
       "path": "sure/skills/sure_trans/scripts/scaffold_adapter.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "a0c774b9ac581b4c596770dfb14f46ce6d54166edbb67c63f565b2699178a759"
+      "sha256": "934af814f7134647f3e119ad82ee09afd5a9d5adb81a6aae400ad5f21c6c8086"
     },
     {
       "path": "sure/skills/sure_trans/scripts/stage_model_payload.py",
@@ -10237,19 +10243,19 @@
       "path": "sure/skills/sure_trans/scripts/test_trans_scripts.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "e12c0c61d0415f9c89d7797051c7fa8bd4c97bc2d26f7c5c99fa5734a0bc2cd9"
+      "sha256": "0c3241dfa6f10e4318e397d4db2e7df98a84051f30f9580b3fcca8ce537040de"
     },
     {
       "path": "sure/skills/sure_trans/scripts/test_vc_exec.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "107d395a42dd9e7a6621c98e757d171a072a005a6f1a85b2ef30aaf0d69fbbaf"
+      "sha256": "7a8729ea9fd9d6e3bfa0d98f5aacd6814cb8638cf1c51f85ab7eee85fa098e30"
     },
     {
       "path": "sure/skills/sure_trans/scripts/vc_exec.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "306a58239b06e0ac72b36c44d4fbe7cbf3a892a44935046fdeca0bbedb5cc08d"
+      "sha256": "d17664c44f09a51733dff7fe413582cfa3917d44afbc45bdc5315ce41482c0d2"
     },
     {
       "path": "sure/skills/sure_trans/scripts/write_runtime_inventory.py",
@@ -10267,7 +10273,7 @@
       "path": "sure/skills/sure_trans/SKILL.md",
       "type": "file",
       "mode": "100644",
-      "sha256": "603418bd861b19e894f88ee3ab9fcb2571d3f49722bbd68462b6a3d99a95526a"
+      "sha256": "2d447d8ceb8a0b3d0ba6cad7e0bf77cbd681a5ecc63c57607e8db168552b4761"
     },
     {
       "path": "sure/skills/sure_trans/sure.skill.json",

--- a/sure/site/public.example.yaml
+++ b/sure/site/public.example.yaml
@@ -27,4 +27,4 @@ network:
   container_registry: registry.example.com
 
 container_delivery:
-  repository_template: "{registry}/example-org/sure-{task}-{model_name}"
+  repository_template: "{registry}/my-org/sure-{task}-{model_name}"

--- a/sure/site/test_loader.py
+++ b/sure/site/test_loader.py
@@ -99,13 +99,13 @@ class ContainerDeliveryTest(unittest.TestCase):
             _policy(
                 network={"container_registry": "registry.example"},
                 container_delivery={
-                    "repository_template": "{registry}/example-org/sure-{task}-{model_name}"
+                    "repository_template": "{registry}/my-org/sure-{task}-{model_name}"
                 },
             )
         )
         self.assertEqual(
             policy["container_delivery"]["repository_template"],
-            "{registry}/example-org/sure-{task}-{model_name}",
+            "{registry}/my-org/sure-{task}-{model_name}",
         )
 
     def test_repository_template_requires_a_registry(self) -> None:
@@ -113,7 +113,7 @@ class ContainerDeliveryTest(unittest.TestCase):
             validate_site_policy(
                 _policy(
                     container_delivery={
-                        "repository_template": "{registry}/example-org/sure-{model_name}"
+                        "repository_template": "{registry}/my-org/sure-{model_name}"
                     }
                 )
             )

--- a/sure/skills/sure_approve/scripts/test_approval_flow.py
+++ b/sure/skills/sure_approve/scripts/test_approval_flow.py
@@ -149,7 +149,7 @@ class ApprovalFlowTests(unittest.TestCase):
         }
         deployment = {
             "schema": "sure.onboard.deployment_ready.v2",
-            "generated_at": approval_core.now_iso(),
+            "generated_at": "2026-08-01T00:00:00+00:00",  # a legacy-shaped marker, sealed before integrity_profile became mandatory
             "status": "ready",
             "model_name": "demo-model",
             "package_profile": "none",

--- a/sure/skills/sure_eval/scripts/deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/deployment_binding.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import json
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -250,6 +251,10 @@ def _normalize_harness_runtime(binding: dict[str, Any]) -> dict[str, Any]:
 
 
 TERMINAL_VERDICT_STATUSES = {"success", "passed", "pass"}
+# Bundles sealed from this instant on must say which integrity profile they carry;
+# omitting the field used to silently select the weaker legacy check.
+INTEGRITY_PROFILE_REQUIRED_FROM = datetime(2026, 9, 1, tzinfo=timezone.utc)
+WEIGHTS_INTEGRITY_MODES = {"bundled", "external"}
 CORE_BUNDLE_FILES = {
     "model.spec.yaml",
     "model.py",
@@ -294,7 +299,13 @@ def _mandatory_integrity_paths(
     package: dict[str, Any],
     declared_hashes: dict[str, Any],
     profile: str,
+    weights_integrity: object,
 ) -> set[str]:
+    weights_integrity = str(weights_integrity or "bundled")
+    _require(
+        weights_integrity in WEIGHTS_INTEGRITY_MODES,
+        f"unsupported deployment weights_integrity: {weights_integrity!r}",
+    )
     required = {*CORE_BUNDLE_FILES, *COMMON_MANDATORY_SIDECARS}
     for relative in COMMON_MANDATORY_SIDECARS:
         _require((model_dir / relative).is_file(), f"mandatory deployment sidecar is missing: {relative}")
@@ -385,30 +396,33 @@ def _mandatory_integrity_paths(
     weights_manifest_path = model_dir / "artifacts" / "weights_manifest.json"
     if weights_manifest_path.is_file():
         required.add("artifacts/weights_manifest.json")
-        weights = _read_json(model_dir, "artifacts/weights_manifest.json")
-        local_dir_name = str(weights.get("local_dir_name") or "")
-        if not local_dir_name:
-            for key in ("checkpoint_root", "resolved_local_model_path"):
-                candidate_value = str(weights.get(key) or "")
-                if not candidate_value:
-                    continue
-                candidate = Path(candidate_value).expanduser().resolve()
-                if _is_relative_to(candidate, model_dir.resolve()):
-                    local_dir_name = candidate.relative_to(model_dir.resolve()).as_posix()
-                    break
-        _require(
-            bool(local_dir_name) or weights.get("required") is not True,
-            "required weights manifest has no model-local weight root",
-        )
-        if local_dir_name:
-            weights_root = (model_dir / _portable_relative(local_dir_name, "weights local_dir_name")).resolve()
-            if weights_root.is_file():
-                _require(not (model_dir / local_dir_name).is_symlink(), "weights file must not be a symlink")
-                weight_files = {weights_root.relative_to(model_dir.resolve()).as_posix()}
-            else:
-                weight_files = _bundle_files(weights_root, model_dir, "weights")
-            _require(weight_files or weights.get("required") is not True, "required weights root is empty")
-            required.update(weight_files)
+        # Weights declared external are held outside the bundle on purpose, so the
+        # bundle carries the manifest that describes them but not the payload.
+        if weights_integrity == "bundled":
+            weights = _read_json(model_dir, "artifacts/weights_manifest.json")
+            local_dir_name = str(weights.get("local_dir_name") or "")
+            if not local_dir_name:
+                for key in ("checkpoint_root", "resolved_local_model_path"):
+                    candidate_value = str(weights.get(key) or "")
+                    if not candidate_value:
+                        continue
+                    candidate = Path(candidate_value).expanduser().resolve()
+                    if _is_relative_to(candidate, model_dir.resolve()):
+                        local_dir_name = candidate.relative_to(model_dir.resolve()).as_posix()
+                        break
+            _require(
+                bool(local_dir_name) or weights.get("required") is not True,
+                "required weights manifest has no model-local weight root",
+            )
+            if local_dir_name:
+                weights_root = (model_dir / _portable_relative(local_dir_name, "weights local_dir_name")).resolve()
+                if weights_root.is_file():
+                    _require(not (model_dir / local_dir_name).is_symlink(), "weights file must not be a symlink")
+                    weight_files = {weights_root.relative_to(model_dir.resolve()).as_posix()}
+                else:
+                    weight_files = _bundle_files(weights_root, model_dir, "weights")
+                _require(weight_files or weights.get("required") is not True, "required weights root is empty")
+                required.update(weight_files)
     return required
 
 
@@ -435,7 +449,9 @@ def _validate_complete_manifest(
             has_deployment_self_entry = True
         else:
             manifest_paths.add(relative.as_posix())
-    mandatory_paths = _mandatory_integrity_paths(model_dir, package, declared_hashes, profile)
+    mandatory_paths = _mandatory_integrity_paths(
+        model_dir, package, declared_hashes, profile, marker.get("weights_integrity")
+    )
     _require(
         has_deployment_self_entry,
         "artifact_manifest must declare artifacts/deployment_ready.json as its terminal self-entry",
@@ -449,6 +465,31 @@ def _validate_complete_manifest(
         "deployment_ready hashes must cover exactly every finalized artifact_manifest required file except deployment_ready.json",
     )
     return manifest
+
+
+def _require_declared_integrity_profile(marker: dict[str, Any]) -> None:
+    """Deny the legacy fallback to bundles young enough to have declared a profile."""
+    if marker.get("integrity_profile") is not None:
+        return
+    raw = marker.get("generated_at") or marker.get("timestamp")
+    # Both deployment_ready schemas make generated_at mandatory, so a marker with
+    # no readable seal date at all is not an old bundle, it is a marker that
+    # dropped the one field the cutoff is read from.
+    _require(
+        raw is not None,
+        "deployment_ready without a seal timestamp must declare integrity_profile",
+    )
+    try:
+        sealed_at = datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+    except ValueError as error:
+        raise DeploymentBindingError(f"deployment_ready timestamp is unreadable: {raw!r} ({error})") from error
+    if sealed_at.tzinfo is None:
+        sealed_at = sealed_at.replace(tzinfo=timezone.utc)
+    _require(
+        sealed_at < INTEGRITY_PROFILE_REQUIRED_FROM,
+        "deployment_ready sealed on or after "
+        f"{INTEGRITY_PROFILE_REQUIRED_FROM.isoformat()} must declare integrity_profile",
+    )
 
 
 def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
@@ -473,6 +514,7 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
     marker = _read_json(model_dir, "artifacts/deployment_ready.json")
     inventory = _read_json(model_dir, "artifacts/runtime_inventory.json")
     package = _read_json(model_dir, "artifacts/package_gate.json")
+    _require_declared_integrity_profile(marker)
 
     if marker.get("package_profile") == "none":
         _require(marker.get("schema") == DEPLOYMENT_READY_V2, "unsupported Python deployment_ready schema")
@@ -620,6 +662,7 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
             package,
             declared_hashes,
             "docker-registry",
+            marker.get("weights_integrity"),
         )
         _require(
             has_deployment_self_entry,

--- a/sure/skills/sure_eval/scripts/sure_eval/agent/vc_submitter.py
+++ b/sure/skills/sure_eval/scripts/sure_eval/agent/vc_submitter.py
@@ -91,7 +91,10 @@ def _infer_repo_root() -> Path:
 
 
 def _infer_default_volume_mount(repo_root: Path) -> str:
-    """Use an identity mount for the current checkout by default."""
+    """Infer a single vc volume covering repo code and shared model symlinks."""
+    for parent in (repo_root, *repo_root.parents):
+        if parent.name == "sjtu_home":
+            return f"{parent}:{parent}"
     return f"{repo_root}:{repo_root}"
 
 

--- a/sure/skills/sure_eval/scripts/sure_eval/datasets/dataset_manager.py
+++ b/sure/skills/sure_eval/scripts/sure_eval/datasets/dataset_manager.py
@@ -30,6 +30,20 @@ from .source_resolver import (
 logger = get_logger(__name__)
 
 
+# ``source`` marker written into every artifact produced from a dataset-pool
+# source root. Records written before the marker was renamed carry the legacy
+# spelling, so reads normalize it back to the current value.
+SITE_DATASET_POOL_SOURCE = "site_dataset_pool"
+LEGACY_SITE_DATASET_POOL_SOURCE = "aispeech_ds_pool"
+
+
+def _normalized_source(source: Any) -> Any:
+    """Report the current marker for records written before the rename."""
+    if source == LEGACY_SITE_DATASET_POOL_SOURCE:
+        return SITE_DATASET_POOL_SOURCE
+    return source
+
+
 # Mapping from CSV filename to metadata
 # This bridges the gap between actual filenames and config names
 CSV_DATASETS = {
@@ -987,7 +1001,7 @@ class DatasetManager:
             language=language,
             dataset_label=ref.dataset_id,
             metadata_base={
-                "source": "site_dataset_pool",
+                "source": SITE_DATASET_POOL_SOURCE,
                 "source_dataset_root": ref.source_root,
                 "source_dataset_name": ref.source_dataset_name,
                 "version_id": ref.version_id,
@@ -1011,7 +1025,7 @@ class DatasetManager:
         shutil.copy2(jsonl_path, sure_jsonl)
 
         source_payload = {
-            "source": "site_dataset_pool",
+            "source": SITE_DATASET_POOL_SOURCE,
             "source_dataset_name": ref.source_dataset_name,
             "version_id": ref.version_id,
             "dataset_root": ref.source_root,
@@ -1029,7 +1043,7 @@ class DatasetManager:
 
         mapping = {
             "projector": "asr_transcription_v1",
-            "source_format": "site_dataset_pool_sample_jsonl",
+            "source_format": f"{SITE_DATASET_POOL_SOURCE}_sample_jsonl",
             "target_format": "sure_eval_jsonl_v1",
             "fields": {
                 "key": "sample_id",
@@ -1061,7 +1075,7 @@ class DatasetManager:
         )
 
         conversion_report = {
-            "source": "site_dataset_pool",
+            "source": SITE_DATASET_POOL_SOURCE,
             "dataset": ref.dataset_id,
             "source_dataset_name": ref.source_dataset_name,
             "source_dataset_root": ref.source_root,
@@ -1092,7 +1106,7 @@ class DatasetManager:
         manifest = {
             "dataset": ref.source_dataset_name,
             "default_projection": "asr_transcription_v1",
-            "source": "site_dataset_pool",
+            "source": SITE_DATASET_POOL_SOURCE,
             "source_dataset_root": ref.source_root,
             "version_id": ref.version_id,
             "projections": {
@@ -1474,7 +1488,9 @@ class DatasetManager:
                 "config_name": existing_jsonl.stem,
                 "task": first_sample.get("task"),
                 "language": first_sample.get("language"),
-                "source": sample_meta.get("source") or first_sample.get("source") or "local_jsonl",
+                "source": _normalized_source(
+                    sample_meta.get("source") or first_sample.get("source") or "local_jsonl"
+                ),
                 "jsonl_path": str(existing_jsonl),
                 "num_samples": self._count_jsonl_rows(existing_jsonl),
                 "is_available": True,

--- a/sure/skills/sure_eval/scripts/test_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_deployment_binding.py
@@ -11,7 +11,16 @@ from pathlib import Path
 from unittest.mock import patch
 
 from container_execution import build_local_container_command
-from deployment_binding import DeploymentBindingError, _portable_relative, load_deployment_binding
+from deployment_binding import (
+    COMMON_MANDATORY_SIDECARS,
+    CORE_BUNDLE_FILES,
+    DeploymentBindingError,
+    _mandatory_integrity_paths,
+    _portable_relative,
+    _require_declared_integrity_profile,
+    _validate_complete_manifest,
+    load_deployment_binding,
+)
 from check_run_report import _submitted_image_error
 from run_vc_execution import (
     _approved_memory_gb,
@@ -238,6 +247,7 @@ class DeploymentBindingTests(unittest.TestCase):
             self.artifacts / "deployment_ready.json",
             {
                 "schema": "sure.onboard.deployment_ready.v1",
+                "generated_at": "2026-08-01T00:00:00+00:00",
                 "status": "ready",
                 "model_name": "demo",
                 "package_profile": "docker-registry",
@@ -318,6 +328,38 @@ class DeploymentBindingTests(unittest.TestCase):
         write_json(self.artifacts / "deployment_ready.json", marker)
 
         with self.assertRaisesRegex(DeploymentBindingError, "mandatory deployment sidecar|mandatory core"):
+            load_deployment_binding(self.model, "demo")
+
+    def _rewrite_marker(self, **fields: object) -> None:
+        marker = json.loads((self.artifacts / "deployment_ready.json").read_text())
+        marker.update(fields)
+        write_json(self.artifacts / "deployment_ready.json", marker)
+
+    def test_marker_sealed_at_the_cutoff_must_declare_an_integrity_profile(self) -> None:
+        self._rewrite_marker(generated_at="2026-09-01T00:00:00+00:00")
+
+        with self.assertRaisesRegex(DeploymentBindingError, "integrity_profile"):
+            load_deployment_binding(self.model, "demo")
+
+    def test_marker_with_an_unreadable_timestamp_may_not_fall_back_to_the_legacy_profile(self) -> None:
+        self._rewrite_marker(generated_at="", timestamp="not-a-timestamp")
+
+        with self.assertRaisesRegex(DeploymentBindingError, "timestamp"):
+            load_deployment_binding(self.model, "demo")
+
+    def test_marker_sealed_before_the_cutoff_keeps_the_legacy_profile(self) -> None:
+        self._rewrite_marker(generated_at="2026-08-31T23:59:59+00:00")
+
+        binding = load_deployment_binding(self.model, "demo")
+
+        self.assertEqual(binding["evidence"]["integrity_profile"], "legacy-partial-v1")
+
+    def test_marker_without_any_timestamp_may_not_fall_back_to_the_legacy_profile(self) -> None:
+        marker = json.loads((self.artifacts / "deployment_ready.json").read_text())
+        marker.pop("generated_at", None)
+        write_json(self.artifacts / "deployment_ready.json", marker)
+
+        with self.assertRaisesRegex(DeploymentBindingError, "integrity_profile"):
             load_deployment_binding(self.model, "demo")
 
     def test_local_command_uses_digest_and_read_only_model(self) -> None:
@@ -707,6 +749,93 @@ class DeploymentBindingTests(unittest.TestCase):
             encoding="utf-8",
         )
         self.assertEqual(_approved_memory_gb(self.model), 29)
+
+
+class MandatoryIntegrityPathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.model = Path(tmp.name) / "model"
+        artifacts = self.model / "artifacts"
+        for name in (
+            "artifact_manifest.json",
+            "fixture_manifest.json",
+            "package_gate.json",
+            "runtime_inventory.json",
+            "sample_output.json",
+            "verdict.json",
+            "model_runtime_manifest.json",
+        ):
+            write_json(artifacts / name, {})
+        write_json(artifacts / "weights_manifest.json", {"required": True, "local_dir_name": "checkpoints"})
+        gt = self.model / "fixture" / "asr" / "gt.jsonl"
+        gt.parent.mkdir(parents=True, exist_ok=True)
+        gt.write_text("{}\n", encoding="utf-8")
+
+    def test_external_weights_are_not_required_inside_the_bundle(self) -> None:
+        required = _mandatory_integrity_paths(self.model, {}, {}, "none", "external")
+
+        self.assertNotIn("checkpoints", {Path(path).parts[0] for path in required})
+        self.assertIn("artifacts/weights_manifest.json", required)
+        self.assertIn("fixture/asr/gt.jsonl", required)
+
+    def test_bundled_weights_must_be_present_inside_the_bundle(self) -> None:
+        with self.assertRaisesRegex(DeploymentBindingError, "weights root is missing"):
+            _mandatory_integrity_paths(self.model, {}, {}, "none", "bundled")
+
+    def test_absent_weights_integrity_means_bundled(self) -> None:
+        with self.assertRaisesRegex(DeploymentBindingError, "weights root is missing"):
+            _mandatory_integrity_paths(self.model, {}, {}, "none", None)
+
+    def test_unknown_weights_integrity_is_rejected(self) -> None:
+        with self.assertRaisesRegex(DeploymentBindingError, "weights_integrity"):
+            _mandatory_integrity_paths(self.model, {}, {}, "none", "extern")
+
+    def _seal_complete_manifest(self, **marker_fields: object) -> dict:
+        paths = sorted(
+            {
+                *CORE_BUNDLE_FILES,
+                *COMMON_MANDATORY_SIDECARS,
+                "artifacts/model_runtime_manifest.json",
+                "artifacts/weights_manifest.json",
+                "fixture/asr/gt.jsonl",
+            }
+        )
+        write_json(
+            self.model / "artifacts" / "artifact_manifest.json",
+            {
+                "schema": "sure.onboard.artifact_manifest.v1",
+                "status": "finalized",
+                "model_dir": ".",
+                "artifacts": {
+                    "required": {
+                        path: {"path": path}
+                        for path in [*paths, "artifacts/deployment_ready.json"]
+                    }
+                },
+            },
+        )
+        return {"required_artifact_sha256": {path: "a" * 64 for path in paths}, **marker_fields}
+
+    def test_external_weights_declared_on_the_marker_reach_the_mandatory_paths(self) -> None:
+        marker = self._seal_complete_manifest(weights_integrity="external")
+
+        manifest = _validate_complete_manifest(self.model, marker, {}, "none")
+
+        self.assertEqual(manifest["status"], "finalized")
+
+    def test_a_marker_without_weights_integrity_still_demands_bundled_weights(self) -> None:
+        marker = self._seal_complete_manifest()
+
+        with self.assertRaisesRegex(DeploymentBindingError, "weights root is missing"):
+            _validate_complete_manifest(self.model, marker, {}, "none")
+
+
+class IntegrityProfileCutoffTests(unittest.TestCase):
+    def test_a_marker_sealed_before_the_cutoff_may_omit_the_integrity_profile(self) -> None:
+        # The accepting branch of the cutoff: the bundle fixture cannot reach it
+        # through load_deployment_binding on a machine without POSIX mount paths.
+        _require_declared_integrity_profile({"generated_at": "2026-08-31T23:59:59Z"})
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_eval/scripts/test_python_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_python_deployment_binding.py
@@ -115,6 +115,7 @@ class PythonDeploymentBindingTests(unittest.TestCase):
         }
         marker = {
             "schema": "sure.onboard.deployment_ready.v2",
+            "generated_at": "2026-08-01T00:00:00+00:00",
             "status": "ready",
             "model_name": "demo",
             "package_profile": "none",

--- a/sure/skills/sure_eval/scripts/test_source_naming_flow.py
+++ b/sure/skills/sure_eval/scripts/test_source_naming_flow.py
@@ -57,6 +57,15 @@ class SourceNamingFlowTests(unittest.TestCase):
         self.assertEqual(info["version_id"], "v1.0.2")
         self.assertEqual(info["source_root"], str(self.dataset_root))
 
+    def test_get_info_normalizes_the_legacy_source_marker(self) -> None:
+        jsonl_path = self.manager.download_and_convert(str(self.dataset_root))
+        rows = jsonl_path.read_text(encoding="utf-8").replace(
+            '"site_dataset_pool"', '"aispeech_ds_pool"'
+        )
+        jsonl_path.write_text(rows, encoding="utf-8", newline="\n")
+        info = self.manager.get_info("demo_ds__v1.0.2") or {}
+        self.assertEqual(info["source"], "site_dataset_pool")
+
     def test_prepare_dataset_emits_plan_fields(self) -> None:
         summary = prepare_sure_dataset.prepare_dataset(
             self.manager, "demo_ds__v1.0.2", requested_name=str(self.dataset_root)

--- a/sure/skills/sure_eval/scripts/test_source_resolver.py
+++ b/sure/skills/sure_eval/scripts/test_source_resolver.py
@@ -169,7 +169,7 @@ class RejectedRootMessageTests(unittest.TestCase):
     """A rejected path has to say which configured key would have taken it."""
 
     def test_path_under_another_configured_key_names_that_key(self) -> None:
-        roots = {"default": "/srv/datasets/public", "secondary": "/srv/datasets/platform"}
+        roots = {"default": "/srv/datasets/public", "aiplatform": "/srv/datasets/platform"}
         with mock.patch.object(source_resolver, "DEFAULT_SOURCE_ROOTS", roots):
             with mock.patch.dict(os.environ, {}, clear=False):
                 os.environ.pop(source_resolver.SOURCE_ROOT_ENV, None)
@@ -178,11 +178,11 @@ class RejectedRootMessageTests(unittest.TestCase):
                         "/srv/datasets/platform/g001/store002/ds_pool/demo_ds"
                     )
         message = str(ctx.exception)
-        self.assertIn("secondary", message)
+        self.assertIn("aiplatform", message)
         self.assertIn("dataset_source_key", message)
 
     def test_path_under_no_configured_key_lists_them(self) -> None:
-        roots = {"default": "/srv/datasets/public", "secondary": "/srv/datasets/platform"}
+        roots = {"default": "/srv/datasets/public", "aiplatform": "/srv/datasets/platform"}
         with mock.patch.object(source_resolver, "DEFAULT_SOURCE_ROOTS", roots):
             with mock.patch.dict(os.environ, {}, clear=False):
                 os.environ.pop(source_resolver.SOURCE_ROOT_ENV, None)
@@ -190,7 +190,7 @@ class RejectedRootMessageTests(unittest.TestCase):
                     source_resolver.resolve_site_source_entry("/elsewhere/ds_pool/demo_ds")
         message = str(ctx.exception)
         self.assertIn("default", message)
-        self.assertIn("secondary", message)
+        self.assertIn("aiplatform", message)
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_eval/scripts/test_vc_submit_readiness.py
+++ b/sure/skills/sure_eval/scripts/test_vc_submit_readiness.py
@@ -263,10 +263,6 @@ class SelectBestImageTests(unittest.TestCase):
         selected = self.vc_submitter.select_best_image("asr_nemo_stt_zh_conformer_transducer")
         self.assertEqual(selected, IMG)
 
-    def test_default_volume_mount_is_the_checkout_identity(self):
-        root = Path("/srv/example/sure-harness")
-        self.assertEqual(self.vc_submitter._infer_default_volume_mount(root), f"{root}:{root}")
-
 
 class CliTests(unittest.TestCase):
     SCRIPT = str(Path(__file__).resolve().parent / "check_vc_submit_readiness.py")

--- a/sure/skills/sure_feed/scripts/test_providers.py
+++ b/sure/skills/sure_feed/scripts/test_providers.py
@@ -195,7 +195,7 @@ wav = model.generate(
         )
 
     def test_runtime_strategy_handles_sherpa_onnx_without_standard_import_load_split(self) -> None:
-        readme = """# Streaming ASR ONNX
+        readme = """# X-ASR
 
 This model provides streaming and offline CPU ASR checkpoints for sherpa-onnx.
 
@@ -207,18 +207,18 @@ pip install sherpa-onnx
         model_input, weak_fields, evidence = synthesize_model_input(
             {
                 "source": "huggingface",
-                "model_id": "example-org/streaming-asr-onnx",
-                "repo": "https://huggingface.co/example-org/streaming-asr-onnx",
+                "model_id": "GilgameshWind/X-ASR-zh-en",
+                "repo": "https://huggingface.co/GilgameshWind/X-ASR-zh-en",
                 "commit": "abc123",
                 "weights_source": "huggingface",
                 "pipeline_tag": "automatic-speech-recognition",
                 "tags": [
                     "sherpa-onnx",
                     "onnx",
-                    "zipformer-transducer",
+                    "x-asr-zipformer-transducer",
                     "automatic-speech-recognition",
                 ],
-                "model_card_url": "https://huggingface.co/example-org/streaming-asr-onnx/blob/main/README.md",
+                "model_card_url": "https://huggingface.co/GilgameshWind/X-ASR-zh-en/blob/main/README.md",
                 "model_card_text": readme,
             },
             "asr",

--- a/sure/skills/sure_onboard/references/memory/bad_cases/asr_metric_bypass.md
+++ b/sure/skills/sure_onboard/references/memory/bad_cases/asr_metric_bypass.md
@@ -69,4 +69,4 @@ Then inspect the changed `sample_output.json` and confirm every ASR metric has
 - `src/sure_eval/models_reonboard/runs/asr_qwen3`
 - `src/sure_eval/models_reonboard/runs/asr_sensevoice_small`
 - `src/sure_eval/models_reonboard/runs/whisper_large_v3_turbo`
-- `src/sure_eval/models_reonboard/runs/example-org__streaming-asr-onnx`
+- `src/sure_eval/models_reonboard/runs/GilgameshWind__X-ASR-zh-en`

--- a/sure/skills/sure_onboard/references/task_playbooks/ASR.md
+++ b/sure/skills/sure_onboard/references/task_playbooks/ASR.md
@@ -2,7 +2,7 @@
 
 本文是 `docs/agents/model_tool_agent/AGENTS.md` 的 ASR 任务补充。新 agent 接入 ASR
 模型时必须先读总规范，再读本文。本文覆盖普通离线 ASR 和流式 ASR，例如
-`example-org__streaming-asr-onnx`。
+`GilgameshWind__X-ASR-zh-en`。
 
 ## 1. 任务边界
 
@@ -59,7 +59,7 @@ sure/models/{model}/
 `weights_manifest.json`。SURE model tool-agent 负责 wrapper、环境、Docker 和验证。
 
 如果只需要仓库中的部分权重文件，必须在 `weights_manifest.json` 和任务文档中写清楚。
-某些流式 ONNX ASR 模型的 SURE smoke 只需要 `deployment/models/chunk-*ms-model/` 中的
+X-ASR 的经验是：SURE smoke 只需要 `deployment/models/chunk-*ms-model/` 中的
 ONNX 文件和 `tokens.txt`，不需要下载 demo 视频或桌面 app 包。
 
 ## 3. Fixture
@@ -151,17 +151,17 @@ GPU 是首选。只有在用户明确接受 CPU smoke，或硬件客观不满足
 - `predict()` 不修改原始 fixture。
 - 音频重采样应显式记录，优先复用 `librosa`、`soundfile`、`torchaudio` 或上游 API。
 
-## 6. 流式 ASR 要点
+## 6. 流式 ASR / X-ASR 要点
 
 流式 ASR 不能只按离线模型处理。必须额外验证：
 
 - chunk 配置是否来自模型权重目录，例如 `chunk-960ms-model`。
 - 每个 chunk 的 `accept_waveform()` / `decode_stream()` / `input_finished()` 调用顺序。
-- 结尾是否需要 tail silence padding。部分模型的短音频如果没有约 1s tail
+- 结尾是否需要 tail silence padding。X-ASR 经验：短音频如果没有约 1s tail
   padding，会丢尾词。
 - provider 必须真实为 CUDA；日志中出现 `Fallback to cpu` 必须失败。
 
-sherpa-onnx 运行经验：
+X-ASR/sherpa-onnx 经验：
 
 - PyPI `sherpa-onnx==1.13.2` 在当前 host 上只有 `CPUExecutionProvider`。
 - 本地 uv 请求 CUDA 会打印 `Please compile with -DSHERPA_ONNX_ENABLE_GPU=ON` 并
@@ -174,8 +174,8 @@ sherpa-onnx 运行经验：
 /opt/conda/lib/python3.11/site-packages/nvidia/cudnn/lib:/usr/local/cuda/lib64:/usr/local/cuda/targets/x86_64-linux/lib
 ```
 
-- 不要把 Docker 中编译的 sherpa-onnx 扩展复制回 host `.venv`；host glibc 低于
-  Docker 构建环境时，复制的扩展会加载失败。
+- 不要把 Docker 中编译的 sherpa-onnx 扩展复制回 host `.venv`；X-ASR 试过后因
+  host glibc 低于 Docker 构建环境而失败。
 
 ## 7. local_uv_validate.sh
 
@@ -212,7 +212,7 @@ Docker 验证必须证明：
 
 ```text
 registry.example.com/sure/sure_asr_<name>:v1.0
-registry.example.com/sure/sure_streaming_asr_zh_en:v1.0
+registry.example.com/sure/sure_x_asr_zh_en:v1.0
 ```
 
 推送后必须用 `docker pull` 验证 registry 可拉取，并记录 digest。

--- a/sure/skills/sure_onboard/references/task_playbooks/README.md
+++ b/sure/skills/sure_onboard/references/task_playbooks/README.md
@@ -7,7 +7,7 @@
 
 | 任务 | 文档 | 适用范围 |
 |------|------|----------|
-| ASR / Streaming ASR | [ASR.md](ASR.md) | 离线 ASR、流式 ASR、sherpa-onnx |
+| ASR / Streaming ASR | [ASR.md](ASR.md) | 离线 ASR、流式 ASR、X-ASR、sherpa-onnx |
 | Speech Understanding | [SPEECH_UNDERSTANDING.md](SPEECH_UNDERSTANDING.md) | ASR、S2TT、SER、SLU、GR 多任务语音理解模型 |
 | TTS | [TTS.md](TTS.md) | F5-TTS、IndexTTS-2、带音色参考的语音合成 |
 | VC | [VC.md](VC.md) | Seed-VC、音频到音频的 voice conversion |

--- a/sure/skills/sure_onboard/references/task_playbooks/SPEECH_UNDERSTANDING.md
+++ b/sure/skills/sure_onboard/references/task_playbooks/SPEECH_UNDERSTANDING.md
@@ -456,7 +456,8 @@ KIMI_AUDIO_VALIDATE_TASKS=SLU sure/models/asr_kimi_audio/docker_validate_multita
 ## 9. VC / 集群运行
 
 完整五任务建议通过 VC 独占资源跑。先从 `vc info -u` 选择当前站点允许的
-partition，并通过环境变量显式传入：
+partition，并通过环境变量显式传入。`-pj` 的取值来自 site policy 的
+`execution.vc_project`，不要写死：
 
 ```bash
 env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy -u ALL_PROXY -u all_proxy \
@@ -465,7 +466,7 @@ vc submit \
   -i registry.example.com/sure/sure_asr_kimi_audio:v1.0 \
   -j kimi-audio-five-task \
   -n 1 -c 8 -m 32G -g 1 \
-  -pj sjtu \
+  -pj <vc_project> \
   -d <legacy-sure-eval-root>/sure/models/asr_kimi_audio \
   -e PYTHONPATH=<legacy-sure-eval-root>/src \
      KIMI_AUDIO_VALIDATE_TASKS=ASR,S2TT,SER,SLU,GR \

--- a/sure/skills/sure_onboard/schemas/deployment_ready.schema.json
+++ b/sure/skills/sure_onboard/schemas/deployment_ready.schema.json
@@ -7,6 +7,7 @@
 	"properties": {
 		"schema": { "const": "sure.onboard.deployment_ready.v1" },
 		"integrity_profile": { "enum": ["manifest-complete-v1", "partial-run-v1"] },
+		"weights_integrity": { "enum": ["bundled", "external"] },
 		"generated_at": { "type": "string" },
 		"status": { "enum": ["ready", "local_only", "api_ready", "blocked"] },
 		"model_name": { "type": "string" },

--- a/sure/skills/sure_onboard/schemas/deployment_ready_output.schema.json
+++ b/sure/skills/sure_onboard/schemas/deployment_ready_output.schema.json
@@ -7,6 +7,7 @@
 	"properties": {
 		"schema": { "enum": ["sure.onboard.deployment_ready.v1", "sure.onboard.deployment_ready.v2"] },
 		"integrity_profile": { "const": "manifest-complete-v1" },
+		"weights_integrity": { "enum": ["bundled", "external"] },
 		"generated_at": { "type": "string" },
 		"status": { "enum": ["ready", "local_only", "api_ready", "blocked"] },
 		"model_name": { "type": "string" },

--- a/sure/skills/sure_onboard/schemas/deployment_ready_v2.schema.json
+++ b/sure/skills/sure_onboard/schemas/deployment_ready_v2.schema.json
@@ -7,6 +7,7 @@
 	"properties": {
 		"schema": { "const": "sure.onboard.deployment_ready.v2" },
 		"integrity_profile": { "const": "manifest-complete-v1" },
+		"weights_integrity": { "enum": ["bundled", "external"] },
 		"generated_at": { "type": "string" },
 		"status": { "enum": ["ready", "local_only", "blocked"] },
 		"model_name": { "type": "string" },

--- a/sure/skills/sure_onboard/scripts/check_finalized_bundle.py
+++ b/sure/skills/sure_onboard/scripts/check_finalized_bundle.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -21,6 +22,9 @@ from deployment_contract import (
 sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
 from sure.runtime.model.bootstrap import ModelRuntimeError, manifest_sha256, verify_runtime
 from sure.site.loader import SitePolicyError, load_site_policy
+
+
+LEGACY_PATH = re.compile(r"/(?:mnt/cloudstorfs|hpc_stor\d+|hpc_\d+)/")
 
 
 def main() -> int:
@@ -162,6 +166,12 @@ def main() -> int:
             if runtime.get("manifest_sha256") != manifest_sha256(manifest):
                 raise ValueError("deployment Model Runtime manifest hash mismatch")
             verify_runtime(Path(configured["policy"]["storage"]["runtime_root"]) / "models", manifest)
+        portable = [
+            read_json(model_dir / "artifacts" / name)
+            for name in ("runtime_inventory.json", "package_gate.json", "artifact_manifest.json", "deployment_ready.json")
+        ]
+        if LEGACY_PATH.search(json.dumps(portable, ensure_ascii=False)):
+            raise ValueError("finalized deployment sidecars contain legacy host absolute paths")
     except (OSError, ValueError, ModelRuntimeError, SitePolicyError) as exc:
         print(f"FINALIZE_MODEL_BUNDLE failed: {exc}", file=sys.stderr)
         return 1

--- a/sure/skills/sure_onboard/scripts/check_package_gate.py
+++ b/sure/skills/sure_onboard/scripts/check_package_gate.py
@@ -213,16 +213,15 @@ def main() -> int:
     if not manifest_ok:
         print(f"PACKAGE_GATE failed: {manifest_message}", file=sys.stderr)
         return 1
-    if data.get("generated_at") or data.get("timestamp"):
-        try:
-            require_timestamp_after(
-                "package_gate.json",
-                data,
-                ("artifact_manifest.json", manifest_data),
-            )
-        except ValueError as exc:
-            print(f"PACKAGE_GATE failed: {exc}", file=sys.stderr)
-            return 1
+    try:
+        require_timestamp_after(
+            "package_gate.json",
+            data,
+            ("artifact_manifest.json", manifest_data),
+        )
+    except ValueError as exc:
+        print(f"PACKAGE_GATE failed: {exc}", file=sys.stderr)
+        return 1
 
     validation_ok, validation_message = validation_results_pass(run_dir, model_dir)
     if not validation_ok:

--- a/sure/skills/sure_onboard/scripts/check_runtime_inventory.py
+++ b/sure/skills/sure_onboard/scripts/check_runtime_inventory.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -22,6 +24,9 @@ from sure.runtime.model.bootstrap import ModelRuntimeError, manifest_sha256, ver
 from sure.site.loader import SitePolicyError, load_site_policy
 
 
+LEGACY_PATH = re.compile(r"/(?:mnt/cloudstorfs|hpc_stor\d+|hpc_\d+)/")
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--run-dir", required=True)
@@ -36,14 +41,11 @@ def main() -> int:
         if not model_copy.is_file() or model_copy.read_bytes() != path.read_bytes():
             raise ValueError("runtime_inventory.json must be copied identically into the model bundle")
         package = read_json(model_dir / "artifacts" / "package_gate.json")
-        if (data.get("generated_at") or data.get("timestamp")) and (
-            package.get("generated_at") or package.get("timestamp")
-        ):
-            require_timestamp_after(
-                "runtime_inventory.json",
-                data,
-                ("package_gate.json", package),
-            )
+        require_timestamp_after(
+            "runtime_inventory.json",
+            data,
+            ("package_gate.json", package),
+        )
         if data.get("schema") != "sure.onboard.runtime_inventory.v2":
             raise ValueError("runtime inventory schema must be sure.onboard.runtime_inventory.v2")
         policy = data.get("policy") if isinstance(data.get("policy"), dict) else {}
@@ -51,6 +53,8 @@ def main() -> int:
             raise ValueError("host Python fallback and image override must both be disabled")
         if policy.get("nfs_models_mutable_by_eval") is not False:
             raise ValueError("Eval must not mutate NFS model bundles")
+        if LEGACY_PATH.search(json.dumps(data, ensure_ascii=False)):
+            raise ValueError("runtime inventory contains a legacy host/staging absolute path")
         deployment_type = resolved.get("deployment_type")
         if deployment_type == "local" and resolved.get("package_profile") == "docker-registry":
             if data.get("status") != "ready" or policy.get("eval_runtime") != "container_only":

--- a/sure/skills/sure_onboard/scripts/check_verdict.py
+++ b/sure/skills/sure_onboard/scripts/check_verdict.py
@@ -226,21 +226,18 @@ def main() -> int:
                 file=sys.stderr,
             )
             return 1
-        if (data.get("generated_at") or data.get("timestamp")) and (
-            package_gate.get("generated_at") or package_gate.get("timestamp")
-        ):
-            runtime_path = run_dir / "artifacts" / "runtime_inventory.json"
-            try:
-                runtime_inventory = read_json(runtime_path)
-                require_timestamp_after(
-                    "verdict.json",
-                    data,
-                    ("package_gate.json", package_gate),
-                    ("runtime_inventory.json", runtime_inventory),
-                )
-            except (OSError, ValueError) as exc:
-                print(f"VERDICT gate: {exc}", file=sys.stderr)
-                return 1
+        runtime_path = run_dir / "artifacts" / "runtime_inventory.json"
+        try:
+            runtime_inventory = read_json(runtime_path)
+            require_timestamp_after(
+                "verdict.json",
+                data,
+                ("package_gate.json", package_gate),
+                ("runtime_inventory.json", runtime_inventory),
+            )
+        except (OSError, ValueError) as exc:
+            print(f"VERDICT gate: {exc}", file=sys.stderr)
+            return 1
 
     if status in SUCCESS_STATUSES:
         profile = package_profile(data, package_gate)

--- a/sure/skills/sure_onboard/scripts/finalize_model_bundle.py
+++ b/sure/skills/sure_onboard/scripts/finalize_model_bundle.py
@@ -102,6 +102,15 @@ def copy_selected_delivery_artifacts(run_dir: Path, model_dir: Path, resolved: d
 
 
 def resolve_weights_root(model_dir: Path, weights_manifest: dict[str, Any]) -> Path | None:
+    """Locate the model-local weights root, or None when the weights live outside.
+
+    check_weights.py allows weights to stay outside the bundle as long as the
+    manifest sets fallback_to_host_global with a reason, and sure_feed writes a
+    default local_dir_name for every model, so a missing model-local root is a
+    normal shape rather than an error. Such weights are not hashed into the
+    bundle identity; see weights_integrity.
+    """
+    external = bool(weights_manifest.get("fallback_to_host_global"))
     candidates = (
         ("local_dir_name", weights_manifest.get("local_dir_name")),
         ("checkpoint_root", weights_manifest.get("checkpoint_root")),
@@ -116,16 +125,24 @@ def resolve_weights_root(model_dir: Path, weights_manifest: dict[str, Any]) -> P
         candidate = value if value.is_absolute() else model_dir / value
         resolved = candidate.resolve()
         if resolved == model_dir.resolve() or not resolved.is_relative_to(model_dir.resolve()):
+            if external:
+                return None
             raise ValueError(f"weights {field} must resolve below the model bundle: {raw}")
         if not resolved.exists():
+            if external:
+                return None
             raise ValueError(f"weights {field} does not exist: {raw}")
         return resolved
-    if weights_manifest.get("required") is True:
+    if weights_manifest.get("required") is True and not external:
         raise ValueError(
             "required weights have no model-local root; declare local_dir_name, "
             "checkpoint_root, or resolved_local_model_path"
         )
     return None
+
+
+def weights_integrity(model_dir: Path, weights_manifest: dict[str, Any]) -> str:
+    return "bundled" if resolve_weights_root(model_dir, weights_manifest) is not None else "external"
 
 
 def update_manifest(model_dir: Path, resolved: dict[str, Any]) -> dict[str, Any]:
@@ -327,6 +344,9 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict[str, A
         "bundle_identity_sha256": bundle_identity,
         "execution_policy": execution_policy,
     }
+    weights_manifest_path = model_dir / "artifacts" / "weights_manifest.json"
+    if weights_manifest_path.is_file():
+        deployment["weights_integrity"] = weights_integrity(model_dir, read_json(weights_manifest_path))
     if python_delivery:
         deployment["model_runtime"] = model_runtime if status == "ready" else {}
     return deployment

--- a/sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py
+++ b/sure/skills/sure_onboard/scripts/test_docker_delivery_contract.py
@@ -9,11 +9,18 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
+import write_package_gate as write_package_gate_module
 from deployment_contract import document_timestamp, resolve_model_dir
-from finalize_model_bundle import ensure_safe_bundle_targets, finalize
-from write_package_gate import write_package_gate
+from finalize_model_bundle import (
+    ensure_safe_bundle_targets,
+    finalize,
+    resolve_weights_root,
+    weights_integrity,
+)
+from write_package_gate import build_package_gate, write_package_gate
 from write_runtime_inventory import write_inventory
 from write_verdict import write_verdict
 
@@ -204,22 +211,6 @@ class DockerDeliveryContractTests(unittest.TestCase):
         env["SURE_HARNESS_LOCK_SHA256"] = "c" * 64
         return env
 
-    def test_finalizer_rejects_a_symlinked_model_artifacts_directory(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            model_dir = root / "sure" / "models" / "demo"
-            outside = root / "outside"
-            model_dir.mkdir(parents=True)
-            outside.mkdir()
-            sentinel = outside / "keep.json"
-            sentinel.write_text("keep\n", encoding="utf-8")
-            (model_dir / "artifacts").symlink_to(outside, target_is_directory=True)
-
-            with self.assertRaises(ValueError):
-                ensure_safe_bundle_targets(model_dir, {"model_dir": str(model_dir)})
-
-            self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep\n")
-
     def test_shared_model_resolver_accepts_trans_input(self) -> None:
         (self.run_artifacts / "model_input_resolved.json").unlink()
         write_json(self.run_artifacts / "trans_input_resolved.json", self.resolved)
@@ -366,30 +357,95 @@ class DockerDeliveryContractTests(unittest.TestCase):
 
         self.validation["harness_runtime"]["runtime_root"] = "/opt/sure-harness/other"
         write_json(self.run_artifacts / "docker_validation.json", self.validation)
+        write_json(self.model_artifacts / "docker_validation.json", self.validation)
         with self.assertRaisesRegex(ValueError, "manifest_path"):
             finalize(self.run_dir, output)
 
-    def test_package_writer_uses_staged_model_evidence_instead_of_mutated_run_copy(self) -> None:
+    def test_package_gate_rejects_evidence_without_a_timestamp(self) -> None:
+        produces = self.run_artifacts / "package_gate.json"
+        write_json(
+            produces,
+            {
+                "schema": "sure.onboard.package_gate.v2",
+                "status": "passed",
+                "package_profile": "docker-registry",
+                "model_dir": ".",
+                "artifact_manifest_path": "artifacts/artifact_manifest.json",
+                "readiness": {
+                    "local_ready": True,
+                    "container_ready": True,
+                    "docker_ready": True,
+                    "registry_ready": True,
+                    "bundle_ready": True,
+                },
+            },
+        )
+
+        proc = self.run_script("check_package_gate.py", produces)
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("package_gate.json must declare generated_at or timestamp", proc.stderr)
+
+    def test_runtime_inventory_gate_rejects_evidence_without_a_timestamp(self) -> None:
+        write_json(
+            self.model_artifacts / "package_gate.json",
+            {"status": "passed", "generated_at": "2026-01-01T00:00:01+00:00"},
+        )
+        produces = self.run_artifacts / "runtime_inventory.json"
+        write_json(produces, {"schema": "sure.onboard.runtime_inventory.v2", "status": "ready"})
+        shutil.copy2(produces, self.model_artifacts / "runtime_inventory.json")
+
+        proc = self.run_script("check_runtime_inventory.py", produces)
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("runtime_inventory.json must declare generated_at or timestamp", proc.stderr)
+
+    def test_verdict_gate_rejects_evidence_without_a_timestamp(self) -> None:
         write_json(
             self.run_artifacts / "package_gate.json",
             {
                 "schema": "sure.onboard.package_gate.v2",
                 "status": "passed",
-                "generated_at": "2099-01-01T00:00:00+00:00",
+                "generated_at": "2026-01-01T00:00:01+00:00",
+                "package_profile": "docker-registry",
+                "readiness": {"local_ready": True, "bundle_ready": True},
             },
         )
         write_json(
-            self.run_artifacts / "infer_result.json",
-            {"infer_passed": False, "duration_ms": 1.0, "error": "real failure"},
+            self.run_artifacts / "runtime_inventory.json",
+            {"schema": "sure.onboard.runtime_inventory.v2", "generated_at": "2026-01-01T00:00:02+00:00"},
         )
-        package = write_package_gate(
-            self.run_dir,
-            self.run_artifacts / "package_gate.json",
-            self.model_dir,
+        produces = self.run_artifacts / "verdict.json"
+        write_json(
+            produces,
+            {
+                "status": "passed",
+                "phase": "verdict",
+                "instance_id": "demo__asr-onboard",
+                "package": {"profile": "docker-registry"},
+            },
         )
 
-        self.assertEqual(package["status"], "passed")
-        self.assertTrue(read_json(self.model_artifacts / "infer_result.json")["infer_passed"])
+        proc = self.run_script("check_verdict.py", produces)
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("verdict.json must declare generated_at or timestamp", proc.stderr)
+
+    def test_finalizer_rejects_a_symlinked_model_artifacts_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            model_dir = root / "sure" / "models" / "demo"
+            outside = root / "outside"
+            model_dir.mkdir(parents=True)
+            outside.mkdir()
+            sentinel = outside / "keep.json"
+            sentinel.write_text("keep\n", encoding="utf-8")
+            (model_dir / "artifacts").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaises(ValueError):
+                ensure_safe_bundle_targets(model_dir, {"model_dir": str(model_dir)})
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "keep\n")
 
     def test_finalized_gate_rejects_deployment_not_later_than_verdict(self) -> None:
         output = self.run_artifacts / "deployment_ready.json"
@@ -420,6 +476,26 @@ class DockerDeliveryContractTests(unittest.TestCase):
         deployment = finalize(self.run_dir, self.run_artifacts / "deployment_ready.json")
 
         self.assertIn("checkpoints/demo/weights.bin", deployment["required_artifact_sha256"])
+        self.assertEqual(deployment["weights_integrity"], "bundled")
+
+    def test_required_weights_declared_external_stay_out_of_the_bundle_identity(self) -> None:
+        weights = {
+            "required": True,
+            "weights_ready": True,
+            "status": "fetched",
+            "local_dir_name": "checkpoints",
+            "fallback_to_host_global": True,
+            "fallback_reason": "weights live in the shared ModelScope cache",
+        }
+        write_json(self.run_artifacts / "weights_manifest.json", weights)
+        write_json(self.model_artifacts / "weights_manifest.json", weights)
+
+        deployment = finalize(self.run_dir, self.run_artifacts / "deployment_ready.json")
+
+        self.assertEqual(deployment["weights_integrity"], "external")
+        self.assertFalse(
+            [path for path in deployment["required_artifact_sha256"] if path.startswith("checkpoints/")]
+        )
 
     def test_required_weights_without_model_local_root_block_finalize(self) -> None:
         weights = {"required": True, "weights_ready": True, "status": "fetched"}
@@ -428,6 +504,61 @@ class DockerDeliveryContractTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "required weights have no model-local root"):
             finalize(self.run_dir, self.run_artifacts / "deployment_ready.json")
+
+    def test_model_local_weights_root_is_bundled(self) -> None:
+        checkpoint_root = self.model_dir / "checkpoints" / "demo"
+        checkpoint_root.mkdir(parents=True)
+        (checkpoint_root / "weights.bin").write_bytes(b"weights")
+        weights = {"required": True, "checkpoint_root": str(checkpoint_root)}
+
+        self.assertEqual(resolve_weights_root(self.model_dir, weights), checkpoint_root.resolve())
+        self.assertEqual(weights_integrity(self.model_dir, weights), "bundled")
+
+    def test_weights_outside_the_bundle_are_external_when_the_manifest_says_so(self) -> None:
+        weights = {
+            "required": True,
+            "local_dir_name": "checkpoints",
+            "fallback_to_host_global": True,
+            "fallback_reason": "weights live in the shared ModelScope cache",
+        }
+
+        self.assertIsNone(resolve_weights_root(self.model_dir, weights))
+        self.assertEqual(weights_integrity(self.model_dir, weights), "external")
+
+    def test_required_weights_without_a_root_or_a_fallback_are_rejected(self) -> None:
+        weights = {"required": True, "weights_ready": True, "status": "fetched"}
+
+        with self.assertRaisesRegex(ValueError, "required weights have no model-local root"):
+            resolve_weights_root(self.model_dir, weights)
+
+    def test_package_writer_uses_staged_model_evidence_instead_of_mutated_run_copy(self) -> None:
+        write_json(
+            self.run_artifacts / "package_gate.json",
+            {
+                "schema": "sure.onboard.package_gate.v2",
+                "status": "passed",
+                "generated_at": "2099-01-01T00:00:00+00:00",
+            },
+        )
+        write_json(
+            self.run_artifacts / "infer_result.json",
+            {"infer_passed": False, "duration_ms": 1.0, "error": "real failure"},
+        )
+        package = write_package_gate(
+            self.run_dir,
+            self.run_artifacts / "package_gate.json",
+            self.model_dir,
+        )
+
+        self.assertEqual(package["status"], "passed")
+        self.assertTrue(read_json(self.model_artifacts / "infer_result.json")["infer_passed"])
+
+    def test_package_writer_refuses_a_short_circuited_evidence_check(self) -> None:
+        with unittest.mock.patch.object(
+            write_package_gate_module, "validate_local_evidence", return_value={}
+        ):
+            with self.assertRaisesRegex(ValueError, "local evidence was not fully checked"):
+                build_package_gate(self.run_dir, self.model_dir)
 
     def test_container_gate_rejects_harness_model_alias(self) -> None:
         self.validation["harness_runtime"]["python_executable"] = "python"

--- a/sure/skills/sure_onboard/scripts/write_package_gate.py
+++ b/sure/skills/sure_onboard/scripts/write_package_gate.py
@@ -29,6 +29,12 @@ STAGE_RESULTS = {
     "infer_result.json": "infer_passed",
     "contract_result.json": "contract_passed",
 }
+LOCAL_EVIDENCE_CHECKS = (
+    "build_env_result.json",
+    "env_compat_result.json",
+    *STAGE_RESULTS,
+    "sample_output.json",
+)
 CORE_FILES = ("model.spec.yaml", "model.py", "server.py", "__init__.py", "validate.py", "config.yaml")
 GENERATED_TERMINAL_PATHS = {
     "artifacts/package_gate.json",
@@ -69,20 +75,38 @@ def model_manifest(model_dir: Path) -> dict[str, Any]:
     return manifest
 
 
-def validate_local_evidence(run_dir: Path, model_dir: Path) -> None:
+def validate_local_evidence(run_dir: Path, model_dir: Path) -> dict[str, bool]:
+    """Check every staged local evidence file and report what was actually seen.
+
+    The caller derives readiness from the returned map, so a check that never
+    ran is missing from it rather than silently counting as a pass.
+    """
+    observed: dict[str, bool] = {}
     build_env = load_model_artifact(model_dir, "build_env_result.json")
     if build_env.get("env_ready") is not True:
         raise ValueError("build_env_result.json must prove env_ready=true")
+    observed["build_env_result.json"] = True
     env_compat = load_model_artifact(model_dir, "env_compat_result.json")
     if env_compat.get("compat_ok") is not True:
         raise ValueError("env_compat_result.json must prove compat_ok=true")
+    observed["env_compat_result.json"] = True
     for filename, pass_key in STAGE_RESULTS.items():
         result = load_model_artifact(model_dir, filename)
         if result.get(pass_key) is not True:
             raise ValueError(f"{filename} must prove {pass_key}=true")
+        observed[filename] = True
     sample = load_model_artifact(model_dir, "sample_output.json")
     if not sample:
         raise ValueError("sample_output.json must contain a non-empty JSON object")
+    observed["sample_output.json"] = True
+    return observed
+
+
+def local_readiness(observed: dict[str, bool]) -> bool:
+    missing = [name for name in LOCAL_EVIDENCE_CHECKS if name not in observed]
+    if missing:
+        raise ValueError("local evidence was not fully checked: " + ", ".join(missing))
+    return all(observed[name] for name in LOCAL_EVIDENCE_CHECKS)
 
 
 def validate_local_container(build: dict[str, Any], validation: dict[str, Any]) -> tuple[str, str, str]:
@@ -112,7 +136,7 @@ def build_package_gate(run_dir: Path, model_dir: Path) -> dict[str, Any]:
     missing_core = [name for name in CORE_FILES if not (model_dir / name).is_file()]
     if missing_core:
         raise ValueError("model bundle is missing core files: " + ", ".join(missing_core))
-    validate_local_evidence(run_dir, model_dir)
+    local_ready = local_readiness(validate_local_evidence(run_dir, model_dir))
 
     deployment_type = str(resolved.get("deployment_type") or "local")
     profile = str(resolved.get("package_profile") or "none")
@@ -171,12 +195,15 @@ def build_package_gate(run_dir: Path, model_dir: Path) -> dict[str, Any]:
             if runtime_manifest.get(key) is not None
         }
 
-    bundle_ready = deployment_type == "api" or (
-        deployment_type == "local"
-        and (profile == "none" or (profile == "docker-registry" and registry_ready))
+    bundle_ready = local_ready and (
+        deployment_type == "api"
+        or (
+            deployment_type == "local"
+            and (profile == "none" or (profile == "docker-registry" and registry_ready))
+        )
     )
     readiness = {
-        "local_ready": True,
+        "local_ready": local_ready,
         "container_ready": container_ready,
         "docker_ready": docker_ready,
         "registry_ready": registry_ready,
@@ -186,12 +213,12 @@ def build_package_gate(run_dir: Path, model_dir: Path) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "schema": "sure.onboard.package_gate.v2",
         "generated_at": timestamp_after(("artifact_manifest.json", manifest)),
-        "status": "passed",
+        "status": "passed" if local_ready else "failed",
         "package_profile": profile,
         "model_dir": ".",
         "artifact_manifest_path": "artifacts/artifact_manifest.json",
         "readiness": readiness,
-        "local": {"validation_passed": True, "artifacts_complete": True},
+        "local": {"validation_passed": local_ready, "artifacts_complete": True},
         "bundle": {},
         "notes": "Generated from validated onboard artifacts by write_package_gate.py.",
     }

--- a/sure/skills/sure_trans/SKILL.md
+++ b/sure/skills/sure_trans/SKILL.md
@@ -22,11 +22,11 @@ Convert an existing model delivery into the same Eval-ready contract produced by
 | `model_name` | yes | Must use `<organization>__<model-name>`; all bundle and image names use this value. |
 | `task_type` | no | Infer from evidence; require an explicit value when ambiguous. |
 | `fixture` | no | Absolute smoke input path. A same-stem `.expected.json` with a non-empty reference annotation is required; otherwise select an unambiguous `examples/smoke.*` file from the build context. |
-| `device` | no | `auto` (default), `cuda`, or `cpu`. `cpu` validates with local Docker only; `cuda` and GPU-capable `auto` submit VC jobs to the configured partition `<vc_default_partition>`. |
+| `device` | no | `auto` (default), `cuda`, or `cpu`. `cpu` validates with local Docker only; `cuda` and GPU-capable `auto` submit VC jobs to the dedicated partition `<vc_default_partition>`. |
 | `model_mount_target` | no | Default to `/models/<model_name>`. |
 | `model_stage_policy` | no | `auto` (default), `copy`, or `hardlink`; materialize the model payload into the final bundle. |
 | `vc_partition` | no | VC partition for GPU validation; default and site requirement `<vc_default_partition>`. |
-| `vc_memory_gb` | no | VC memory request in GiB; default 32. The backend validates it against project and partition policy. |
+| `vc_memory_gb` | no | VC memory request in GiB; default 32. `<vc_default_partition>` caps each GPU at 32 GiB, so do not exceed it there. |
 | `vc_gpus` | no | VC GPU count; default 1. |
 | `image_version` | no | Explicit tag override for the site-resolved target repository. When omitted, query both resolved source and adapter repositories, find the highest `major.minor.patch` tag, and select the next unused patch version; an empty repository starts at `0.1.0`. |
 | `max_retries` | no | Default 3. |
@@ -140,8 +140,8 @@ Static analysis is evidence, not proof. Build the source image, create `executio
 Execution surfaces split by device:
 
 - `device=cpu`: the probe runs in local Docker without `--gpus`; `execution_surface=local_docker`.
-- `device=cuda` or GPU-capable `auto`: the gate pushes the source image to `trans_input_resolved.json.container_delivery.source_image` and submits the probe through `vc submit` on `<vc_default_partition>` under `execution.vc_project`; `execution_surface=vc` with `vc_partition`, `vc_job_id`, `vc_memory_gb`, `vc_gpus`, and `vc_submit_command` recorded.
-- `auto` with a model that does not require CUDA falls back to a local CPU probe only after the VC CUDA probe fails or times out; the fallback evidence is recorded in `fallback` and `execution_surface` stays `vc`. When `vc` is unavailable, the partition is outside `execution.vc_partitions`, or the backend rejects submission, the gate blocks with a clear repair instead of silently falling back.
+- `device=cuda` or GPU-capable `auto`: the gate pushes the source image to `trans_input_resolved.json.container_delivery.source_image` and submits the probe through `vc submit` on `<vc_default_partition>`; `execution_surface=vc` with `vc_partition`, `vc_job_id`, `vc_memory_gb`, `vc_gpus`, and `vc_submit_command` recorded.
+- `auto` with a model that does not require CUDA falls back to a local CPU probe only after the VC CUDA probe fails or times out; the fallback evidence is recorded in `fallback` and `execution_surface` stays `vc`. When `vc` is unavailable or the partition is not permitted, the gate blocks with a clear repair instead of silently falling back.
 
 For original and adapter smoke units, write the stage artifact with a real `run_command`. The original inference and adapter inference artifacts also need `input`, the staged fixture the command consumes (`staged_path` from `fixture_manifest.json`), and the MCP artifact needs `tool_name`, the tool the adapter exposes. The gate executes the command through `run_trans_validate.py`, captures stdout/stderr and exit status, and only then writes the matching pass field. A manually written `status=passed` is not sufficient. A required field the artifact omits blocks the unit and spends a retry before the command ever runs, so write them all in one go.
 
@@ -206,7 +206,7 @@ Automatic selection is advisory until the immutable push succeeds: another run c
 
 ## VC Execution
 
-`<vc_default_partition>`, `execution.vc_project`, and the source/target image repositories are policy values, not constants. Repositories are resolved from `network.container_registry` plus `container_delivery.repository_template` in `config/site.bundled.yaml` (or `config/site.local.yaml`) and persisted in `trans_input_resolved.json`. Read policy with `npm run sure:site-info`; never hardcode a deployment value in this skill.
+`<vc_default_partition>`, `execution.vc_project`, and the source/target image repositories are site policy values, not constants. Repositories are resolved from `network.container_registry` plus `container_delivery.repository_template` in `config/site.bundled.yaml` (or `config/site.local.yaml`) and persisted in `trans_input_resolved.json`. Read policy with `npm run sure:site-info`; never hardcode a site value in this skill.
 
 GPU-touching work never runs `docker run --gpus all` on the login node. Gates submit to `<vc_default_partition>` through `scripts/vc_exec.py`; the same CLI drives the unit 17 post-pull MCP smoke:
 
@@ -223,24 +223,22 @@ GPU-touching work never runs `docker run --gpus all` on the login node. Gates su
   --produces <run_dir>/artifacts/vc_logs/post_pull_smoke.json
 ```
 
-- This VC backend accepts `repo:tag` but not `repo@sha256:...` for job submission. Submit the tag and pass `--expect-digest`; `vc_exec.py` pulls the tag, reads back the manifest digest the registry serves for it, and refuses to submit when it is not the pinned one. It records `image_ref` and `resolved_digest`, which is what the registry gate checks against `target_image_digest`. Copy both into `docker_registry_result.json` under `post_pull_smoke`. Never hand a digest-pinned reference to `vc submit`, and never write `resolved_digest` by hand.
+- `vc submit` takes `repo:tag` only: it answers `镜像不存在` to every `repo@sha256:...` reference, however well that digest pulls with docker. Submit the tag and pass `--expect-digest`; `vc_exec.py` pulls the tag, reads back the manifest digest the registry serves for it, and refuses to submit when it is not the pinned one. It records `image_ref` and `resolved_digest`, which is what the registry gate checks against `target_image_digest`. Copy both into `docker_registry_result.json` under `post_pull_smoke`. Never hand a digest-pinned reference to `vc submit`, and never write `resolved_digest` by hand.
 - Defaults: 1 GPU, 32 GiB, 8 CPUs, 1800 s poll timeout. `vc_memory_gb` and `vc_gpus` from the slash command override the memory/GPU defaults; the partition defaults to `<vc_default_partition>`.
 - Every submitted job wraps its container command in `timeout --kill-after=15 <seconds>` (default 1200 s, `--command-timeout-seconds` on the CLI). A hung command is killed and still writes `exit_code` (124), so the submit host never waits for a file that will never appear; exit 124 surfaces a targeted repair.
 - Never submit a raw `vc submit` and then hand-roll `sleep`/`while` polling loops in bash. Re-running a job always goes through `scripts/vc_exec.py`, which polls the `exit_code` file internally and records `vc info --job` / `vc logs` diagnostics.
-- Mount preparation is deterministic: the gate creates missing bind-mount host sources as the submitting user before `vc submit` (a backend-created source may use a service identity that the job cannot write); a missing `:ro` source blocks, and an existing unwritable directory blocks with a repair telling the agent to recreate the empty scratch dir or point the mount at a user-owned path. Job-side `Permission denied` on an output mount surfaces the same repair.
-- `vc submit` receives the required project from `execution.vc_project`. The standalone CLI may override it explicitly with `--project`; omitted values always resolve from policy.
-- `execution.vc_partitions` is the deterministic pre-submit allowlist. Backend authorization, project validity, capacity, and admission policy remain authoritative in the `vc submit` result; do not infer them from `vc info -u`.
+- Mount preparation is deterministic: the gate creates missing bind-mount host sources as the submitting user before `vc submit` (the vc platform would otherwise create them as `nobody`, which the job uid cannot write); a missing `:ro` source blocks, and an existing unwritable directory blocks with a repair telling the agent to recreate the empty scratch dir or point the mount at a user-owned path. Job-side `Permission denied` on an output mount surfaces the same repair.
+- `vc submit` requires the quota project; the gates pass the `execution.vc_project` value from site policy automatically (override with `--project` on the CLI).
 - Job evidence lands under `artifacts/vc_logs/<stage>/`: `inner.sh`, `stdout.log`, `stderr.log`, `exit_code`, `vc_job.log`. Push logs live at `artifacts/vc_logs/source_push.log` and `adapter_push.log`.
 - The submit host polls the `exit_code` file written by the in-job wrapper; `vc info --job` and `vc logs` output is diagnostic evidence only.
 - Never submit real VC jobs outside this skill's gates or a `/sure_trans` run the user started.
 
 Memory sizing is enforced deterministically:
 
-- Before submitting a model-loading validation (original inference, load,
-  infer, contract, MCP, equivalence), the gate compares the payload size with
-  2x loading headroom against `vc_memory_gb` and reports the minimum required
-  request. Adjust `vc_gpus` only when the backend's scheduling policy requires
-  it for that memory request.
+- `<vc_default_partition>` caps 32 GiB RAM per GPU. Before submitting a model-loading
+  validation (original inference, load, infer, contract, MCP, equivalence), the
+  gate compares the payload size with 2x loading headroom against
+  `vc_memory_gb` and blocks with the exact fix (`vc_gpus=2 vc_memory_gb=64`).
 - When a job fails with exit 137 / `OOMKilled` / `std::bad_alloc` / `Killed`,
   the gate repairs with the RAM sizing fix. A `CUDA out of memory` failure is
   confirmed from a non-zero exit code plus the OOM evidence, in the job log or
@@ -281,9 +279,9 @@ Write a successful `verdict.json`, then run:
 "$HARNESS_PYTHON_BIN" scripts/finalize_trans_bundle.py --run-dir <run_dir>
 ```
 
-This seals the already-staged model payload, adapter, and small evidence under `sure/models/<model_name>/`. The sealed bundle matches the `/sure_onboard` product layout: wrapper set plus `Dockerfile.sure` at the bundle root, `fixture/<task>/` with `gt.jsonl`, and `artifacts/` carrying `package_gate.json` (`sure.onboard.package_gate.v2`), `artifact_manifest.json` (`sure.onboard.artifact_manifest.v1`), `runtime_inventory.json`, `verdict.json`, `docker_registry_result.json`, and `deployment_ready.json` (`sure.onboard.deployment_ready.v1`, written identically to the run directory). Ready bundles declare `integrity_profile=manifest-complete-v1`; the deployment hashes cover every required wrapper, fixture, evidence file, generated sample output, and staged payload file. The terminal gate re-verifies the payload manifest, terminal timeline, hashes, bundle identity, portable paths, Dockerfile hash, and digest-pinned execution policy.
+This seals the already-staged model payload, adapter, and small evidence under `sure/models/<model_name>/`. The sealed bundle matches the `/sure_onboard` product layout: wrapper set plus `Dockerfile.sure` at the bundle root, `fixture/<task>/` with `gt.jsonl`, and `artifacts/` carrying `package_gate.json` (`sure.onboard.package_gate.v2`), `artifact_manifest.json` (`sure.onboard.artifact_manifest.v1`), `runtime_inventory.json`, `verdict.json`, `docker_registry_result.json`, and `deployment_ready.json` (`sure.onboard.deployment_ready.v1`, written identically to the run directory). Ready bundles declare `integrity_profile=manifest-complete-v1` and `weights_integrity=bundled`; the deployment hashes cover every required wrapper, fixture, evidence file, generated sample output, and staged payload file. The terminal gate re-verifies the payload manifest, terminal timeline, hashes, bundle identity, portable paths, Dockerfile hash, and digest-pinned execution policy.
 
-The generated `validate.py` keeps the same CLI contract as `/sure_onboard`: `--stage import|load|infer|contract|all`, writing `<stage>_result.json` and, during infer, `sample_output.json` into `SURE_VALIDATE_ARTIFACTS_DIR`, then validating that sample against the filled `io_contract` in the contract stage — from the same directory. The adapter image embeds the locked Harness Runtime; `runtime_inventory.harness_runtime.required=true`, so `/sure_eval` uses the image binding and does not mount the repository Harness Runtime into the model container.
+The generated `validate.py` keeps the same CLI contract as `/sure_onboard`: `--stage import|load|infer|contract|all`, writing `<stage>_result.json` and, during infer, `sample_output.json` into `SURE_VALIDATE_ARTIFACTS_DIR`, then validating that sample against the filled `io_contract` in the contract stage — from the same directory. For `tts` and `vc`, the generated audio that `sample_output.audio_path` points at must be written below `$SURE_VALIDATE_ARTIFACTS_DIR/outputs`, because finalization only promotes generated audio from there into the bundle. The adapter image embeds the locked Harness Runtime; `runtime_inventory.harness_runtime.required=true`, so `/sure_eval` uses the image binding and does not mount the repository Harness Runtime into the model container.
 
 After completion, run evaluation locally or through VC without changing the model protocol:
 
@@ -325,9 +323,9 @@ what you recorded.
 - Block when the primary computation framework is not PyTorch.
 - Block when the adapter reloads a large model for every sample without explicit acceptance.
 - Block when MCP output differs from original inference on the fixture: the equivalence gate compares the two recorded output files itself and fails on a mismatch even when the command exited 0.
-- Block when the MCP gate has no `mcp_smoke.json` protocol evidence (initialize/tools/list/tools/call all passed with a non-empty task primary output); placeholder `run_command` values such as `/bin/true` or `print(...)` are rejected.
+- Block when the MCP gate has no `mcp_smoke.json` protocol evidence (initialize/tools/list/tools/call all passed with a non-empty task primary output; a `*_path` output must name a file the smoke can stat); placeholder `run_command` values such as `/bin/true` or `print(...)` are rejected.
 - Block when registry push, digest resolution, exact pull, or post-pull MCP validation fails.
-- Block when `vc submit` fails, the partition is outside the configured allowlist, the GPU probe cannot complete, or the post-pull smoke does not exit 0.
+- Block when `vc submit` fails, the partition is not permitted, the GPU probe cannot complete, or the post-pull smoke does not exit 0.
 - Block when the model payload exceeds the RAM budget (2x headroom) of `vc_memory_gb`; raise `vc_gpus`/`vc_memory_gb` instead of trimming validation.
 - Stop after `max_retries` changed-artifact failures; unchanged artifacts do not consume another retry.
 - `extract_lessons` is the one unit that never stops the run: `check_memory_extraction.py` checks the declaration and every candidate directory (shape, evidence paths, triggers, duplicates, digest sha), and after two consecutive failures the hook advances by itself and records `extraction: failed`. Changing a candidate re-runs that gate even when `extraction_declaration.json` did not change.

--- a/sure/skills/sure_trans/schemas/deployment_ready.schema.json
+++ b/sure/skills/sure_trans/schemas/deployment_ready.schema.json
@@ -8,6 +8,7 @@
 	"properties": {
 		"schema": { "const": "sure.onboard.deployment_ready.v1" },
 		"integrity_profile": { "enum": ["manifest-complete-v1", "partial-run-v1"] },
+		"weights_integrity": { "enum": ["bundled", "external"] },
 		"generated_at": { "type": "string" },
 		"status": { "enum": ["ready", "blocked"] },
 		"blocked_reason": { "type": "string" },

--- a/sure/skills/sure_trans/scripts/check_artifact.py
+++ b/sure/skills/sure_trans/scripts/check_artifact.py
@@ -13,6 +13,7 @@ import yaml
 from vc_exec import default_partition
 
 
+LEGACY_PATH = re.compile(r"/(?:mnt/cloudstorfs|hpc_stor\d+|hpc_\d+)/")
 ANNOTATION_FIELDS = ("ground_truth", "target_text", "text", "segments", "label", "intent")
 TRANS_RESERVED_ROOTS = {
     "model.py",
@@ -47,13 +48,13 @@ def read_object(path: Path) -> dict:
     return value
 
 
-def require_container_harness_paths(harness: dict) -> None:
-    root = PurePosixPath(str(harness.get("runtime_root") or ""))
-    manifest = PurePosixPath(str(harness.get("manifest_path") or ""))
-    python = PurePosixPath(str(harness.get("python_executable") or ""))
-    require(root.is_absolute(), "container Harness Runtime runtime_root must be absolute")
-    require(manifest.is_absolute() and manifest.parent == root, "container Harness Runtime manifest_path must be directly under runtime_root")
-    require(python.is_absolute() and python.is_relative_to(root), "container Harness Runtime python_executable must stay under runtime_root")
+def artifact_time(value: dict, label: str) -> datetime:
+    raw = value.get("generated_at") or value.get("timestamp")
+    require(isinstance(raw, str) and bool(raw.strip()), f"{label} must record generated_at or timestamp")
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(f"{label} timestamp is invalid: {raw}") from error
 
 
 def has_annotation_value(value: object) -> bool:
@@ -62,15 +63,6 @@ def has_annotation_value(value: object) -> bool:
     if isinstance(value, list):
         return bool(value)
     return value is not None
-
-
-def artifact_time(value: dict, label: str) -> datetime:
-    raw = value.get("generated_at") or value.get("timestamp")
-    require(isinstance(raw, str) and bool(raw.strip()), f"{label} must record generated_at or timestamp")
-    try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except ValueError as error:
-        raise ValueError(f"{label} timestamp is invalid: {raw}") from error
 
 
 def validate_fixture_manifest(value: dict) -> None:
@@ -277,11 +269,12 @@ def main() -> int:
             expected_partition = default_partition()
             require(
                 smoke.get("vc_partition") == expected_partition,
-                f"post-pull MCP smoke must run on the configured partition {expected_partition}",
+                f"post-pull MCP smoke must run on the site's dedicated partition {expected_partition}",
             )
-            # This VC backend accepts repo:tag but not repo@sha256:... for job
-            # submission, so the job cannot carry the pin in the reference it
-            # runs. The submission proves the pin instead: vc_exec.py resolves
+            # vc submit takes repo:tag only and answers 镜像不存在 to any
+            # repo@sha256:... reference, so the job cannot carry the pin in the
+            # reference it runs. Requiring that made this unit unsatisfiable on
+            # GPU. The submission proves the pin instead: vc_exec.py resolves
             # what the tag serves and refuses to submit on a mismatch.
             require(
                 str(smoke.get("resolved_digest", "")) == str(value.get("target_image_digest", "")),
@@ -496,7 +489,10 @@ def main() -> int:
             all(harness.get(key) for key in ("runtime_id", "lock_sha256", "python_executable", "manifest_path", "runtime_root")),
             "required Harness Runtime binding is missing identity or path fields",
         )
-        require_container_harness_paths(harness)
+        require(
+            not LEGACY_PATH.search(json.dumps(harness, ensure_ascii=False)),
+            "host Harness Runtime paths cannot be declared as the container runtime",
+        )
         mount_policy = container.get("mount_policy") or {}
         require((mount_policy.get("model_bundle") or {}).get("read_only") is True, "model bundle mount must be read-only")
         require((mount_policy.get("result_workspace") or {}).get("read_only") is False, "result workspace mount must be writable")
@@ -607,7 +603,18 @@ def main() -> int:
                 declared_binding.get("schema") == "sure.harness.runtime.binding.v1" and declared_binding.get("runtime_id"),
                 "ready deployment must expose the common Harness Runtime binding",
             )
-            require_container_harness_paths(declared_binding)
+            require(
+                not LEGACY_PATH.search(json.dumps(declared_binding, ensure_ascii=False)),
+                "deployment Harness Runtime binding must reference an in-image runtime, not host paths",
+            )
+        portable = [
+            read_object(model_dir / "artifacts" / name)
+            for name in ("runtime_inventory.json", "package_gate.json", "artifact_manifest.json", "deployment_ready.json")
+        ]
+        require(
+            not LEGACY_PATH.search(json.dumps(portable, ensure_ascii=False)),
+            "finalized deployment sidecars contain legacy host absolute paths",
+        )
     print(f"{kind} OK: {path}")
     return 0
 

--- a/sure/skills/sure_trans/scripts/finalize_trans_bundle.py
+++ b/sure/skills/sure_trans/scripts/finalize_trans_bundle.py
@@ -226,7 +226,6 @@ def stage_fixture(run_dir: Path, model_dir: Path, resolved: dict) -> None:
     annotation_source = dict(fixture_manifest["annotation_source"])
     annotation_source["staged_path"] = str(expected_destination)
     annotation_source["bundled_path"] = str(expected_destination)
-    gt_jsonl = fixture_dir / "gt.jsonl"
     finalized_manifest = {
         **fixture_manifest,
         "model_id": resolved["model_name"],
@@ -404,7 +403,7 @@ def write_package_gate(run_dir: Path, model_dir: Path, registry: dict) -> dict:
     return package
 
 
-def write_artifact_manifest(run_dir: Path, model_dir: Path, resolved: dict, *, status: str) -> dict:
+def write_artifact_manifest(run_dir: Path, model_dir: Path, resolved: dict) -> dict:
     required = {
         name.replace(".", "_").replace("-", "_"): {
             "path": name,
@@ -465,8 +464,8 @@ def write_artifact_manifest(run_dir: Path, model_dir: Path, resolved: dict, *, s
         "model_dir": ".",
         "model_id": resolved["model_name"],
         "model_name": resolved["model_name"],
-        "phase": "deployment_ready" if status == "finalized" else "local_onboard",
-        "status": status,
+        "phase": "deployment_ready",
+        "status": "finalized",
         "generated_at": now_iso(),
         "timestamp": now_iso(),
         "artifacts": {"required": required, "conditional": {}, "optional": {}},
@@ -477,31 +476,6 @@ def write_artifact_manifest(run_dir: Path, model_dir: Path, resolved: dict, *, s
     write_identical(path, content)
     write_identical(run_dir / "artifacts" / "artifact_manifest.json", content)
     return manifest
-
-
-def regenerate_terminal_evidence(run_dir: Path) -> None:
-    scripts = Path(__file__).resolve().parent
-    prior_inventory = read_object(run_dir / "artifacts" / "runtime_inventory.json")
-    container = prior_inventory.get("container_runtime") if isinstance(prior_inventory.get("container_runtime"), dict) else {}
-    inventory_command = [
-        sys.executable,
-        str(scripts / "write_runtime_inventory.py"),
-        "--run-dir",
-        str(run_dir),
-        "--gpu-required" if container.get("gpu_required") is True else "--no-gpu-required",
-    ]
-    commands = [
-        [sys.executable, str(scripts / "check_artifact.py"), "--run-dir", str(run_dir), "--produces", str(run_dir / "artifacts" / "model_payload_manifest.json"), "--kind", "model_payload"],
-        inventory_command,
-        [sys.executable, str(scripts / "check_artifact.py"), "--run-dir", str(run_dir), "--produces", str(run_dir / "artifacts" / "runtime_inventory.json"), "--kind", "runtime_inventory"],
-        [sys.executable, str(scripts / "write_verdict.py"), "--run-dir", str(run_dir)],
-        [sys.executable, str(scripts / "check_artifact.py"), "--run-dir", str(run_dir), "--produces", str(run_dir / "artifacts" / "verdict.json"), "--kind", "verdict"],
-    ]
-    for command in commands:
-        completed = subprocess.run(command, check=False, capture_output=True, text=True)
-        if completed.returncode != 0:
-            detail = completed.stderr.strip() or completed.stdout.strip()
-            raise ValueError(f"terminal evidence regeneration failed: {detail}")
 
 
 def finalized_hashes(model_dir: Path) -> dict[str, str]:
@@ -526,6 +500,38 @@ def finalized_hashes(model_dir: Path) -> dict[str, str]:
     return hashes
 
 
+def regenerate_terminal_evidence(run_dir: Path) -> None:
+    """Rewrite the inventory and verdict so the terminal timeline is ordered.
+
+    The bundle they describe is only complete once the wrapper, fixture and
+    payload are staged, so evidence written before that has an earlier
+    timestamp than the manifest it is supposed to follow. Rerun the writers
+    and their gates on the sealed bundle instead of trusting the run copies.
+    """
+    scripts = Path(__file__).resolve().parent
+    prior_inventory = read_object(run_dir / "artifacts" / "runtime_inventory.json")
+    container = prior_inventory.get("container_runtime") if isinstance(prior_inventory.get("container_runtime"), dict) else {}
+    inventory_command = [
+        sys.executable,
+        str(scripts / "write_runtime_inventory.py"),
+        "--run-dir",
+        str(run_dir),
+        "--gpu-required" if container.get("gpu_required") is True else "--no-gpu-required",
+    ]
+    commands = [
+        [sys.executable, str(scripts / "check_artifact.py"), "--run-dir", str(run_dir), "--produces", str(run_dir / "artifacts" / "model_payload_manifest.json"), "--kind", "model_payload"],
+        inventory_command,
+        [sys.executable, str(scripts / "check_artifact.py"), "--run-dir", str(run_dir), "--produces", str(run_dir / "artifacts" / "runtime_inventory.json"), "--kind", "runtime_inventory"],
+        [sys.executable, str(scripts / "write_verdict.py"), "--run-dir", str(run_dir)],
+        [sys.executable, str(scripts / "check_artifact.py"), "--run-dir", str(run_dir), "--produces", str(run_dir / "artifacts" / "verdict.json"), "--kind", "verdict"],
+    ]
+    for command in commands:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise ValueError(f"terminal evidence regeneration failed: {detail}")
+
+
 def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict, registry: dict, package: dict) -> dict:
     inventory = read_object(model_dir / "artifacts" / "runtime_inventory.json")
     verdict = read_object(model_dir / "artifacts" / "verdict.json")
@@ -543,6 +549,9 @@ def build_deployment_ready(run_dir: Path, model_dir: Path, resolved: dict, regis
     deployment = {
         "schema": "sure.onboard.deployment_ready.v1",
         "integrity_profile": "manifest-complete-v1",
+        # A trans payload is always copied into the bundle, so every weight
+        # file is covered by required_artifact_sha256.
+        "weights_integrity": "bundled",
         "generated_at": now_iso(),
         "status": "ready",
         "model_name": str(resolved["model_name"]),
@@ -644,7 +653,7 @@ def main() -> int:
     stage_fixture(run_dir, model_dir, resolved)
     promote_sample_output(run_dir)
     stage_artifacts(run_dir, model_dir)
-    write_artifact_manifest(run_dir, model_dir, resolved, status="finalized")
+    write_artifact_manifest(run_dir, model_dir, resolved)
     package = write_package_gate(run_dir, model_dir, registry)
     regenerate_terminal_evidence(run_dir)
     stage_artifacts(run_dir, model_dir)

--- a/sure/skills/sure_trans/scripts/mcp_smoke.py
+++ b/sure/skills/sure_trans/scripts/mcp_smoke.py
@@ -42,6 +42,21 @@ def primary_output_field(tool: str) -> str:
     return "audio_path" if tool in {"synthesize_speech", "convert_voice"} else "text"
 
 
+def output_is_nonempty(primary_field: str, value: str) -> bool:
+    """Whether the tool really produced its primary output.
+
+    A path-valued field only proves an output exists if the file is there and
+    holds bytes; the server runs as this script's child, so the path it
+    returns is one this process can stat.
+    """
+    if not value:
+        return False
+    if primary_field.endswith("_path"):
+        candidate = Path(value)
+        return candidate.is_file() and candidate.stat().st_size > 0
+    return True
+
+
 def _read_line(fd: int, buffer: bytearray, deadline: float) -> str | None:
     """Read one line from fd before deadline; None on timeout or EOF."""
     while True:
@@ -192,11 +207,12 @@ def main() -> int:
         primary_value = ""
         if isinstance(text, dict):
             primary_value = str(text.get(primary_field) or "")
+        output_nonempty = output_is_nonempty(primary_field, primary_value)
         steps["tools_call"] = {
-            "ok": ok and bool(primary_value),
+            "ok": ok and output_nonempty,
             "primary_field": primary_field,
-            "output_nonempty": bool(primary_value),
-            "text_nonempty": bool(primary_value) if primary_field == "text" else False,
+            "output_nonempty": output_nonempty,
+            "text_nonempty": output_nonempty if primary_field == "text" else False,
             primary_field: primary_value[:500],
         }
         if not steps["tools_call"]["ok"]:

--- a/sure/skills/sure_trans/scripts/prepare_fixture.py
+++ b/sure/skills/sure_trans/scripts/prepare_fixture.py
@@ -104,16 +104,21 @@ def main() -> int:
         raise ValueError(
             f"fixture reference annotation has no non-empty supported field: {expected_source}"
         )
+    # prompt_text is a TTS input, not a label: the fixture gate recomputes
+    # annotation_fields from ANNOTATION_FIELDS and compares it with what the
+    # sample declares, so listing prompt_text there fails every TTS fixture.
+    annotation_fields = list(annotations)
+    gt_extras: dict[str, object] = {}
     if task == "tts":
         prompt_text = expected.get("prompt_text")
         if not isinstance(prompt_text, str) or not prompt_text.strip():
             raise ValueError(f"TTS fixture annotation requires non-empty prompt_text: {expected_source}")
-        annotations["prompt_text"] = prompt_text.strip()
+        gt_extras["prompt_text"] = prompt_text.strip()
     expected_destination = staged_dir / expected_source.name
     shutil.copy2(expected_source, expected_destination)
     gt_jsonl = staged_dir / "gt.jsonl"
     audio_field = "reference_audio" if task in {"tts", "vc"} else "audio"
-    gt_row = {audio_field: source.name, "task_type": task, **annotations}
+    gt_row = {audio_field: source.name, "task_type": task, **annotations, **gt_extras}
     gt_jsonl.write_text(json.dumps(gt_row, ensure_ascii=False) + "\n", encoding="utf-8")
     payload = {
         "schema": "sure.trans.fixture_manifest.v1",
@@ -130,7 +135,7 @@ def main() -> int:
                 "key": source.stem,
                 "audio": source.name,
                 "audio_path": str(destination),
-                "annotation_fields": list(annotations),
+                "annotation_fields": annotation_fields,
             }
         ],
         "source_path": str(source),

--- a/sure/skills/sure_trans/scripts/pyproject.toml
+++ b/sure/skills/sure_trans/scripts/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "sure-trans-backend"
+version = "0.1.0"
+description = "Model transformation backend bundled inside the sure_trans skill package."
+requires-python = ">=3.10"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[tool.uv]
+# The gate scripts are otherwise standard library only. check_artifact.py
+# parses the generated adapter config.yaml, which is the single reason pyyaml
+# is here; torch and the model dependencies belong to the model-local env.

--- a/sure/skills/sure_trans/scripts/run_trans_validate.py
+++ b/sure/skills/sure_trans/scripts/run_trans_validate.py
@@ -377,8 +377,8 @@ def run_vc_validation(
         raise ValueError(
             f"model payload is {payload_bytes / GIB:.1f} GiB; with {RAM_SAFETY_FACTOR}x loading "
             f"headroom the job needs about {required_gb} GiB RAM but vc_memory_gb={memory_gb} "
-            f"is configured. Set vc_memory_gb to at least {required_gb} and adjust vc_gpus if "
-            f"required by scheduler policy, then rerun the gate."
+            f"(the partition caps 32 GiB per GPU). Set vc_gpus=2 vc_memory_gb=64 in the slash "
+            f"command or trans_input_resolved.json, then rerun the gate."
         )
     log_dir = run_dir / "artifacts" / "vc_logs" / kind
     attempts: list[dict[str, object]] = []

--- a/sure/skills/sure_trans/scripts/scaffold_adapter.py
+++ b/sure/skills/sure_trans/scripts/scaffold_adapter.py
@@ -97,27 +97,39 @@ def image_carries_runtime(data: dict, harness: dict[str, str]) -> bool:
     )
 
 
+def probe_source_python(reference: str, executable: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            executable,
+            reference,
+            "-c",
+            "import sys; print(sys.executable)",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
 def container_python_executable(reference: str) -> str:
     """Resolve the Python that the source image actually executes from PATH."""
     if not reference:
         raise ValueError("source image has no usable image reference")
     try:
-        probe = subprocess.run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--entrypoint",
-                "python",
-                reference,
-                "-c",
-                "import sys; print(sys.executable)",
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
+        probe = probe_source_python(reference, "python")
+        # An image that ships only python3 has no python on PATH; docker
+        # reports that as exit 127 before the interpreter ever runs.
+        if probe.returncode == 127 or "executable file not found" in probe.stderr.lower():
+            probe = probe_source_python(reference, "python3")
+    except FileNotFoundError as error:
+        raise ValueError(
+            f"docker is required to probe the source image Python but is not available: {error}"
+        ) from error
     except (OSError, subprocess.SubprocessError) as error:
         raise ValueError(f"cannot probe Python in source image {reference}: {error}") from error
     lines = [line.strip() for line in probe.stdout.splitlines() if line.strip()]

--- a/sure/skills/sure_trans/scripts/test_trans_scripts.py
+++ b/sure/skills/sure_trans/scripts/test_trans_scripts.py
@@ -17,9 +17,9 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 import run_docker_build  # noqa: E402
 import run_trans_validate  # noqa: E402
-import scaffold_adapter  # noqa: E402
-import prepare_fixture  # noqa: E402
 import mcp_smoke  # noqa: E402
+import prepare_fixture  # noqa: E402
+import scaffold_adapter  # noqa: E402
 import stage_model_payload  # noqa: E402
 import write_runtime_inventory  # noqa: E402
 import finalize_trans_bundle  # noqa: E402
@@ -118,6 +118,46 @@ class TransScriptsTest(unittest.TestCase):
         environment["PATH"] = f"{binaries}{os.pathsep}{environment['PATH']}"
         return environment
 
+    def _payload_run_dir(self, root: Path) -> Path:
+        """A run whose resolved input stages two weight files into the bundle."""
+        run_dir = root / "run"
+        artifacts = run_dir / "artifacts"
+        artifacts.mkdir(parents=True)
+        source = root / "delivery" / "model" / "demo"
+        (source / "nested").mkdir(parents=True)
+        (source / "weights.bin").write_bytes(b"weights")
+        (source / "nested" / "extra.bin").write_bytes(b"extra")
+        models_root = root / "sure" / "models"
+        models_root.mkdir(parents=True)
+        (artifacts / "trans_input_resolved.json").write_text(
+            json.dumps({
+                "model_name": "demo",
+                "task_type": "asr",
+                "model_path": str(source),
+                "model_dir": str(models_root / "demo"),
+                "model_mount_target": "/models/demo",
+                "model_stage_policy": "copy",
+                "path_policy": {"allowed_model_root": str(models_root)},
+            }) + "\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "stage_model_payload.py"), "--run-dir", str(run_dir)],
+            check=True, capture_output=True, text=True,
+        )
+        return run_dir
+
+    def _check_model_payload(self, run_dir: Path) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable, str(SCRIPTS_DIR / "check_artifact.py"),
+                "--run-dir", str(run_dir),
+                "--produces", str(run_dir / "artifacts" / "model_payload_manifest.json"),
+                "--kind", "model_payload",
+            ],
+            capture_output=True, text=True,
+        )
+
     def test_fixture_cleanup_rejects_a_symlinked_staging_directory(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -135,6 +175,73 @@ class TransScriptsTest(unittest.TestCase):
                 finalize_trans_bundle.clear_directory(controlled / "asr", controlled)
 
             self.assertEqual(sentinel.read_bytes(), b"keep")
+
+    def test_tts_fixture_declares_only_annotation_fields_the_gate_recomputes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_dir = root / "run"
+            artifacts = run_dir / "artifacts"
+            artifacts.mkdir(parents=True)
+            fixture = root / "prompt.wav"
+            fixture.write_bytes(b"RIFF-prompt")
+            (root / "prompt.expected.json").write_text(
+                json.dumps({"text": "spoken target", "prompt_text": "prompt transcript"}) + "\n",
+                encoding="utf-8",
+            )
+            (artifacts / "trans_input_resolved.json").write_text(
+                json.dumps({
+                    "model_name": "demo",
+                    "task_type": "tts",
+                    "fixture_path": str(fixture),
+                    "path_policy": {"allowed_model_root": str(root / "models")},
+                }) + "\n",
+                encoding="utf-8",
+            )
+            subprocess.run(
+                [sys.executable, str(SCRIPTS_DIR / "prepare_fixture.py"), "--run-dir", str(run_dir)],
+                check=True, capture_output=True, text=True,
+            )
+            manifest = json.loads(
+                (artifacts / "fixture_manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["samples"][0]["annotation_fields"], ["text"])
+            gt = json.loads((run_dir / "fixture" / "tts" / "gt.jsonl").read_text(encoding="utf-8"))
+            self.assertEqual(gt["reference_audio"], "prompt.wav")
+            self.assertEqual(gt["prompt_text"], "prompt transcript")
+            accepted = subprocess.run(
+                [
+                    sys.executable, str(SCRIPTS_DIR / "check_artifact.py"),
+                    "--run-dir", str(run_dir),
+                    "--produces", str(artifacts / "fixture_manifest.json"),
+                    "--kind", "fixture",
+                ],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stdout + accepted.stderr)
+
+    def test_ground_truth_requires_a_reference_sidecar(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_dir = root / "run"
+            artifacts = run_dir / "artifacts"
+            artifacts.mkdir(parents=True)
+            fixture = root / "smoke.wav"
+            fixture.write_bytes(b"RIFF-smoke")
+            fixture_manifest = artifacts / "fixture_manifest.json"
+            fixture_manifest.write_text(
+                json.dumps({
+                    "status": "ready",
+                    "model_dir": str(root),
+                    "staged_dir": str(root),
+                    "staged_path": str(fixture),
+                    "gt_jsonl": str(root / "gt.jsonl"),
+                    "samples": [{"audio": fixture.name, "audio_path": str(fixture), "annotation_fields": ["text"]}],
+                    "sample_count": 1,
+                }) + "\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                finalize_trans_bundle.stage_fixture(run_dir, root / "model", {"task_type": "asr"})
 
     def test_generated_audio_is_promoted_only_from_the_validation_outputs_directory(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -172,6 +279,20 @@ class TransScriptsTest(unittest.TestCase):
         self.assertEqual(mcp_smoke.primary_output_field("synthesize_speech"), "audio_path")
         self.assertEqual(mcp_smoke.primary_output_field("convert_voice"), "audio_path")
 
+    def test_generated_audio_output_must_name_a_real_non_empty_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            empty = root / "empty.wav"
+            empty.write_bytes(b"")
+            filled = root / "speech.wav"
+            filled.write_bytes(b"RIFF-output")
+
+            self.assertTrue(mcp_smoke.output_is_nonempty("text", "transcribed text"))
+            self.assertFalse(mcp_smoke.output_is_nonempty("text", ""))
+            self.assertTrue(mcp_smoke.output_is_nonempty("audio_path", str(filled)))
+            self.assertFalse(mcp_smoke.output_is_nonempty("audio_path", str(empty)))
+            self.assertFalse(mcp_smoke.output_is_nonempty("audio_path", str(root / "absent.wav")))
+
     def test_bundle_writes_reject_symlinked_destination_parents(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -190,6 +311,29 @@ class TransScriptsTest(unittest.TestCase):
                 finalize_trans_bundle.ensure_safe_bundle_parent(bundle, destination)
 
             self.assertEqual(sentinel.read_bytes(), b"keep")
+
+    def test_model_payload_manifest_hashes_every_staged_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            run_dir = self._payload_run_dir(Path(temporary))
+            payload = json.loads(
+                (run_dir / "artifacts" / "model_payload_manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                set(payload["files"]), {"weights.bin", "nested/extra.bin"}
+            )
+            self.assertEqual(payload["files"]["weights.bin"]["size_bytes"], len(b"weights"))
+            self.assertEqual(len(payload["payload_identity_sha256"]), 64)
+            passed = self._check_model_payload(run_dir)
+            self.assertEqual(passed.returncode, 0, passed.stdout + passed.stderr)
+
+    def test_model_payload_check_rejects_an_unregistered_bundle_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            run_dir = self._payload_run_dir(root)
+            (root / "sure" / "models" / "demo" / "smuggled.bin").write_bytes(b"smuggled")
+            rejected = self._check_model_payload(run_dir)
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertIn("exactly cover staged payload files", rejected.stdout + rejected.stderr)
 
     @unittest.skipIf(os.name == "nt", "docker mount syntax collides with Windows drive letters")
     def test_output_cleanup_refuses_a_mount_outside_the_run_directory(self) -> None:
@@ -880,7 +1024,7 @@ class TransScriptsTest(unittest.TestCase):
             self.assertNotIn("vc submit", output)
 
     def test_registry_gate_takes_a_tag_submit_that_proves_the_digest(self) -> None:
-        """This VC backend accepts tags but not digest references for jobs.
+        """VC answers 镜像不存在 to any repo@sha256:... reference.
 
         Requiring the smoke to *run* on a digest-pinned reference therefore made
         the unit unsatisfiable on GPU. The pin is proven by the digest the tag
@@ -1281,6 +1425,26 @@ class TransScriptsTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "absolute Python executable"):
                 scaffold_adapter.container_python_executable("demo-source:0.1.0")
 
+    def test_source_image_python_probe_falls_back_to_python3(self) -> None:
+        missing = mock.Mock(returncode=127, stdout="", stderr="executable file not found in $PATH")
+        found = mock.Mock(returncode=0, stdout="/usr/bin/python3\n", stderr="")
+        with mock.patch.object(
+            scaffold_adapter.subprocess, "run", side_effect=[missing, found]
+        ) as run:
+            self.assertEqual(
+                scaffold_adapter.container_python_executable("demo-source:0.1.0"),
+                "/usr/bin/python3",
+            )
+        entrypoints = [call.args[0][call.args[0].index("--entrypoint") + 1] for call in run.call_args_list]
+        self.assertEqual(entrypoints, ["python", "python3"])
+
+    def test_source_image_python_probe_names_docker_when_it_is_missing(self) -> None:
+        with mock.patch.object(
+            scaffold_adapter.subprocess, "run", side_effect=FileNotFoundError("docker")
+        ):
+            with self.assertRaisesRegex(ValueError, "docker"):
+                scaffold_adapter.container_python_executable("demo-source:0.1.0")
+
     def test_final_bundle_matches_eval_deployment_binding(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1444,6 +1608,8 @@ class TransScriptsTest(unittest.TestCase):
             deployment = json.loads(
                 (model_dir / "artifacts" / "deployment_ready.json").read_text(encoding="utf-8")
             )
+            self.assertEqual(deployment["integrity_profile"], "manifest-complete-v1")
+            self.assertEqual(deployment["weights_integrity"], "bundled")
             self.assertIn("artifacts/sample_output.json", deployment["required_artifact_sha256"])
             self.assertIn("model.py", deployment["required_artifact_sha256"])
             self.assertIn("weights.bin", deployment["required_artifact_sha256"])
@@ -1489,30 +1655,6 @@ class TransScriptsTest(unittest.TestCase):
                 text=True,
             )
             self.assertEqual(fixture_check.returncode, 0, fixture_check.stdout + fixture_check.stderr)
-
-    def test_ground_truth_requires_a_reference_sidecar(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            run_dir = root / "run"
-            artifacts = run_dir / "artifacts"
-            artifacts.mkdir(parents=True)
-            fixture = root / "smoke.wav"
-            fixture.write_bytes(b"RIFF-smoke")
-            fixture_manifest = artifacts / "fixture_manifest.json"
-            fixture_manifest.write_text(
-                json.dumps({
-                    "status": "ready",
-                    "model_dir": str(root),
-                    "staged_dir": str(root),
-                    "staged_path": str(fixture),
-                    "gt_jsonl": str(root / "gt.jsonl"),
-                    "samples": [{"audio": fixture.name, "audio_path": str(fixture), "annotation_fields": ["text"]}],
-                    "sample_count": 1,
-                }) + "\n",
-                encoding="utf-8",
-            )
-            with self.assertRaises(ValueError):
-                finalize_trans_bundle.stage_fixture(run_dir, root / "model", {"task_type": "asr"})
 
 
     def test_blocked_finalize_writes_an_honest_terminal_marker(self) -> None:

--- a/sure/skills/sure_trans/scripts/test_vc_exec.py
+++ b/sure/skills/sure_trans/scripts/test_vc_exec.py
@@ -87,6 +87,7 @@ from vc_exec import (
     registry_image,
     run_vc_job,
     safe_image_component,
+    user_partitions,
     vc_available,
 )
 
@@ -272,7 +273,7 @@ class MountHostPathTest(unittest.TestCase):
 class AgentBinShadowingTest(unittest.TestCase):
     """The coding agent puts its own bin dir first on PATH so its bundled fd and
     rg win. Anything else dropped in there shadows the system binary of the same
-    name, so deployment tools must resolve from the configured host PATH."""
+    name, which is how a stray docker took over every push in this pipeline."""
 
     def _layout(self, root: Path) -> tuple[Path, Path]:
         agent_bin = root / "agent" / "bin"
@@ -383,12 +384,12 @@ class DiagnoseOomTest(unittest.TestCase):
         hint = diagnose_oom(137, "Killed\n")
         self.assertIsNotNone(hint)
         self.assertIn("vc_memory_gb", hint)
-        self.assertIn("configured project and partition limits", hint)
+        self.assertIn("vc_gpus=2 vc_memory_gb=64", hint)
 
     def test_cuda_oom_maps_to_gpu_repair(self) -> None:
         hint = diagnose_oom(1, "RuntimeError: CUDA out of memory. Tried to allocate 64.00 MiB")
         self.assertIsNotNone(hint)
-        self.assertIn("GPU VRAM exhausted", hint)
+        self.assertIn("24 GiB", hint)
         self.assertNotIn("vc_gpus=2", hint)
 
     def test_alloc_failure_maps_to_ram_repair(self) -> None:
@@ -403,36 +404,51 @@ class DiagnoseOomTest(unittest.TestCase):
 class AvailabilityTest(unittest.TestCase):
     def test_vc_available(self) -> None:
         with mock.patch.object(vc_exec.shutil, "which", return_value="/usr/bin/vc"), mock.patch.object(
-            vc_exec, "run_command"
-        ) as run:
+            vc_exec, "run_command", return_value=completed(["vc", "info"])
+        ):
             self.assertTrue(vc_available())
-            run.assert_not_called()
         with mock.patch.object(vc_exec.shutil, "which", return_value=None):
             self.assertFalse(vc_available())
-
-    def test_configured_partitions_reads_validated_site_policy(self) -> None:
-        self.assertEqual(vc_exec.configured_partitions(), {TEST_PARTITION})
-
-    def test_configured_partitions_requires_site_partitions(self) -> None:
-        with mock.patch.object(
-            vc_exec,
-            "load_site_policy",
-            return_value={"policy": {"execution": {}}},
+        with mock.patch.object(vc_exec.shutil, "which", return_value="/usr/bin/vc"), mock.patch.object(
+            vc_exec, "run_command", return_value=completed(["vc", "info"], returncode=1)
         ):
-            with self.assertRaises(ValueError):
-                vc_exec.configured_partitions()
+            self.assertFalse(vc_available())
+
+    def test_user_partitions_reads_only_the_partition_block(self) -> None:
+        stdout = (
+            "User: example" + chr(10)
+            + "[Partition]" + chr(10)
+            + "------------------------------" + chr(10)
+            + "gpu-test" + chr(10)
+            + "gpu-2" + chr(10)
+            + "[是否允许资源配比超配]" + chr(10)
+            + "NO" + chr(10)
+            + "[Quota]" + chr(10)
+            + "GPU: 32" + chr(10)
+        )
+        with mock.patch.object(vc_exec.shutil, "which", return_value="/usr/bin/vc"), mock.patch.object(
+            vc_exec, "run_command", return_value=completed(["vc", "info", "-u"], stdout=stdout)
+        ):
+            self.assertEqual(user_partitions(), {"gpu-test", "gpu-2"})
+
+    def test_user_partitions_is_empty_without_a_partition_block(self) -> None:
+        with mock.patch.object(vc_exec.shutil, "which", return_value="/usr/bin/vc"), mock.patch.object(
+            vc_exec, "run_command", return_value=completed(["vc", "info", "-u"], stdout="User: example" + chr(10))
+        ):
+            self.assertEqual(user_partitions(), set())
+
 
 class EnsureRegistryImageTest(unittest.TestCase):
     def test_push_digest_selects_the_requested_tag(self) -> None:
         old = "sha256:" + "a" * 64
         expected = "sha256:" + "b" * 64
-        output = "\n".join(
+        output = chr(10).join(
             [
                 json.dumps({"status": f"0.1.1: digest: {old} size: 1"}),
                 json.dumps({"status": f"0.1.2: digest: {expected} size: 1"}),
             ]
         )
-        self.assertEqual(push_digest(output, "registry.example/example-org/demo:0.1.2"), expected)
+        self.assertEqual(push_digest(output, registry_image("demo", "0.1.2")), expected)
 
     def test_push_records_commands_and_parses_digest(self) -> None:
         digest = "sha256:" + "c" * 64
@@ -506,7 +522,7 @@ class EnsureRegistryImageTest(unittest.TestCase):
     def test_a_rerun_keeps_the_digest_the_first_push_earned(self) -> None:
         ref = registry_image("demo", "0.1.0")
         digest = "sha256:" + "c" * 64
-        rejection = "tag already exists; use a new tag"
+        rejection = "镜像已存在，请更新tag"
 
         def fake_run(args, *, timeout=None, env=None):
             if args[:2] == ["docker", "tag"]:
@@ -526,11 +542,12 @@ class EnsureRegistryImageTest(unittest.TestCase):
         ref = registry_image("demo", "0.1.0")
         stale = "sha256:" + "a" * 64
         current = "sha256:" + "b" * 64
+        rejection = "镜像已存在，请更新tag"
 
         def fake_run(args, *, timeout=None, env=None):
             if args[:2] == ["docker", "tag"]:
                 return completed(args)
-            return completed(args, stdout="tag already exists; use a new tag\n")
+            return completed(args, stdout=rejection + chr(10))
 
         with tempfile.TemporaryDirectory() as temporary:
             log = Path(temporary) / "push.log"
@@ -555,7 +572,7 @@ class EnsureRegistryImageTest(unittest.TestCase):
 
     def test_push_without_digest_is_a_failure(self) -> None:
         ref = registry_image("demo", "0.1.0")
-        rejection = "tag already exists; use a new tag"
+        rejection = "镜像已存在，请更新tag"
 
         def fake_run(args, *, timeout=None, env=None):
             if args[:2] == ["docker", "tag"]:
@@ -571,7 +588,7 @@ class EnsureRegistryImageTest(unittest.TestCase):
             self.assertIn(rejection, message)
             self.assertIn("image_version", message)
 
-    def test_push_failure_mentions_policy_target(self) -> None:
+    def test_push_failure_mentions_site_target(self) -> None:
         ref = registry_image("demo", "0.1.0")
 
         def fake_run(args: list[str], *, timeout: float | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
@@ -585,7 +602,7 @@ class EnsureRegistryImageTest(unittest.TestCase):
                 with self.assertRaises(ValueError) as raised:
                     ensure_registry_image("local-image", ref, log)
             message = str(raised.exception)
-            self.assertIn("policy-resolved target", message)
+            self.assertIn("site-resolved target", message)
             self.assertIn("image_version", message)
 
 
@@ -721,7 +738,9 @@ class RunVcJobTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             log_dir = Path(temporary) / "logs"
             patch, recorded = self._submit_side_effect()
-            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True):
+            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"gpu-test"}
+            ):
                 result = run_vc_job(image="registry/demo:0.1.0", command="python -c 'print(1)'", log_dir=log_dir)
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.job_id, "job-abc-123")
@@ -745,13 +764,17 @@ class RunVcJobTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary:
             log_dir = Path(temporary) / "logs"
             patch, _ = self._submit_side_effect()
-            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True):
+            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"gpu-test"}
+            ):
                 run_vc_job(image="registry/demo:0.1.0", command="true", log_dir=log_dir, command_timeout_seconds=60)
             inner = (log_dir / "inner.sh").read_text(encoding="utf-8")
             self.assertIn("timeout --kill-after=15 60 true", inner)
 
             patch, _ = self._submit_side_effect()
-            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True):
+            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"gpu-test"}
+            ):
                 run_vc_job(image="registry/demo:0.1.0", command="true", log_dir=log_dir, command_timeout_seconds=0)
             inner = (log_dir / "inner.sh").read_text(encoding="utf-8")
             self.assertNotIn("timeout ", inner)
@@ -763,7 +786,9 @@ class RunVcJobTest(unittest.TestCase):
             host_source = Path(temporary) / "host"
             host_source.write_text("x", encoding="utf-8")
             ro_mount = f"{host_source}:/cont:ro"
-            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True):
+            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"gpu-test"}
+            ):
                 run_vc_job(
                     image="registry/demo:0.1.0",
                     command="true",
@@ -790,7 +815,7 @@ class RunVcJobTest(unittest.TestCase):
 
             with mock.patch.object(vc_exec, "run_command", side_effect=fake_run), mock.patch.object(
                 vc_exec, "vc_available", return_value=True
-            ):
+            ), mock.patch.object(vc_exec, "user_partitions", return_value={"gpu-test"}):
                 result = run_vc_job(
                     image="registry/demo:0.1.0",
                     command="sleep 1000",
@@ -808,31 +833,35 @@ class RunVcJobTest(unittest.TestCase):
             def fake_run(args: list[str], *, timeout: float | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
                 if args[:2] == ["vc", "info"]:
                     return completed(args, stdout="cluster ok\n")
-                return completed(args, returncode=1, stderr="submission denied by backend policy\n")
+                return completed(args, returncode=1, stderr="quota exceeded\n")
 
             with mock.patch.object(vc_exec, "run_command", side_effect=fake_run), mock.patch.object(
                 vc_exec, "vc_available", return_value=True
-            ):
+            ), mock.patch.object(vc_exec, "user_partitions", return_value={"gpu-test"}):
                 with self.assertRaises(ValueError) as raised:
                     run_vc_job(image="registry/demo:0.1.0", command="true", log_dir=log_dir)
             self.assertIn("vc submit failed", str(raised.exception))
 
-    def test_partition_outside_policy_allowlist_raises(self) -> None:
+    def test_unavailable_partition_raises(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            with mock.patch.object(vc_exec, "vc_available", return_value=True):
+            with mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"other-queue"}
+            ):
                 with self.assertRaises(ValueError) as raised:
                     run_vc_job(
                         image="registry/demo:0.1.0",
                         command="true",
                         log_dir=Path(temporary) / "logs",
-                        partition="other-queue",
+                        partition="gpu-test",
                     )
-            self.assertIn("execution.vc_partitions", str(raised.exception))
+            self.assertIn("gpu-test", str(raised.exception))
 
     def test_explicit_project_overrides_the_site_policy(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             patch, recorded = self._submit_side_effect()
-            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True):
+            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"gpu-test"}
+            ):
                 run_vc_job(
                     image="registry/demo:0.1.0",
                     command="true",
@@ -842,21 +871,6 @@ class RunVcJobTest(unittest.TestCase):
             submit = recorded[0]
             project_index = submit.index("--project")
             self.assertEqual(submit[project_index + 1], "override-project")
-
-    def test_submit_is_authoritative_after_policy_preflight(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
-            log_dir = Path(temporary) / "logs"
-            patch, recorded = self._submit_side_effect()
-            with patch, mock.patch.object(vc_exec, "vc_available", return_value=True):
-                result = run_vc_job(
-                    image="registry/demo:0.1.0",
-                    command="true",
-                    log_dir=log_dir,
-                    partition="gpu-test",
-                )
-            self.assertEqual(result.exit_code, 0)
-            self.assertEqual(recorded[0][:2], ["vc", "submit"])
-            self.assertEqual(recorded[0][recorded[0].index("-p") + 1], "gpu-test")
 
     def test_missing_vc_binary_raises(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1143,10 +1157,10 @@ class TransValidateVcTest(unittest.TestCase):
                     run_trans_validate.main()
             message = str(raised.exception)
             self.assertIn("OOM", message)
-            self.assertIn("configured project and partition limits", message)
+            self.assertIn("vc_gpus=2 vc_memory_gb=64", message)
             payload = json.loads(load_result.read_text(encoding="utf-8"))
             self.assertEqual(payload["status"], "failed")
-            self.assertIn("configured project and partition limits", payload["error"])
+            self.assertIn("vc_gpus=2 vc_memory_gb=64", payload["error"])
 
     def test_gpu_oom_retries_with_fresh_vc_jobs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1416,8 +1430,8 @@ class TransValidateVcTest(unittest.TestCase):
                     run_trans_validate.main()
             message = str(raised.exception)
             self.assertIn("40.0 GiB", message)
-            self.assertIn("vc_memory_gb", message)
-            self.assertIn("required by scheduler policy", message)
+            self.assertIn("vc_gpus=2 vc_memory_gb=64", message)
+            self.assertIn("32 GiB per GPU", message)
 
     def test_import_kind_skips_payload_budget(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -1438,6 +1452,8 @@ class VcExecCliTest(unittest.TestCase):
             produces = root / "smoke.json"
             patch, _ = RunVcJobTest()._submit_side_effect()
             with patch, mock.patch.object(vc_exec, "vc_available", return_value=True), mock.patch.object(
+                vc_exec, "user_partitions", return_value={"gpu-test"}
+            ), mock.patch.object(
                 sys, "argv",
                 ["vc_exec.py", "--image", "registry/demo:0.1.0", "--command", "true", "--log-dir", str(log_dir), "--produces", str(produces)],
             ):
@@ -1454,11 +1470,11 @@ class VcExecCliTest(unittest.TestCase):
             def fake_run(args: list[str], *, timeout: float | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
                 if args[:2] == ["vc", "info"]:
                     return completed(args, stdout="cluster ok\n")
-                return completed(args, returncode=1, stderr="submission denied by backend policy\n")
+                return completed(args, returncode=1, stderr="quota exceeded\n")
 
             with mock.patch.object(vc_exec, "run_command", side_effect=fake_run), mock.patch.object(
                 vc_exec, "vc_available", return_value=True
-            ), mock.patch.object(
+            ), mock.patch.object(vc_exec, "user_partitions", return_value={"gpu-test"}), mock.patch.object(
                 sys, "argv",
                 ["vc_exec.py", "--image", "registry/demo:0.1.0", "--command", "true", "--log-dir", str(root / "logs"), "--produces", str(root / "smoke.json")],
             ):
@@ -1509,11 +1525,17 @@ class SitePolicySourcedDefaultsTest(unittest.TestCase):
     def test_default_project_comes_from_the_site_policy(self) -> None:
         self.assertEqual(vc_exec.default_project(), "example-project")
 
+    def test_default_project_fails_closed_without_the_policy_field(self) -> None:
+        with mock.patch.object(
+            vc_exec,
+            "load_site_policy",
+            return_value={"policy": {"execution": {}}},
+        ):
+            with self.assertRaisesRegex(ValueError, "execution.vc_project"):
+                vc_exec.default_project()
+
     def test_registry_image_uses_the_site_container_registry(self) -> None:
-        self.assertEqual(
-            vc_exec.registry_image("demo", "0.1.0"),
-            "registry.example/example-org/sure-asr-demo:0.1.0",
-        )
+        self.assertEqual(vc_exec.registry_image("demo", "0.1.0"), "registry.example/example-org/sure-asr-demo:0.1.0")
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_trans/scripts/vc_exec.py
+++ b/sure/skills/sure_trans/scripts/vc_exec.py
@@ -2,7 +2,7 @@
 """Shared Volcano (vc) execution helpers for SURE-TRANS GPU validation.
 
 The GPU-touching trans gates (run_execution_compat.py, run_trans_validate.py)
-route container work through ``vc submit`` on a policy-configured GPU
+route container work through ``vc submit`` on the site's dedicated GPU
 partition instead of ``docker run --gpus all`` on the login node.
 
 Mechanics:
@@ -50,8 +50,9 @@ DEFAULT_POLL_INTERVAL_SECONDS = 15.0
 DONE_MARKER = "SURE_TRANS_JOB_DONE"
 
 def default_partition() -> str:
-    """Return the configured default VC partition for trans GPU validation."""
-    value = _site_policy().get("execution", {}).get("vc_default_partition")
+    """Return the site's default VC partition for trans GPU validation."""
+    resolved = load_site_policy(required=True) or {}
+    value = resolved.get("policy", {}).get("execution", {}).get("vc_default_partition")
     if not value:
         raise ValueError(
             "site policy is missing execution.vc_default_partition; set it in "
@@ -61,8 +62,9 @@ def default_partition() -> str:
 
 
 def default_project() -> str:
-    """Return the configured VC submission project."""
-    value = _site_policy().get("execution", {}).get("vc_project")
+    """Return the site's VC submission project for trans GPU validation."""
+    resolved = load_site_policy(required=True) or {}
+    value = resolved.get("policy", {}).get("execution", {}).get("vc_project")
     if not value:
         raise ValueError(
             "site policy is missing execution.vc_project; set it in "
@@ -71,20 +73,10 @@ def default_project() -> str:
     return str(value)
 
 
-def configured_partitions() -> set[str]:
-    """Return the policy allowlist used for pre-submit partition validation."""
-    value = _site_policy().get("execution", {}).get("vc_partitions")
-    if not isinstance(value, list) or not value:
-        raise ValueError(
-            "site policy is missing execution.vc_partitions; set it in "
-            "config/site.bundled.yaml or config/site.local.yaml"
-        )
-    return {str(partition) for partition in value}
-
-
 def registry_host() -> str:
-    """Return the configured container registry host for trans image delivery."""
-    value = _site_policy().get("network", {}).get("container_registry")
+    """Return the site's container registry host for trans image delivery."""
+    resolved = load_site_policy(required=True) or {}
+    value = resolved.get("policy", {}).get("network", {}).get("container_registry")
     if not value:
         raise ValueError(
             "site policy is missing network.container_registry; set it in "
@@ -150,8 +142,9 @@ def agent_bin_dir() -> Path:
 def agent_bin_cleared_env() -> dict[str, str]:
     """The environment with the agent's own bin dir taken off PATH.
 
-    That leading bin dir shadows any system binary of the same name. Drop the
-    directory so deployment tools resolve from the host's configured PATH.
+    That leading bin dir shadows any system binary of the same name. A docker
+    left there answered every push with "denied" while the system one pushed
+    fine, so drop the directory rather than trust whatever now sits in it.
     """
     env = os.environ.copy()
     path = env.get("PATH")
@@ -171,7 +164,43 @@ def proxy_cleared_env() -> dict[str, str]:
 
 
 def vc_available() -> bool:
-    return shutil.which("vc") is not None
+    if not shutil.which("vc"):
+        return False
+    try:
+        result = run_command(["vc", "info"], timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0
+
+
+def user_partitions() -> set[str]:
+    if not shutil.which("vc"):
+        return set()
+    try:
+        result = run_command(["vc", "info", "-u"], timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    # Only the [Partition] block lists partitions. Scanning the whole output
+    # collected the separator rule and answers from other blocks ("NO" from
+    # the overcommit block), which made the caller's precheck accept them.
+    partitions: set[str] = set()
+    in_block = False
+    for line in result.stdout.splitlines():
+        name = line.strip()
+        if name == "[Partition]":
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        if name.startswith("["):
+            break
+        if name.strip("-") and re.fullmatch(r"[A-Za-z0-9._-]+", name):
+            partitions.add(name)
+    return partitions
+
+
+def partition_allowed(partition: str) -> bool:
+    return partition in user_partitions()
 
 
 def safe_image_component(value: str) -> str:
@@ -301,10 +330,10 @@ def recorded_push_digest(artifact: dict, registry_ref: str) -> str:
 def registry_tag_digest(image_ref: str, log_path: Path) -> str:
     """Manifest digest the registry currently serves for this reference.
 
-    This VC backend accepts ``repo:tag`` but not ``repo@sha256:...`` for job
-    submission, so a job cannot carry the pin in the reference it runs. Pull
-    the tag and read the digest back instead, which makes the pin something
-    the submission proves rather than states.
+    ``vc submit`` takes ``repo:tag`` only and answers 镜像不存在 to any
+    ``repo@sha256:...`` reference, so a job cannot carry the pin in the
+    reference it runs. Pull the tag and read the digest back instead, which
+    makes the pin something the submission proves rather than states.
     """
     log_path.parent.mkdir(parents=True, exist_ok=True)
     command = ["docker", "pull", image_ref]
@@ -368,8 +397,8 @@ def ensure_registry_image(
                 )
                 raise ValueError(
                     f"{' '.join(command)} failed ({reason}); see {log_path}. "
-                    "Check repository permissions, registry immutability policy, and the tag choice; "
-                    f"verify the policy-resolved target and bump image_version when content changed.\n{output}"
+                    "The registry may reject an unapproved repository or a reused tag; "
+                    f"verify the site-resolved target and bump image_version when content changed.\n{output}"
                 )
     if known_digest and not push_reported_digest:
         digest = registry_tag_digest(registry_ref, log_path)
@@ -623,19 +652,19 @@ def diagnose_oom(exit_code: int | None, evidence: str) -> str | None:
     text = (evidence or "").lower()
     if exit_code == 137 or "oomkilled" in text:
         return (
-            "job was OOM-killed (exit 137): requested RAM was insufficient. Increase "
-            "vc_memory_gb within the configured project and partition limits, or reduce "
-            "the workload, then rerun the gate."
+            "job was OOM-killed (exit 137): RAM request too small. Raise vc_memory_gb "
+            "(the partition caps 32 GiB per GPU; request more GPUs to raise it, e.g. "
+            "vc_gpus=2 vc_memory_gb=64), then rerun the gate."
         )
     if GPU_OOM_MARKER in text:
         return (
-            "GPU VRAM exhausted: reduce batch/beam size, enable bf16 where supported, "
+            "GPU VRAM exhausted (RTX 4090 has 24 GiB): reduce batch/beam size, enable bf16, "
             "or shard the model, then rerun the gate."
         )
     if any(marker in text for marker in RAM_OOM_MARKERS) or "killed" in text:
         return (
-            "job RAM exhausted: increase vc_memory_gb within the configured project and "
-            "partition limits, or reduce the workload, then rerun the gate."
+            "job RAM exhausted: raise vc_memory_gb (the partition caps 32 GiB per GPU; "
+            "request more GPUs to raise it, e.g. vc_gpus=2 vc_memory_gb=64), then rerun the gate."
         )
     return None
 
@@ -745,12 +774,14 @@ def run_vc_job(
     partition = partition or default_partition()
     project = project or default_project()
     if not vc_available():
-        raise ValueError("vc is required for GPU validation but is not available on PATH")
-    allowed = configured_partitions()
+        raise ValueError(
+            "vc is required for GPU validation: `which vc && vc info` did not pass on this host"
+        )
+    allowed = user_partitions()
     if partition not in allowed:
         raise ValueError(
-            f"vc partition {partition!r} is not listed in execution.vc_partitions "
-            f"(configured partitions: {sorted(allowed)})"
+            f"vc partition {partition!r} is not available to this user "
+            f"(visible partitions: {sorted(allowed)}); ask the cluster admin for access"
         )
     log_dir = log_dir.resolve()
     mount_list = list(mounts or [])
@@ -827,7 +858,7 @@ def main() -> int:
     parser.add_argument("--mount", action="append", default=[])
     parser.add_argument("--env", action="append", default=[])
     parser.add_argument("--partition", default=None, help="defaults to the site policy partition")
-    parser.add_argument("--project", default=None, help="override the site policy VC project")
+    parser.add_argument("--project", default=None, help="defaults to the site policy VC project")
     parser.add_argument("--gpus", type=int, default=DEFAULT_GPUS)
     parser.add_argument("--memory-gb", type=int, default=DEFAULT_MEMORY_GB)
     parser.add_argument("--cpus", type=int, default=DEFAULT_CPUS)


### PR DESCRIPTION
Projection of the GitLab mainline `c1a4f88` after the three public commits (aacc6fec, 87c3445c, 5980a7a4) were reviewed and ported back with the following deviations kept on the mainline: legacy host path checks stay, live VC partition authorization stays, weights outside the bundle are allowed through `weights_integrity`, `integrity_profile` is required for bundles sealed from 2026-09-01, and `execution.vc_project` is required whenever the vc surface is enabled.

Files that only ever changed on this side (placeholder and naming swaps, the `sjtu_home` traversal removal) return to the mainline version, since the mainline is the source of the projection. `public-export-manifest.json` is regenerated from the full export.

Tree built on Linux from the export output: 1718 entries, executable bits preserved, no `private/`, no `config/site.bundled.yaml`, no `.gitlab-ci.yml`.
