### PR TITLE
chore(public): sync GitLab projection through 07de3fb

### DIFF
--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "sure.public_export_manifest.v2",
-  "projection_id": "sha256:e630d5768345f3eda3d95e9a89ff66c4627ae56c4864ce518e9ab61b9923be22",
-  "tree_sha256": "e630d5768345f3eda3d95e9a89ff66c4627ae56c4864ce518e9ab61b9923be22",
+  "projection_id": "sha256:6722b1c279ec4086dbd9ece6b062ae97781940c4414a345b5cb2ec1b87bfbe3b",
+  "tree_sha256": "6722b1c279ec4086dbd9ece6b062ae97781940c4414a345b5cb2ec1b87bfbe3b",
   "files": [
     {
       "path": ".gitattributes",
@@ -6961,7 +6961,7 @@
       "path": "sure/runtime/memory/test_cli.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "1220bff32fbe53dd7fd28a26df4b35f9f38a66c66a0110eade8cad7adc2611d4"
+      "sha256": "78db170a0f334a36228b098614dbb0a360242209d0d2ae89d2c5c85a4f919421"
     },
     {
       "path": "sure/runtime/memory/test_digest.py",
@@ -7693,7 +7693,7 @@
       "path": "sure/skills/sure_eval/scripts/deployment_binding.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "af339e408706c0b5e7396c85ca189599bc9b6ff92f9cf2737e60c15c8259a126"
+      "sha256": "322618efcf803886486b87e65054abd80f093669b30a18eee33914aef60a9fcc"
     },
     {
       "path": "sure/skills/sure_eval/scripts/download_sure_data.py",
@@ -8563,7 +8563,7 @@
       "path": "sure/skills/sure_eval/scripts/test_deployment_binding.py",
       "type": "file",
       "mode": "100644",
-      "sha256": "e13f60e25905e85bf54be8c386712eb9d192dc8c3e481d116b34d7bd2ea504d1"
+      "sha256": "040f75e1eeb8639e9bcd29e268f3e9c4c117b51a51ec2af111d6de0868191be3"
     },
     {
       "path": "sure/skills/sure_eval/scripts/test_eval_input_policy.py",

--- a/sure/runtime/memory/test_cli.py
+++ b/sure/runtime/memory/test_cli.py
@@ -8,6 +8,7 @@ import sys
 import tempfile
 import types
 import unittest
+from datetime import date, timedelta
 from pathlib import Path
 from unittest import mock
 
@@ -820,8 +821,11 @@ class ModifyOfAnExportedTargetTests(CliTestBase):
         self.assertEqual(self.run_cli("confirm", MODIFY_ID)[0], 0)
         self.assertEqual(self.run_cli("export", KERNEL_ID)[0], 0)
         self.assertIn(self.MARKER, self.tracked.read_text(encoding="utf-8"))
-        self.dispute("run-x", "2026-09-01T10:00:00Z")
-        self.dispute("run-y", "2026-09-02T10:00:00Z")
+        # _demote_streak only counts disputes dated after the human confirm (utc_today), so the
+        # dates must be computed from today: fixed ones passed until the calendar caught up.
+        today = date.fromisoformat(paths.utc_today())
+        self.dispute("run-x", f"{today + timedelta(days=1)}T10:00:00Z")
+        self.dispute("run-y", f"{today + timedelta(days=2)}T10:00:00Z")
         self.assertEqual([r["action"] for r in promote.promote_all(self.root, config=self.config)], ["demote"])
         self.assertEqual(self.meta_of(KERNEL_ID)["status"], "provisional")
         # cmd_confirm re-stages from the provisional copy: a copy left un-merged reverts the entry

--- a/sure/skills/sure_eval/scripts/deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/deployment_binding.py
@@ -527,9 +527,14 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
             _validate_complete_manifest(model_dir, marker, package, "none")
         return _load_python_binding(model_dir, model_name, marker, inventory, package)
 
-    manifest = _read_json(model_dir, "artifacts/artifact_manifest.json")
-    _require(manifest.get("status") == "finalized", "artifact_manifest status must be finalized")
-    _require(manifest.get("model_dir") == ".", "artifact_manifest model_dir must be portable (.)")
+    declared_profile = marker.get("integrity_profile")
+    if declared_profile is not None:
+        # Only a declared profile promised a finalized, portable manifest. Bundles sealed before
+        # INTEGRITY_PROFILE_REQUIRED_FROM wrote that file by hand and were always bound on the
+        # hashes the marker declares; the legacy profile keeps binding them that way.
+        manifest = _read_json(model_dir, "artifacts/artifact_manifest.json")
+        _require(manifest.get("status") == "finalized", "artifact_manifest status must be finalized")
+        _require(manifest.get("model_dir") == ".", "artifact_manifest model_dir must be portable (.)")
     _require(marker.get("schema") == DEPLOYMENT_READY_V1, "unsupported deployment_ready schema")
     _require(marker.get("status") == "ready", "deployment_ready status must be ready")
     _require(marker.get("model_name") == model_name, "deployment_ready model_name does not match requested model")
@@ -633,22 +638,6 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
 
     declared_hashes = marker.get("required_artifact_sha256")
     _require(isinstance(declared_hashes, dict) and declared_hashes, "deployment_ready artifact hashes are missing")
-    manifest_artifacts = manifest.get("artifacts")
-    required_entries = manifest_artifacts.get("required") if isinstance(manifest_artifacts, dict) else None
-    _require(isinstance(required_entries, dict) and required_entries, "artifact_manifest required entries are missing")
-    manifest_paths: set[str] = set()
-    has_deployment_self_entry = False
-    for entry in required_entries.values():
-        _require(isinstance(entry, dict), "artifact_manifest required entry is invalid")
-        raw_path = str(entry.get("path") or "")
-        path = Path(raw_path)
-        _require(raw_path and not path.is_absolute() and ".." not in path.parts, "artifact_manifest contains a non-portable path")
-        if path.as_posix() == "artifacts/deployment_ready.json":
-            has_deployment_self_entry = True
-        else:
-            manifest_paths.add(path.as_posix())
-    declared_paths = {str(path) for path in declared_hashes}
-    declared_profile = marker.get("integrity_profile")
     if declared_profile is None:
         integrity_profile = "legacy-partial-v1"
     else:
@@ -657,6 +646,21 @@ def load_deployment_binding(model_dir: Path, model_name: str) -> dict[str, Any]:
             f"unsupported ready deployment integrity profile: {declared_profile!r}",
         )
         integrity_profile = str(declared_profile)
+        manifest_artifacts = manifest.get("artifacts")
+        required_entries = manifest_artifacts.get("required") if isinstance(manifest_artifacts, dict) else None
+        _require(isinstance(required_entries, dict) and required_entries, "artifact_manifest required entries are missing")
+        manifest_paths: set[str] = set()
+        has_deployment_self_entry = False
+        for entry in required_entries.values():
+            _require(isinstance(entry, dict), "artifact_manifest required entry is invalid")
+            raw_path = str(entry.get("path") or "")
+            path = Path(raw_path)
+            _require(raw_path and not path.is_absolute() and ".." not in path.parts, "artifact_manifest contains a non-portable path")
+            if path.as_posix() == "artifacts/deployment_ready.json":
+                has_deployment_self_entry = True
+            else:
+                manifest_paths.add(path.as_posix())
+        declared_paths = {str(path) for path in declared_hashes}
         mandatory_paths = _mandatory_integrity_paths(
             model_dir,
             package,

--- a/sure/skills/sure_eval/scripts/test_deployment_binding.py
+++ b/sure/skills/sure_eval/scripts/test_deployment_binding.py
@@ -354,6 +354,25 @@ class DeploymentBindingTests(unittest.TestCase):
 
         self.assertEqual(binding["evidence"]["integrity_profile"], "legacy-partial-v1")
 
+    def test_a_legacy_marker_does_not_need_a_finalized_portable_manifest(self) -> None:
+        # Bundles sealed before the cutoff wrote artifact_manifest.json by hand: status is whatever
+        # the author typed and model_dir an absolute path. Eval bound them on the marker hashes alone
+        # and the legacy profile keeps that promise; only a declared profile buys the manifest check.
+        write_json(self.artifacts / "artifact_manifest.json", {"status": "passed", "model_dir": "/nfs/models/demo"})
+
+        binding = load_deployment_binding(self.model, "demo")
+
+        self.assertEqual(binding["evidence"]["integrity_profile"], "legacy-partial-v1")
+
+    def test_a_declared_profile_still_demands_a_finalized_portable_manifest(self) -> None:
+        self._rewrite_marker(integrity_profile="manifest-complete-v1")
+        manifest = json.loads((self.artifacts / "artifact_manifest.json").read_text())
+        manifest["status"] = "passed"
+        write_json(self.artifacts / "artifact_manifest.json", manifest)
+
+        with self.assertRaisesRegex(DeploymentBindingError, "must be finalized"):
+            load_deployment_binding(self.model, "demo")
+
     def test_marker_without_any_timestamp_may_not_fall_back_to_the_legacy_profile(self) -> None:
         marker = json.loads((self.artifacts / "deployment_ready.json").read_text())
         marker.pop("generated_at", None)


### PR DESCRIPTION
Full-tree projection of the GitLab mainline at 07de3fb (parent c36710a5). Two fixes:

- sure_eval: legacy deployment bundles (no declared integrity_profile) bind on the marker hashes again without a finalized artifact manifest; a declared profile still demands one.
- memory: the demote test dates its disputes relative to the confirm day instead of hard-coded dates.

Regenerates public-export-manifest.json. No GitHub-only commits since c36710a5, so nothing is overwritten.