### PR TITLE
chore(public): sync GitLab projection through 153aaf5

### DIFF
--- a/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
+++ b/packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts
@@ -2841,24 +2841,14 @@ describe("sure_onboard artifact manifest structure compatibility", () => {
 		expect(existsSync(join(targetDir, ".venv"))).toBe(false);
 		expect(existsSync(join(targetDir, "artifacts", "package_gate.json"))).toBe(true);
 
-		// The adoption stamps its manifest and its verdict from the wall clock but leaves
-		// the package gate unstamped, and it writes no runtime inventory at all. Pin the
-		// first two documents into the past and stage the inventory the verdict gate reads,
-		// so the gates below judge the adoption itself and not the missing stamps.
+		// The adoption writes no runtime inventory at all. Stage the one the verdict gate reads,
+		// dated with the adopted package gate, so the gates below judge the stamps the adoption
+		// itself wrote for its manifest, gate, and verdict.
 		const adoptedArtifacts = join(targetDir, "artifacts");
-		const adoptedManifestPath = join(adoptedArtifacts, "artifact_manifest.json");
-		const adoptedGatePath = join(adoptedArtifacts, "package_gate.json");
-		writeJson(adoptedManifestPath, {
-			...JSON.parse(readFileSync(adoptedManifestPath, "utf-8")),
-			timestamp: "2026-01-01T00:00:01+00:00",
-		});
-		writeJson(adoptedGatePath, {
-			...JSON.parse(readFileSync(adoptedGatePath, "utf-8")),
-			generated_at: "2026-01-01T00:00:02+00:00",
-		});
+		const adoptedGate = JSON.parse(readFileSync(join(adoptedArtifacts, "package_gate.json"), "utf-8"));
 		writeJson(join(adoptedArtifacts, "runtime_inventory.json"), {
 			schema: "sure.onboard.runtime_inventory.v2",
-			generated_at: "2026-01-01T00:00:03+00:00",
+			generated_at: adoptedGate.generated_at,
 		});
 
 		for (const [script, artifact] of [

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "sure.public_export_manifest.v2",
-  "projection_id": "sha256:6722b1c279ec4086dbd9ece6b062ae97781940c4414a345b5cb2ec1b87bfbe3b",
-  "tree_sha256": "6722b1c279ec4086dbd9ece6b062ae97781940c4414a345b5cb2ec1b87bfbe3b",
+  "projection_id": "sha256:3d611fb50a670c10b459db0d4075fb664c2be3c1fdef53fed41c8072f4b942de",
+  "tree_sha256": "3d611fb50a670c10b459db0d4075fb664c2be3c1fdef53fed41c8072f4b942de",
   "files": [
     {
       "path": ".gitattributes",
@@ -5665,7 +5665,7 @@
       "path": "packages/coding-agent/test/suite/sure-onboard-state-machine.test.ts",
       "type": "file",
       "mode": "100644",
-      "sha256": "f9d729fc0b44c084811057f44f10c1f8b137a0ceee15360c31caf44cfd66f698"
+      "sha256": "817d8ea07417e780bd33138680c48177a97888efb271496cd7b6efc57fc9f8a6"
     },
     {
       "path": "packages/coding-agent/test/suite/sure-onboard-terminal.test.ts",
@@ -9517,7 +9517,7 @@
       "path": "sure/skills/sure_onboard/scripts/adopt_reference_model.py",
       "type": "file",
       "mode": "100755",
-      "sha256": "27e131aa21a5f4c5c2ae51f69c39bb0158e0e874598455d41525120c0082aa94"
+      "sha256": "f98bda2f930b417709de1a1cab5f900dce3f344878ed83b238c1c38a44f12db2"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/build_run_digest.py",
@@ -9794,6 +9794,12 @@
       "type": "file",
       "mode": "100644",
       "sha256": "87fd7aa1fce1fa5013d3f38e43c382e1c2a706bd87603e669bd7662be2be7942"
+    },
+    {
+      "path": "sure/skills/sure_onboard/scripts/test_adopt_reference_model.py",
+      "type": "file",
+      "mode": "100644",
+      "sha256": "6ab9207a1298b7ff8c100f5edc864168dfe4b3d954bbdceeca4a4db63fb3172c"
     },
     {
       "path": "sure/skills/sure_onboard/scripts/test_container_delivery_resolution.py",

--- a/sure/skills/sure_onboard/scripts/adopt_reference_model.py
+++ b/sure/skills/sure_onboard/scripts/adopt_reference_model.py
@@ -17,6 +17,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from deployment_contract import timestamp_after
+
 SKIP_TOP_LEVEL = {"artifacts", "__pycache__", "eval_runs", "eval_runs_old", ".venv"}
 ASSET_LINK_DIRS = {"checkpoints", ".runtime"}
 RUNTIME_LINK_ALLOW_NAMES = {"modelscope_cache", "huggingface", "hf-home", "hf-cache", "nemo-cache"}
@@ -433,10 +435,13 @@ def write_artifact_manifest(target_dir: Path, model_id: str, model_name: str) ->
 
 
 def write_package_gate(target_dir: Path, manifest_path: Path) -> None:
+    # check_package_gate.py requires the gate to be stamped strictly after the manifest it cites.
+    manifest = read_json(manifest_path)
     write_json(
         target_dir / "artifacts" / "package_gate.json",
         {
             "schema": "sure.onboard.package_gate.v2",
+            "generated_at": timestamp_after(("artifact_manifest.json", manifest)),
             "status": "passed",
             "package_profile": "none",
             "model_dir": str(target_dir),
@@ -468,11 +473,13 @@ def write_package_gate(target_dir: Path, manifest_path: Path) -> None:
 
 
 def write_verdict(target_dir: Path, model_id: str, model_name: str, verdict: dict[str, Any]) -> None:
+    # check_verdict.py requires the verdict to be stamped strictly after the package gate.
+    package_gate = read_json(target_dir / "artifacts" / "package_gate.json")
     write_json(
         target_dir / "artifacts" / "verdict.json",
         {
             "instance_id": f"{model_name}-adopted",
-            "timestamp": now_iso(),
+            "timestamp": timestamp_after(("package_gate.json", package_gate)),
             "model_id": model_id,
             "model_name": model_name,
             "status": "partial",

--- a/sure/skills/sure_onboard/scripts/test_adopt_reference_model.py
+++ b/sure/skills/sure_onboard/scripts/test_adopt_reference_model.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from adopt_reference_model import read_json, write_artifact_manifest, write_package_gate, write_verdict
+from deployment_contract import require_timestamp_after
+
+
+class AdoptedDocumentStampsTest(unittest.TestCase):
+    """check_package_gate.py and check_verdict.py require each adopted document to be stamped
+    strictly after the documents it cites; the adopter has to write stamps that satisfy that."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.target = Path(self.temporary.name) / "model"
+        (self.target / "artifacts").mkdir(parents=True)
+        self.manifest_path = write_artifact_manifest(self.target, "example/demo", "example__demo")
+        write_package_gate(self.target, self.manifest_path)
+        write_verdict(self.target, "example/demo", "example__demo", {})
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def document(self, name: str) -> dict:
+        return read_json(self.target / "artifacts" / name)
+
+    def test_the_package_gate_is_stamped_after_the_manifest_it_cites(self) -> None:
+        require_timestamp_after(
+            "package_gate.json",
+            self.document("package_gate.json"),
+            ("artifact_manifest.json", self.document("artifact_manifest.json")),
+        )
+
+    def test_the_verdict_is_stamped_after_the_package_gate(self) -> None:
+        require_timestamp_after(
+            "verdict.json",
+            self.document("verdict.json"),
+            ("package_gate.json", self.document("package_gate.json")),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Full-tree projection of the GitLab mainline at 153aaf5 (parent bf1ef2d).

- sure_onboard: adopt_reference_model.py stamps the adopted package gate after the manifest it cites and the verdict after the gate (check_package_gate.py / check_verdict.py require that ordering); new unit test; the state-machine adopt test judges the real stamps instead of pinning them.

Regenerates public-export-manifest.json. No GitHub-only commits since bf1ef2d.