### PR TITLE
chore(public): sync GitLab projection through ed3f5ba

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -49,6 +49,9 @@ jobs:
           "$RUNNER_TEMP/sure-harness-venv/bin/pip" install --require-hashes -r sure/runtime/harness/requirements.lock.txt
           echo "$RUNNER_TEMP/sure-harness-venv/bin" >> "$GITHUB_PATH"
 
+      - name: Materialize the Harness Runtime
+        run: python sure/runtime/harness/bootstrap.py --json > /dev/null
+
       - name: Configure the public CI fixture
         run: |
           cp config/site.example.yaml config/site.local.yaml

--- a/packages/coding-agent/test/sure-harness-runtime.setup.ts
+++ b/packages/coding-agent/test/sure-harness-runtime.setup.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+// vitest globalSetup: materialize the Harness Runtime once, before any worker starts.
+//
+// sure_onboard's preStart resolves the runtime through sure/runtime/harness/bootstrap.py. On a
+// fresh checkout, a fresh CI runner, or after the dependency lock changes, that bootstrap runs
+// `uv sync` for half a minute to two minutes while holding the runtime lock. Left to the first
+// test that needs the runtime, the wait lands inside a 30s test budget and every other worker's
+// first harness test blocks on the same lock, so unrelated files time out together.
+export default function setup(): void {
+	const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+	const python = process.env.SURE_HARNESS_BOOTSTRAP_PYTHON?.trim() || "python3";
+	const started = Date.now();
+	const result = spawnSync(python, ["sure/runtime/harness/bootstrap.py", "--json"], {
+		cwd: repoRoot,
+		encoding: "utf-8",
+		timeout: 900_000,
+	});
+	if (result.status !== 0) {
+		// Not fatal: the tests that need the runtime report this failure themselves.
+		const detail = (result.stderr || result.stdout || result.error?.message || "").trim().split("\n").pop();
+		console.warn(`[sure] harness runtime bootstrap skipped: ${detail || `exit ${result.status}`}`);
+		return;
+	}
+	const seconds = (Date.now() - started) / 1000;
+	if (seconds > 5) {
+		console.log(`[sure] harness runtime materialized in ${seconds.toFixed(1)}s before the tests`);
+	}
+}

--- a/packages/coding-agent/vitest.config.ts
+++ b/packages/coding-agent/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 		globals: true,
 		environment: "node",
 		testTimeout: 30000,
+		globalSetup: ["./test/sure-harness-runtime.setup.ts"],
 		server: {
 			deps: {
 				external: [/@silvia-odwyer\/photon-node/],

--- a/public-export-manifest.json
+++ b/public-export-manifest.json
@@ -1,7 +1,7 @@
 {
   "schema": "sure.public_export_manifest.v2",
-  "projection_id": "sha256:3d611fb50a670c10b459db0d4075fb664c2be3c1fdef53fed41c8072f4b942de",
-  "tree_sha256": "3d611fb50a670c10b459db0d4075fb664c2be3c1fdef53fed41c8072f4b942de",
+  "projection_id": "sha256:45baf21b44dd266269f1abf09658bc7f9e2fe90a92857d6257ee5af7d406f048",
+  "tree_sha256": "45baf21b44dd266269f1abf09658bc7f9e2fe90a92857d6257ee5af7d406f048",
   "files": [
     {
       "path": ".gitattributes",
@@ -13,7 +13,7 @@
       "path": ".github/workflows/public-ci.yml",
       "type": "file",
       "mode": "100644",
-      "sha256": "4c588c748d8300731ef11dd1249df642ce698bdef9aee16f6cdbea86a9215215"
+      "sha256": "0e7036a591458f4722dd51014bbce13ce69a0bdd72c39b28815278a8bdf53292"
     },
     {
       "path": ".gitignore",
@@ -5734,6 +5734,12 @@
       "sha256": "13e052f4f667426d627a90cf1f9d0169a57d926bbee8dc291478a7cf833489d6"
     },
     {
+      "path": "packages/coding-agent/test/sure-harness-runtime.setup.ts",
+      "type": "file",
+      "mode": "100644",
+      "sha256": "02812a6adb6ed869bcbff0a789213c57b589dd7152e32095c9d02e23e2a26321"
+    },
+    {
       "path": "packages/coding-agent/test/sure/init-apply.test.ts",
       "type": "file",
       "mode": "100644",
@@ -5911,7 +5917,7 @@
       "path": "packages/coding-agent/vitest.config.ts",
       "type": "file",
       "mode": "100644",
-      "sha256": "5023d933f47ee3a8904281b45725e16a6ac5b64bd373115493fcdfede01a0aec"
+      "sha256": "d883e73f17e99a4b07e3def5f795afe2316b17dc51ece6c2681c02cca2732f96"
     },
     {
       "path": "packages/orchestrator/CHANGELOG.md",


### PR DESCRIPTION
Full-tree projection of the GitLab mainline at ed3f5ba (parent c09b02e).

- tests: a vitest globalSetup materializes the Harness Runtime once before any worker starts, and the public CI gets a "Materialize the Harness Runtime" step after installing uv and the lock. The cold `uv sync` used to run inside the first test that called preStart, within a 30s test budget, which is what made `sure_onboard MODEL_INPUT startup` time out on some runs.

Regenerates public-export-manifest.json. No GitHub-only commits since c09b02e.