### PR TITLE
fix(sure-eval): zbc-fix-API

### DIFF
--- a/packages/coding-agent/src/core/sure/init.ts
+++ b/packages/coding-agent/src/core/sure/init.ts
@@ -197,7 +197,11 @@ async function ensureAuth(
 	ctx: ExtensionCommandContext,
 	args: SureInitArgs,
 ): Promise<{ ok: boolean; message?: string }> {
-	if (modelRegistry.hasConfiguredAuth({ provider: option.provider, id: option.defaultModel } as any)) {
+	const hasConfiguredAuth = modelRegistry.hasConfiguredAuth({
+		provider: option.provider,
+		id: option.defaultModel,
+	} as any);
+	if (!args.apiKey?.trim() && hasConfiguredAuth) {
 		return { ok: true };
 	}
 
@@ -205,7 +209,7 @@ async function ensureAuth(
 		return runOAuthLogin(option, modelRegistry, ctx);
 	}
 
-	let apiKey = args.apiKey;
+	let apiKey = args.apiKey?.trim();
 	if (!apiKey) {
 		if (!ctx.hasUI) {
 			return {

--- a/packages/coding-agent/test/sure/init.test.ts
+++ b/packages/coding-agent/test/sure/init.test.ts
@@ -205,8 +205,11 @@ describe("parseInitArgs", () => {
 
 describe("runSureInit", () => {
 	let tempDir: string;
+	let previousKimiApiKey: string | undefined;
 
 	beforeEach(() => {
+		previousKimiApiKey = process.env.KIMI_API_KEY;
+		delete process.env.KIMI_API_KEY;
 		tempDir = join(tmpdir(), `pi-sure-init-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 		mkdirSync(tempDir, { recursive: true });
 	});
@@ -214,6 +217,11 @@ describe("runSureInit", () => {
 	afterEach(() => {
 		if (existsSync(tempDir)) {
 			rmSync(tempDir, { recursive: true, force: true });
+		}
+		if (previousKimiApiKey === undefined) {
+			delete process.env.KIMI_API_KEY;
+		} else {
+			process.env.KIMI_API_KEY = previousKimiApiKey;
 		}
 		vi.unstubAllGlobals();
 	});


### PR DESCRIPTION
Rebased onto the current checkout. Keeps the init auth precedence fix on top of the refreshed base.