### PR TITLE
docs(sure): sync command list and eval config docs with the six-command refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,7 @@ Attribution:
 
 ## SURE Harness
 
-This fork adds the SURE evaluation control plane (`/sure_feed`, `/sure_onboard`, `/sure_infer`, `/sure_eval`). The common user entry point is `README.md`; bundled company distributions also carry `private/site/docs/handbook.md`. This section is the maintainer side.
+This fork adds the SURE evaluation control plane: six skill commands (`/sure_feed`, `/sure_onboard`, `/sure_trans`, `/sure_approve`, `/sure_infer`, `/sure_eval`) plus the built-in `/sure_init` and `/sure_resume` commands. The common user entry point is `README.md`; bundled company distributions also carry `private/site/docs/handbook.md`. This section is the maintainer side.
 
 ### Skill Package Layout
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Configure `storage.approved_models_roots[0]` once. `/sure_approve` publishes app
 
 For `docker-registry` delivery, the active site policy supplies the registry and repository template. SURE resolves the image destination and version before planning, rather than allowing an agent to invent a namespace; registry credentials remain in the deployment's Docker credential store.
 
-Site policy is independent from the evaluation engine configuration. Evaluation still resolves `config=` first, then `SURE_EVAL_CONFIG`, then the evaluation submodule's `config/default.yaml`.
+Site policy is independent from the evaluation engine configuration. `/sure_infer` resolves its `config=` parameter first, then `SURE_EVAL_CONFIG`, then the evaluation submodule's `config/default.yaml`. `/sure_eval` rejects an explicit `config=`; it always scores the source bundle as resolved.
 
 ## Verify Installation
 

--- a/docs/evaluation_engine.md
+++ b/docs/evaluation_engine.md
@@ -28,7 +28,7 @@ sure/external/sure-evaluation
 git submodule update --init --recursive
 ```
 
-要指到另一个 checkout(高级用法,跟 `evaluation_engine_root=` 参数干的是同一件事):
+要指到另一个 checkout(高级用法;`/sure_eval` 不接受 `evaluation_engine_root=` 参数,只能用这个环境变量):
 
 ```bash
 export SURE_EVALUATION_HOME=/path/to/sure-evaluation


### PR DESCRIPTION
## What

Docs-only sync after the six-command refactor:

1. `AGENTS.md`: the SURE Harness section listed only four commands (`/sure_feed`, `/sure_onboard`, `/sure_infer`, `/sure_eval`). It now lists all six skill commands (adding `/sure_trans` and `/sure_approve`) plus the built-in `/sure_init` and `/sure_resume`.
2. `README.md`: the evaluation config resolution chain (`config=` → `SURE_EVAL_CONFIG` → submodule `config/default.yaml`) belongs to `/sure_infer` input resolution. `/sure_eval` rejects an explicit `config=`; the sentence now says so.
3. `docs/evaluation_engine.md`: removed the reference to the `evaluation_engine_root=` slash-command parameter, which `/sure_eval` now rejects; `SURE_EVALUATION_HOME` is documented as the remaining override.

## Verification

Compared against current sources: `sure/skills/*/sure.skill.json`, `packages/coding-agent/src/core/sure/manifest.ts` (`SURE_COMMANDS`), `packages/coding-agent/src/core/sure/extension.ts` (`sure_init` / `sure_resume` registration), `sure/skills/sure_eval/SKILL.md` (rejected parameters), and `sure/skills/sure_infer/scripts/resolve_eval_input.py` (config precedence).

This PR is AI-generated.
