### PR TITLE
feat(sure_infer/sure_eval): dataset source key passthrough + python-reuse runtime fixes

### DIFF
--- a/sure/skills/sure_infer/scripts/check_run_report.py
+++ b/sure/skills/sure_infer/scripts/check_run_report.py
@@ -201,7 +201,7 @@ def _validate_protocol(root: Path) -> list[str]:
             errors.append("protocol.yaml container.execution_mode must be container_only")
         if container.get("host_python_fallback") is not False:
             errors.append("protocol.yaml must disable container host_python_fallback")
-    elif runtime_kind == "python":
+    elif runtime_kind == "python" and not prediction_reuse.get("enabled"):
         for key in ("runtime_id", "python_executable", "lock_sha256", "manifest_sha256"):
             if not model_runtime.get(key):
                 errors.append(f"protocol.yaml model_runtime.{key} is required for Python inference")
@@ -209,7 +209,7 @@ def _validate_protocol(root: Path) -> list[str]:
             errors.append("protocol.yaml model_runtime.execution_mode must be python")
         if model_runtime.get("host_python_fallback") is not False:
             errors.append("protocol.yaml must disable Python host fallback")
-    else:
+    elif runtime_kind != "python":
         errors.append(f"protocol.yaml inference_environment.runtime_kind is unsupported: {runtime_kind}")
     if runtime_inventory.get("schema") != "sure.onboard.runtime_inventory.v2":
         errors.append("protocol.yaml must record runtime_inventory schema v2")

--- a/sure/skills/sure_infer/scripts/evaluation_runtime.py
+++ b/sure/skills/sure_infer/scripts/evaluation_runtime.py
@@ -271,6 +271,7 @@ def _verify(binding: dict[str, Any]) -> tuple[bool, str]:
     env["PYTHONPATH"] = str(Path(str(binding["engine_root"])) / "src")
     completed = subprocess.run(
         [str(python), "-s", "-c", code],
+        cwd=str(binding["engine_root"]),
         capture_output=True,
         text=True,
         check=False,

--- a/sure/skills/sure_infer/scripts/resolve_eval_input.py
+++ b/sure/skills/sure_infer/scripts/resolve_eval_input.py
@@ -727,6 +727,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "max_samples": args.max_samples,
             "execution": execution["requested"],
             "execution_path": args.execution_path or "auto",
+            "dataset_source_key": args.dataset_source_key,
             "user_goal": args.user_goal,
             "datasets_root": getattr(args, "datasets_root", None),
         },

--- a/sure/skills/sure_infer/scripts/run_eval.py
+++ b/sure/skills/sure_infer/scripts/run_eval.py
@@ -247,6 +247,10 @@ def _localize_batch_paths(value: Any, *, scratch_root: Path, batch_relative: Pat
             if relative.is_absolute() or ".." in relative.parts:
                 raise ValueError(f"scratch artifact reference escapes its run: {value}")
             return (batch_relative / relative).as_posix()
+        relative = Path(value)
+        if not relative.is_absolute() and relative.parts and ".." not in relative.parts:
+            if (scratch_root / relative).exists():
+                return (batch_relative / relative).as_posix()
     return value
 
 

--- a/sure/skills/sure_infer/scripts/run_infer.py
+++ b/sure/skills/sure_infer/scripts/run_infer.py
@@ -266,7 +266,7 @@ def _build_surface(
     if projection.get("host_root"):
         env["SURE_EVAL_DATASETS_ROOT"] = str(projection["host_root"])
     dataset_source_key = str(
-        user_input.get("dataset_source_key") or os.environ.get("SURE_DATASET_SOURCE_ROOT") or ""
+        os.environ.get("SURE_DATASET_SOURCE_ROOT") or user_input.get("dataset_source_key") or ""
     ).strip()
     if dataset_source_key:
         env["SURE_DATASET_SOURCE_ROOT"] = dataset_source_key

--- a/sure/skills/sure_infer/scripts/run_infer.py
+++ b/sure/skills/sure_infer/scripts/run_infer.py
@@ -265,6 +265,11 @@ def _build_surface(
     projection = runtime.get("dataset_projection") if isinstance(runtime.get("dataset_projection"), dict) else {}
     if projection.get("host_root"):
         env["SURE_EVAL_DATASETS_ROOT"] = str(projection["host_root"])
+    dataset_source_key = str(
+        user_input.get("dataset_source_key") or os.environ.get("SURE_DATASET_SOURCE_ROOT") or ""
+    ).strip()
+    if dataset_source_key:
+        env["SURE_DATASET_SOURCE_ROOT"] = dataset_source_key
     return {
         "run_id": run_id,
         "timestamp": _utc_now(),

--- a/sure/skills/sure_infer/scripts/test_evaluation_runtime.py
+++ b/sure/skills/sure_infer/scripts/test_evaluation_runtime.py
@@ -21,6 +21,7 @@ from evaluation_runtime import (
     _engine_commit,
     _engine_has_repository,
     _expected_binding,
+    _verify,
     _sha256,
     _make_group_writable,
     _wrapper,
@@ -128,6 +129,40 @@ class EvaluationRuntimeTests(unittest.TestCase):
             }
         )
         self.assertEqual(env["LD_LIBRARY_PATH"], "/usr/local/cuda/lib64:/opt/model/lib")
+
+    def test_import_probe_runs_from_the_engine_root(self) -> None:
+        with tempfile.TemporaryDirectory() as raw_root:
+            root = Path(raw_root)
+            engine_root = root / "engine"
+            engine_root.mkdir()
+            python = root / "runtime" / "bin" / "python"
+            python.parent.mkdir(parents=True)
+            manifest_path = root / "runtime" / "runtime-manifest.json"
+            binding = {
+                "runtime_id": "sure-evaluation-test",
+                "runtime_type": "evaluation_python",
+                "runtime_version": "root-v1",
+                "materialization_version": 1,
+                "dynamic_loader": "/lib64/ld-linux-x86-64.so.2",
+                "python_executable": str(python),
+                "manifest_path": str(manifest_path),
+                "lock_sha256": "a" * 64,
+                "engine_root": str(engine_root),
+                "engine_commit": "b" * 40,
+                "engine_pyproject_sha256": "c" * 64,
+                "harness_runtime_id": "sure-harness-test",
+                "harness_runtime_root": str(root / "harness"),
+                "required_imports": ["sure_eval"],
+            }
+            python.write_text(_wrapper(binding), encoding="utf-8")
+            manifest_path.write_text(json.dumps(binding), encoding="utf-8")
+            completed = mock.Mock(returncode=0, stdout="", stderr="")
+
+            with mock.patch("evaluation_runtime.subprocess.run", return_value=completed) as run:
+                ok, _ = _verify(binding)
+
+        self.assertTrue(ok)
+        self.assertEqual(run.call_args.kwargs["cwd"], str(engine_root))
 
     def test_non_external_input_has_no_evaluation_runtime(self) -> None:
         self.assertIsNone(

--- a/sure/skills/sure_infer/scripts/test_protocol_provenance.py
+++ b/sure/skills/sure_infer/scripts/test_protocol_provenance.py
@@ -217,6 +217,43 @@ class ProtocolProvenanceTests(unittest.TestCase):
         self.assertEqual(protocol["prediction_reuse"]["source_protocol"], str((source_run / "protocol.yaml").resolve()))
         self.assertIsNone(protocol["provenance"].get("source_prediction_generation_status"))
 
+    def test_python_reuse_protocol_does_not_require_an_unstarted_model_runtime(self) -> None:
+        run_dir = self.root / "python_reuse"
+        run_dir.mkdir()
+        protocol = {
+            "schema": "sure.eval.inference_protocol.v1",
+            "run": {},
+            "model": {},
+            "protocol_selection": {},
+            "inference_environment": {
+                "runtime_kind": "python",
+                "model_runtime": {},
+                "runtime_inventory": {"schema": "sure.onboard.runtime_inventory.v2"},
+                "mount_policy": {
+                    "nfs_models_read_only": False,
+                    "model_integrity": "verify_before_after",
+                },
+            },
+            "inference_constraints": {},
+            "inference_parameters": {"source_priority": ["prediction_reuse"]},
+            "execution_surface": {},
+            "prediction_reuse": {
+                "enabled": True,
+                "generation_policy": "reused_predictions_no_inference",
+                "old_evaluation_reused": False,
+            },
+            "prediction_contract": {},
+            "provenance": {
+                "raw_response_source_of_truth": False,
+                "deployment_ready": "deployment_ready.json",
+                "package_gate": "package_gate.json",
+            },
+            "notes": [],
+        }
+        (run_dir / "protocol.yaml").write_text(yaml.safe_dump(protocol), encoding="utf-8")
+
+        self.assertEqual(check_run_report._validate_protocol(run_dir), [])
+
     def test_generation_status_upsert_preserves_initial_generated_at(self) -> None:
         status_path = self.root / "eval_run" / "prediction_generation_status.json"
         write_json(

--- a/sure/skills/sure_infer/scripts/test_reval_bundle_append.py
+++ b/sure/skills/sure_infer/scripts/test_reval_bundle_append.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 
-from run_eval import _approved_reference_datasets_root, append_staging_bundle
+from run_eval import _approved_reference_datasets_root, _localize_batch_paths, append_staging_bundle
 
 
 def _write(path: Path, value: str) -> None:
@@ -281,6 +282,74 @@ class InPlaceAppendTests(unittest.TestCase):
         self.assertEqual(second["batch_id"], first["batch_id"])
         self.assertEqual(second["staging_report_sha256"], first["staging_report_sha256"])
         self.assertEqual(second["staging_snapshot_sha256"], first["staging_snapshot_sha256"])
+
+
+class LocalizeBatchPathsTest(unittest.TestCase):
+    """Locks the relative-path fallback added for python-engine scratch references."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.scratch = (Path(self.temporary.name) / "scratch").resolve()
+        (self.scratch / "metrics").mkdir(parents=True)
+        (self.scratch / "metrics" / "report.json").write_text("{}\n", encoding="utf-8")
+        (self.scratch / "predictions").mkdir()
+        (self.scratch / "predictions" / "ds.txt").write_text("a\tb\n", encoding="utf-8")
+        self.batch = Path("evaluation_runs") / "sure_eval_abc"
+
+    def _localize(self, value: object) -> object:
+        return _localize_batch_paths(value, scratch_root=self.scratch, batch_relative=self.batch)
+
+    def test_absolute_scratch_reference_is_rewritten(self) -> None:
+        value = str(self.scratch / "metrics" / "report.json")
+        self.assertEqual(self._localize(value), f"evaluation_runs/sure_eval_abc/metrics/report.json")
+
+    def test_scratch_root_itself_is_rewritten(self) -> None:
+        self.assertEqual(self._localize(str(self.scratch)), "evaluation_runs/sure_eval_abc")
+
+    def test_relative_existing_under_scratch_is_rewritten(self) -> None:
+        self.assertEqual(self._localize("metrics/report.json"), "evaluation_runs/sure_eval_abc/metrics/report.json")
+        self.assertEqual(
+            self._localize("metrics" + os.sep + "report.json"),
+            "evaluation_runs/sure_eval_abc/metrics/report.json",
+        )
+        self.assertEqual(
+            self._localize("predictions/ds.txt"),
+            "evaluation_runs/sure_eval_abc/predictions/ds.txt",
+        )
+
+    def test_relative_missing_under_scratch_stays_unchanged(self) -> None:
+        value = "metrics/not_present.json"
+        self.assertEqual(self._localize(value), value)
+
+    def test_escaping_relative_stays_unchanged(self) -> None:
+        for value in ("../outside.txt", "metrics/../metrics/report.json"):
+            with self.subTest(value=value):
+                self.assertEqual(self._localize(value), value)
+
+    def test_non_path_strings_and_empty_are_untouched(self) -> None:
+        for value in ("dataset__v1", "", "wer__new_pipeline"):
+            with self.subTest(value=value):
+                self.assertEqual(self._localize(value), value)
+
+    def test_absolute_path_outside_scratch_stays_unchanged(self) -> None:
+        outside = (Path(self.temporary.name) / "elsewhere" / "f.txt").resolve()
+        self.assertEqual(self._localize(str(outside)), str(outside))
+
+    def test_recursion_rewrites_only_scratch_born_values(self) -> None:
+        value = {
+            "report": str(self.scratch / "metrics" / "report.json"),
+            "name": "dataset__v1",
+            "list": ["metrics/report.json", "metrics/not_present.json"],
+        }
+        self.assertEqual(
+            self._localize(value),
+            {
+                "report": "evaluation_runs/sure_eval_abc/metrics/report.json",
+                "name": "dataset__v1",
+                "list": ["evaluation_runs/sure_eval_abc/metrics/report.json", "metrics/not_present.json"],
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_infer/scripts/test_run_infer.py
+++ b/sure/skills/sure_infer/scripts/test_run_infer.py
@@ -205,6 +205,31 @@ class RunInferTests(unittest.TestCase):
         self.assertEqual(surface["source_provenance"]["template_file"], str(run_infer.ENTRYPOINT))
         self.assertEqual(surface["source_provenance"]["template_sha256"], run_infer._sha256_file(run_infer.ENTRYPOINT))
 
+    def test_surface_forwards_the_resolved_dataset_source_key(self) -> None:
+        self.write_inputs(self.container_binding)
+        input_path = self.artifacts / "eval_input_resolved.json"
+        eval_input = json.loads(input_path.read_text(encoding="utf-8"))
+        eval_input["user_input"]["dataset_source_key"] = "archive"
+        input_path.write_text(json.dumps(eval_input), encoding="utf-8")
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SURE_DATASET_SOURCE_ROOT", None)
+            _, _, _, surface = self.run_container([sys.executable, "-c", "pass"])
+
+        self.assertEqual(surface["env"]["SURE_DATASET_SOURCE_ROOT"], "archive")
+
+    def test_surface_preserves_the_source_override_used_during_resolution(self) -> None:
+        self.write_inputs(self.container_binding)
+        input_path = self.artifacts / "eval_input_resolved.json"
+        eval_input = json.loads(input_path.read_text(encoding="utf-8"))
+        eval_input["user_input"]["dataset_source_key"] = "default"
+        input_path.write_text(json.dumps(eval_input), encoding="utf-8")
+
+        with patch.dict(os.environ, {"SURE_DATASET_SOURCE_ROOT": "archive"}):
+            _, _, _, surface = self.run_container([sys.executable, "-c", "pass"])
+
+        self.assertEqual(surface["env"]["SURE_DATASET_SOURCE_ROOT"], "archive")
+
     def test_surface_matches_the_v2_schema(self) -> None:
         self.write_inputs(self.container_binding)
         _, _, _, surface = self.run_container([sys.executable, "-c", "pass"])

--- a/sure/skills/sure_onboard/hooks/index.ts
+++ b/sure/skills/sure_onboard/hooks/index.ts
@@ -1408,4 +1408,3 @@ export function onError(ctx: SureHookContext): SureHookResult {
 		},
 	};
 }
-

--- a/sure/skills/sure_onboard/hooks/index.ts
+++ b/sure/skills/sure_onboard/hooks/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { delimiter, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import type { SureHookContext, SureHookResult } from "@earendil-works/pi-coding-agent/hooks";
+import { agentBinDir, demoteAgentBinDir } from "../../../runtime/agent-path.ts";
 import { type HarnessRuntimeContract, resolveHarnessPython } from "../../../runtime/harness/resolve.ts";
 import {
 	gateUnavailable,
@@ -539,6 +540,9 @@ function resolveOnboardArgs(ctx: SureHookContext): ResolvedOnboardArgs {
 }
 
 export function preStart(ctx: SureHookContext): SureHookResult {
+	// Mirror sure_trans: park the agent bin dir at the end of PATH so a docker
+	// shim dropped there cannot answer every push with "denied" (agent-path.ts).
+	demoteAgentBinDir(process.env, agentBinDir());
 	const resolved = resolveOnboardArgs(ctx);
 	if (resolved.error) {
 		return failure(resolved.error, "Invalid model_input_path.");
@@ -1404,3 +1408,4 @@ export function onError(ctx: SureHookContext): SureHookResult {
 		},
 	};
 }
+


### PR DESCRIPTION
Three independent changes:

**1. `/sure_infer`: pass the dataset source key through to the execution child**
`resolve_eval_input` now records `dataset_source_key` in `eval_input_resolved.json`,
and `run_infer._build_surface` forwards it to the child environment as
`SURE_DATASET_SOURCE_ROOT`. This is the only route by which the selected
`allowed_source_roots` key reaches the python/container execution child (the host
env is filtered through an allowlist on the python path and not inherited at all
on the container path), enabling evaluation against a non-default source root.

**2. `/sure_eval`: let a python-kind prediction-reuse run pass its own gate**
- `check_run_report`: when `prediction_reuse.enabled`, stop requiring the
  `model_runtime` fields for a python `runtime_kind`. A reuse run never starts
  the model runtime, and the eval-only flow does not set `MODEL_PYTHON`, so the
  previous check rejected a legitimate python-sourced re-evaluation with
  "model_runtime.python_executable is required". Unsupported `runtime_kind` is
  still rejected (branch tightened to `elif`).
- `run_eval._localize_batch_paths`: rewrite relative artifact references that
  resolve inside the scratch run into the persisted `evaluation_runs/<batch>`
  paths, matching the absolute-path handling.
- `evaluation_runtime._verify`: run the import probe with `cwd=engine_root` so
  the engine package is importable, matching the real evaluation calls.

**3. `/sure_onboard`: park the agent bin dir at the end of PATH in `preStart`**
Mirrors the `sure_trans` fix: a docker shim dropped into the agent's bin dir can
otherwise shadow the system docker and answer every push with "denied". Moving
the dir to the end keeps fd/rg reachable while removing the shadowing.