### PR TITLE
fix(coding-agent): align SURE provider and adapter contracts

### DIFF
--- a/packages/coding-agent/src/core/sure/init-model-listing.ts
+++ b/packages/coding-agent/src/core/sure/init-model-listing.ts
@@ -105,6 +105,7 @@ export async function listBuiltInProviderModels(
 ): Promise<ModelListing> {
 	try {
 		switch (option.provider) {
+			case "deepseek":
 			case "openai":
 			case "kimi-coding": {
 				const apiKey = await modelRegistry.getApiKeyForProvider(option.provider);

--- a/packages/coding-agent/src/core/sure/init.ts
+++ b/packages/coding-agent/src/core/sure/init.ts
@@ -76,6 +76,14 @@ export const SURE_INIT_PROVIDER_OPTIONS: SureInitProviderOption[] = [
 		description: "Standard OpenAI API",
 	},
 	{
+		id: "deepseek",
+		name: "DeepSeek",
+		provider: "deepseek",
+		defaultModel: "deepseek-v4-flash",
+		authType: "api_key",
+		description: "Standard DeepSeek API",
+	},
+	{
 		id: "azure-openai",
 		name: "Azure OpenAI (Responses)",
 		provider: "azure-openai-responses",

--- a/packages/coding-agent/test/sure/init-provider-options.test.ts
+++ b/packages/coding-agent/test/sure/init-provider-options.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AuthStorage } from "../../src/core/auth-storage.ts";
+import { ModelRegistry } from "../../src/core/model-registry.ts";
+import { needsCapabilityProbe, SURE_INIT_PROVIDER_OPTIONS } from "../../src/core/sure/init.ts";
+import { listBuiltInProviderModels } from "../../src/core/sure/init-model-listing.ts";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("SURE init provider options", () => {
+	it("offers the built-in DeepSeek provider with its catalog default", () => {
+		expect(SURE_INIT_PROVIDER_OPTIONS.find((option) => option.id === "deepseek")).toEqual({
+			id: "deepseek",
+			name: "DeepSeek",
+			provider: "deepseek",
+			defaultModel: "deepseek-v4-flash",
+			authType: "api_key",
+			description: "Standard DeepSeek API",
+		});
+		expect(needsCapabilityProbe("deepseek", "deepseek-v4-flash")).toBe(false);
+	});
+
+	it("queries the official DeepSeek model list when auth is configured", async () => {
+		const option = SURE_INIT_PROVIDER_OPTIONS.find((entry) => entry.id === "deepseek");
+		if (!option) throw new Error("missing DeepSeek option");
+		const registry = ModelRegistry.inMemory(AuthStorage.inMemory({ deepseek: { type: "api_key", key: "sk-live" } }));
+		const fetchMock = vi.fn(async () => Response.json({ data: [{ id: "deepseek-v4-flash" }] }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const listing = await listBuiltInProviderModels(option, registry);
+
+		expect(listing).toEqual({ source: "live", models: [{ id: "deepseek-v4-flash" }] });
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.deepseek.com/v1/models",
+			expect.objectContaining({
+				headers: expect.objectContaining({ Authorization: "Bearer sk-live" }),
+			}),
+		);
+	});
+});

--- a/sure/skills/sure_trans/scripts/templates/server.py
+++ b/sure/skills/sure_trans/scripts/templates/server.py
@@ -20,6 +20,7 @@ def respond(payload: dict) -> None:
 
 def main() -> int:
     wrapper = ModelWrapper()
+    loaded = False
     for line in sys.stdin:
         if not line.strip():
             continue
@@ -40,8 +41,9 @@ def main() -> int:
                     if params.get("name") == "healthcheck":
                         result = wrapper.healthcheck()
                     else:
-                        if wrapper.model is None:
+                        if not loaded:
                             wrapper.load()
+                            loaded = True
                         arguments = params.get("arguments") if isinstance(params.get("arguments"), dict) else {}
                         result = wrapper.predict(arguments)
                 respond({"jsonrpc": "2.0", "id": request_id, "result": {"content": [{"type": "text", "text": json.dumps(result, ensure_ascii=False)}]}})

--- a/sure/skills/sure_trans/scripts/test_server_template_contract.py
+++ b/sure/skills/sure_trans/scripts/test_server_template_contract.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+
+
+class ServerTemplateContractTests(unittest.TestCase):
+    def test_server_loads_wrapper_once_without_model_attribute(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "model.py").write_text(
+                "class ModelWrapper:\n"
+                "    def __init__(self):\n"
+                "        self.loaded = False\n"
+                "    def load(self):\n"
+                "        if self.loaded:\n"
+                "            raise RuntimeError('load called twice')\n"
+                "        self.loaded = True\n"
+                "    def predict(self, input_data):\n"
+                "        if not self.loaded:\n"
+                "            raise RuntimeError('predict called before load')\n"
+                "        return {'text': input_data['audio_path']}\n"
+                "    def healthcheck(self):\n"
+                "        return {'status': 'ok'}\n",
+                encoding="utf-8",
+            )
+            template = (SCRIPTS_DIR / "templates" / "server.py").read_text(encoding="utf-8")
+            rendered = template.replace('"__TOOL_NAME__"', '"transcribe_audio"').replace(
+                "__INPUT_SCHEMA__",
+                '{"type":"object","properties":{"audio_path":{"type":"string"}},"required":["audio_path"]}',
+            )
+            server = root / "server.py"
+            server.write_text(rendered, encoding="utf-8")
+            requests = (
+                {"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": "transcribe_audio", "arguments": {"audio_path": "one.wav"}},
+                },
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "transcribe_audio", "arguments": {"audio_path": "two.wav"}},
+                },
+                {"jsonrpc": "2.0", "id": 4, "method": "shutdown"},
+            )
+            completed = subprocess.run(
+                [sys.executable, str(server)],
+                input="".join(json.dumps(request) + "\n" for request in requests),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=30,
+                cwd=root,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            responses = [json.loads(line) for line in completed.stdout.splitlines() if line.strip()]
+            self.assertEqual([response["id"] for response in responses], [1, 2, 3, 4])
+            self.assertTrue(all("result" in response for response in responses))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add DeepSeek as a built-in SURE init provider and query its official model endpoint
- keep generated MCP servers compatible with the documented `ModelWrapper` contract
- add TypeScript and Python regression coverage for both paths

## Testing

- `npm run check`
- `npm run check:sure-hooks`
- targeted SURE init tests: 16 passed
- SURE trans Python tests: 58 passed
- `./test.sh`: affected tests pass; four existing `sure-extension.test.ts` failures reproduce unchanged on base commit `6f8a661`

No changelog entry was added, per `CONTRIBUTING.md`.
