### PR TITLE
fix(agent): support VAD pool dataset projections

### DIFF
--- a/sure/skills/sure_infer/scripts/resolve_eval_input.py
+++ b/sure/skills/sure_infer/scripts/resolve_eval_input.py
@@ -29,6 +29,7 @@ from sure_eval.datasets.source_resolver import (
     SourceResolutionError,
     is_source_entry,
     read_source_language,
+    read_source_task,
     resolve_site_source_entry,
 )
 
@@ -492,6 +493,8 @@ def _fallback_default_metrics(task: str, language: str) -> list[str]:
         return ["wer"] if language_lower == "en" else ["cer"]
     if task_upper in {"TTS", "VC"}:
         return []
+    if task_upper == "VAD":
+        return ["f1"]
     return [TEXT_DEFAULT_METRICS.get(task_upper, "accuracy")]
 
 
@@ -540,7 +543,7 @@ def _dataset_details(
             source_root = source_root or ref.source_root
             source_name = source_name or ref.source_dataset_name
             version_id = version_id or ref.version_id
-            dataset_task = dataset_task or "ASR"
+            dataset_task = dataset_task or read_source_task(ref) or "ASR"
             language = language or (read_source_language(ref) or "auto").lower()
         task = _effective_dataset_task(dataset_task, model_task, requested_metrics)
         if not task:

--- a/sure/skills/sure_infer/scripts/sure_eval/datasets/dataset_manager.py
+++ b/sure/skills/sure_infer/scripts/sure_eval/datasets/dataset_manager.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import csv
 import json
+import math
 import shutil
 import subprocess
 from datetime import datetime, timezone
@@ -24,6 +25,7 @@ from sure_eval.core.logging import get_logger
 from .source_resolver import (
     DatasetSourceRef,
     is_source_entry,
+    read_source_task,
     resolve_site_source_entry,
 )
 
@@ -482,6 +484,35 @@ class DatasetManager:
                 return text.strip()
         return ""
 
+    def _extract_oref_speech_segments(
+        self, record: dict[str, Any]
+    ) -> tuple[list[dict[str, float]], str | None]:
+        annotations = record.get("annotation")
+        if not isinstance(annotations, list):
+            return [], "missing annotation list"
+
+        segments: list[dict[str, float]] = []
+        for annotation in annotations:
+            if not isinstance(annotation, dict):
+                continue
+            timestamp = annotation.get("timestamp")
+            if not isinstance(timestamp, dict):
+                continue
+            begin = timestamp.get("begin_time")
+            end = timestamp.get("end_time")
+            if begin is None or end is None:
+                continue
+            try:
+                start = float(begin)
+                finish = float(end)
+            except (TypeError, ValueError):
+                return [], "invalid VAD timestamp"
+            if not math.isfinite(start) or not math.isfinite(finish) or finish <= start:
+                return [], "invalid VAD timestamp interval"
+            segments.append({"start": start, "end": finish})
+
+        return segments, None
+
     def _resolve_oref_audio_path(self, raw_value: str, raw_dir: Path) -> Path:
         audio_path = Path(raw_value).expanduser()
         if audio_path.is_absolute():
@@ -538,10 +569,17 @@ class DatasetManager:
                         })
                         continue
 
-                text = self._extract_oref_transcription_text(record)
-                if not text:
-                    skipped.append({"line": line_no, "reason": "missing transcription text"})
-                    continue
+                speech_segments: list[dict[str, float]] | None = None
+                if task == "VAD":
+                    speech_segments, segment_error = self._extract_oref_speech_segments(record)
+                    if segment_error:
+                        skipped.append({"line": line_no, "reason": segment_error})
+                        continue
+                else:
+                    text = self._extract_oref_transcription_text(record)
+                    if not text:
+                        skipped.append({"line": line_no, "reason": "missing transcription text"})
+                        continue
 
                 key = str(record.get("sample_id") or audio_path.stem)
                 if key in seen_keys:
@@ -549,10 +587,9 @@ class DatasetManager:
                     continue
                 seen_keys.add(key)
 
-                rows.append({
+                row: dict[str, Any] = {
                     "key": key,
                     "path": str(audio_path),
-                    "target": text,
                     "task": task,
                     "language": language,
                     "dataset": dataset_label,
@@ -567,7 +604,22 @@ class DatasetManager:
                         "size": attr.get("size"),
                         "channels": attr.get("channels"),
                     },
-                })
+                }
+                if task == "VAD":
+                    duration_ms = attr.get("duration", 0)
+                    try:
+                        duration = float(duration_ms) / 1000.0
+                    except (TypeError, ValueError):
+                        skipped.append({"line": line_no, "reason": "invalid audio duration"})
+                        continue
+                    if not math.isfinite(duration) or duration <= 0:
+                        skipped.append({"line": line_no, "reason": "invalid audio duration"})
+                        continue
+                    row["duration"] = duration
+                    row["speech_segments"] = speech_segments or []
+                else:
+                    row["target"] = text
+                rows.append(row)
         return rows, skipped, source_records
 
     def _copy_source_files(
@@ -592,13 +644,33 @@ class DatasetManager:
     def _convert_source_root_to_jsonl(self, ref: DatasetSourceRef) -> Path:
         """Project a site dataset-pool source root into SURE-EVAL JSONL."""
         jsonl_path = self.jsonl_dir / f"{ref.dataset_id}.jsonl"
+        source_task = read_source_task(ref)
         if jsonl_path.exists():
+            existing_task = ""
+            try:
+                with jsonl_path.open("r", encoding="utf-8") as handle:
+                    for line in handle:
+                        if line.strip():
+                            payload = json.loads(line)
+                            if isinstance(payload, dict):
+                                existing_task = str(payload.get("task") or "").strip().upper()
+                            break
+            except (OSError, json.JSONDecodeError):
+                pass
+            if not source_task or existing_task == source_task:
+                logger.info(
+                    "Using existing source-root projection",
+                    dataset=ref.dataset_id,
+                    jsonl=str(jsonl_path),
+                )
+                return jsonl_path
             logger.info(
-                "Using existing source-root projection",
+                "Rebuilding stale source-root projection",
                 dataset=ref.dataset_id,
+                existing_task=existing_task or "unknown",
+                source_task=source_task,
                 jsonl=str(jsonl_path),
             )
-            return jsonl_path
 
         sample_jsonl_path = Path(ref.sample_jsonl)
         ds_jsonl_path = Path(ref.ds_jsonl)
@@ -607,13 +679,14 @@ class DatasetManager:
             raise FileNotFoundError(f"source sample.jsonl not found: {sample_jsonl_path}")
         if not raw_dir.exists():
             raise FileNotFoundError(f"source raw_dir not found: {raw_dir}")
-        task = "ASR"
+        task = source_task or "ASR"
         ds_meta = self._load_single_json_object(ds_jsonl_path)
         language = str(
             (((ds_meta.get("audio") or {}).get("speech") or {}).get("language")) or "auto"
         )
         package_dir = self.sure_dir / ref.source_dataset_name
-        projection_dir = package_dir / "projections" / "asr_transcription_v1"
+        projection_name = "vad_segments_v1" if task == "VAD" else "asr_transcription_v1"
+        projection_dir = package_dir / "projections" / projection_name
         projection_dir.mkdir(parents=True, exist_ok=True)
 
         rows, skipped, source_records = self._project_sample_rows(
@@ -663,19 +736,32 @@ class DatasetManager:
             source_payload=source_payload,
         )
 
+        fields = {
+            "key": "sample_id",
+            "path": "attribute.path",
+            "task": f"constant:{task}",
+            "language": "ds.audio.speech.language",
+            "sample_rate": "attribute.sample_rate",
+        }
+        if task == "VAD":
+            fields.update(
+                {
+                    "duration": "attribute.duration / 1000",
+                    "speech_segments": "annotation[].timestamp.{begin_time,end_time}",
+                }
+            )
+        else:
+            fields.update(
+                {
+                    "target": "annotation[0].transcription.text[0]",
+                    "duration_ms": "attribute.duration",
+                }
+            )
         mapping = {
-            "projector": "asr_transcription_v1",
+            "projector": projection_name,
             "source_format": f"{SITE_DATASET_POOL_SOURCE}_sample_jsonl",
             "target_format": "sure_eval_jsonl_v1",
-            "fields": {
-                "key": "sample_id",
-                "path": "attribute.path",
-                "target": "annotation[0].transcription.text[0]",
-                "task": f"constant:{task}",
-                "language": "ds.audio.speech.language",
-                "sample_rate": "attribute.sample_rate",
-                "duration_ms": "attribute.duration",
-            },
+            "fields": fields,
         }
         try:
             import yaml
@@ -688,8 +774,16 @@ class DatasetManager:
         io_contract = {
             "task": task,
             "input": {"primary_field": "path", "type": "audio_path", "required_fields": ["key", "path"]},
-            "output": {"prediction_format": "tsv", "columns": ["key", "prediction_text"], "type": "text"},
-            "reference": {"primary_field": "target", "type": "text"},
+            "output": (
+                {"prediction_format": "jsonl", "columns": ["key", "speech_segments"], "type": "json"}
+                if task == "VAD"
+                else {"prediction_format": "tsv", "columns": ["key", "prediction_text"], "type": "text"}
+            ),
+            "reference": (
+                {"primary_field": "speech_segments", "type": "segments"}
+                if task == "VAD"
+                else {"primary_field": "target", "type": "text"}
+            ),
         }
         (projection_dir / "io_contract.json").write_text(
             json.dumps(io_contract, indent=2, ensure_ascii=False) + "\n",
@@ -727,17 +821,17 @@ class DatasetManager:
 
         manifest = {
             "dataset": ref.source_dataset_name,
-            "default_projection": "asr_transcription_v1",
+            "default_projection": projection_name,
             "source": SITE_DATASET_POOL_SOURCE,
             "source_dataset_root": ref.source_root,
             "version_id": ref.version_id,
             "projections": {
-                "asr_transcription_v1": {
+                projection_name: {
                     "dataset": ref.dataset_id,
                     "sure_jsonl": sure_jsonl.relative_to(package_dir).as_posix(),
-                    "mapping": "projections/asr_transcription_v1/mapping.yaml",
-                    "io_contract": "projections/asr_transcription_v1/io_contract.json",
-                    "conversion_report": "projections/asr_transcription_v1/conversion_report.json",
+                    "mapping": f"projections/{projection_name}/mapping.yaml",
+                    "io_contract": f"projections/{projection_name}/io_contract.json",
+                    "conversion_report": f"projections/{projection_name}/conversion_report.json",
                 }
             },
         }

--- a/sure/skills/sure_infer/scripts/sure_eval/datasets/source_resolver.py
+++ b/sure/skills/sure_infer/scripts/sure_eval/datasets/source_resolver.py
@@ -31,6 +31,25 @@ DEFAULT_SOURCE_ROOTS = (
 )
 SOURCE_ROOT_ENV = "SURE_DATASET_SOURCE_ROOT"
 _SOURCE_KEY_RE = re.compile(r"[a-z0-9][a-z0-9._-]*")  # the allowed_source_roots key grammar (sure.site.loader)
+_SOURCE_TASK_ALIASES = {
+    "asr": "ASR",
+    "classification": "CLASSIFICATION",
+    "gr": "GR",
+    "kws": "KWS",
+    "s2tt": "S2TT",
+    "sa-asr": "SA-ASR",
+    "sa_asr": "SA-ASR",
+    "sd": "SD",
+    "se": "SE",
+    "ser": "SER",
+    "slu": "SLU",
+    "sv": "SV",
+    "tse": "TSE",
+    "tts": "TTS",
+    "vad": "VAD",
+    "voice_activity_detection": "VAD",
+    "vc": "VC",
+}
 
 
 class SourceResolutionError(ValueError):
@@ -210,3 +229,79 @@ def read_source_language(ref: DatasetSourceRef) -> str:
         return ""
     speech = (payload.get("audio") or {}).get("speech") or {}
     return str(speech.get("language") or "")
+
+
+def _normalize_source_task(value: object) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return _SOURCE_TASK_ALIASES.get(normalized, "")
+
+
+def _read_first_sample(path: Path) -> dict[str, object]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if line.strip():
+                    payload = json.loads(line)
+                    return payload if isinstance(payload, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return {}
+
+
+def _sample_annotation_task(sample: dict[str, object]) -> str:
+    sample_task = _normalize_source_task(sample.get("task"))
+    if sample_task:
+        return sample_task
+
+    annotations = sample.get("annotation")
+    if not isinstance(annotations, list):
+        return ""
+    for annotation in annotations:
+        if not isinstance(annotation, dict):
+            continue
+        timestamp = annotation.get("timestamp")
+        if isinstance(timestamp, dict) and (
+            timestamp.get("begin_time") is not None or timestamp.get("end_time") is not None
+        ):
+            return "VAD"
+        transcription = annotation.get("transcription")
+        if isinstance(transcription, dict) and transcription.get("text") not in (None, "", []):
+            return "ASR"
+    return ""
+
+
+def read_source_task(ref: DatasetSourceRef) -> str:
+    """Resolve a source-root task without changing the source dataset.
+
+    Explicit task metadata wins. If the pool only declares a generic task such
+    as ``other``, the first sample's annotation shape identifies structured VAD
+    timestamp annotations before falling back to ``supported_tasks``.
+    """
+    metadata: dict[str, object] = {}
+    try:
+        text = Path(ref.ds_jsonl).read_text(encoding="utf-8").strip()
+        payload = json.loads(text) if text else {}
+        if isinstance(payload, dict):
+            metadata = payload
+    except (OSError, json.JSONDecodeError):
+        pass
+
+    for field in ("task", "task_type"):
+        task = _normalize_source_task(metadata.get(field))
+        if task:
+            return task
+
+    sample = _read_first_sample(Path(ref.sample_jsonl))
+    sample_task = _sample_annotation_task(sample)
+    if sample_task:
+        return sample_task
+
+    supported_tasks = metadata.get("supported_tasks")
+    if isinstance(supported_tasks, str):
+        supported_tasks = [supported_tasks]
+    if isinstance(supported_tasks, list):
+        tasks = [_normalize_source_task(item) for item in supported_tasks]
+        for task in tasks:
+            if task:
+                return task
+    return ""

--- a/sure/skills/sure_infer/scripts/test_eval_input_policy.py
+++ b/sure/skills/sure_infer/scripts/test_eval_input_policy.py
@@ -19,7 +19,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import resolve_eval_input  # noqa: E402
 from sure_eval.datasets import source_resolver  # noqa: E402
-from test_source_conversion import make_flat_source_tree, make_manager, make_source_tree  # noqa: E402
+from test_source_conversion import (  # noqa: E402
+    make_flat_source_tree,
+    make_manager,
+    make_source_tree,
+    make_vad_source_tree,
+)
 
 
 class MainFlowRemovalTests(unittest.TestCase):
@@ -221,6 +226,16 @@ class DatasetDetailsSourceTests(unittest.TestCase):
         self.assertEqual(detail["source_root"], str(flat_root))
         self.assertEqual(detail["source_dataset_name"], "flat_ds")
         self.assertEqual(detail["version_id"], "unversioned")
+
+    def test_unconverted_vad_source_entry_yields_vad_detail(self) -> None:
+        vad_root = make_vad_source_tree(self.source_root, "vad_ds", "v0.0.1")
+        details = resolve_eval_input._dataset_details(self.manager, [str(vad_root)], [], None)
+        self.assertEqual(len(details), 1)
+        detail = details[0]
+        self.assertEqual(detail["name"], "vad_ds__v0.0.1")
+        self.assertEqual(detail["task"], "VAD")
+        self.assertEqual(detail["language"], "zh")
+        self.assertEqual(detail["default_metrics"], ["f1"])
 
 
 class MainErrorHandlingTests(unittest.TestCase):

--- a/sure/skills/sure_infer/scripts/test_source_conversion.py
+++ b/sure/skills/sure_infer/scripts/test_source_conversion.py
@@ -96,6 +96,48 @@ def make_flat_source_tree(root: Path, name: str) -> Path:
     return dataset_root
 
 
+def make_vad_source_tree(root: Path, name: str, version: str) -> Path:
+    dataset_root = root / "g001" / "store002" / "ds_pool" / name
+    version_dir = dataset_root / "sample_files" / version
+    version_dir.mkdir(parents=True)
+    raw_dir = dataset_root / "raws" / "sample"
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    audio = raw_dir / "utt1.wav"
+    audio.write_bytes(b"RIFFxxxx")
+    (version_dir / "sample.jsonl").write_text(
+        json.dumps(
+            {
+                "sample_id": "utt1",
+                "attribute": {
+                    "path": str(audio),
+                    "size": audio.stat().st_size,
+                    "sample_rate": 16000,
+                    "duration": 1500,
+                    "raw_data_format": "wav",
+                    "channels": 1,
+                },
+                "annotation": [
+                    {"seg_id": "0", "timestamp": {"begin_time": 0.1, "end_time": 0.4}},
+                    {"seg_id": "1", "timestamp": {"begin_time": 0.8, "end_time": 1.2}},
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (version_dir / "ds.jsonl").write_text(
+        json.dumps(
+            {
+                "supported_tasks": ["other"],
+                "audio": {"speech": {"language": "zh"}},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return dataset_root
+
+
 class SourceConversionTests(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
@@ -185,6 +227,48 @@ class SourceConversionTests(unittest.TestCase):
         self.assertTrue(Path(row["path"]).is_absolute())
         self.assertEqual(row["metadata"]["version_id"], "unversioned")
         self.assertEqual(row["metadata"]["source_dataset_root"], str(flat_root))
+
+    def test_converts_timestamp_annotations_to_vad_projection(self) -> None:
+        vad_root = make_vad_source_tree(self.source_root, "vad_ds", "v0.0.1")
+        ref = source_resolver.resolve_site_source_entry(str(vad_root))
+        self.assertEqual(source_resolver.read_source_task(ref), "VAD")
+
+        jsonl_path = self.manager._convert_source_root_to_jsonl(ref)
+        row = json.loads(jsonl_path.read_text(encoding="utf-8").splitlines()[0])
+
+        self.assertEqual(jsonl_path.name, "vad_ds__v0.0.1.jsonl")
+        self.assertEqual(row["task"], "VAD")
+        self.assertEqual(row["duration"], 1.5)
+        self.assertEqual(
+            row["speech_segments"],
+            [{"start": 0.1, "end": 0.4}, {"start": 0.8, "end": 1.2}],
+        )
+        self.assertNotIn("target", row)
+
+        projection_dir = self.manager.sure_dir / "vad_ds" / "projections" / "vad_segments_v1"
+        contract = json.loads((projection_dir / "io_contract.json").read_text(encoding="utf-8"))
+        self.assertEqual(contract["task"], "VAD")
+        self.assertEqual(contract["reference"]["primary_field"], "speech_segments")
+        manifest = json.loads(
+            (self.manager.sure_dir / "vad_ds" / "dataset_manifest.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(manifest["default_projection"], "vad_segments_v1")
+
+    def test_rebuilds_stale_asr_projection_for_vad_source(self) -> None:
+        vad_root = make_vad_source_tree(self.source_root, "vad_ds", "v0.0.1")
+        stale_path = self.manager.jsonl_dir / "vad_ds__v0.0.1.jsonl"
+        stale_path.write_text(
+            json.dumps({"key": "utt1", "task": "ASR", "target": "stale"}) + "\n",
+            encoding="utf-8",
+        )
+
+        ref = source_resolver.resolve_site_source_entry(str(vad_root))
+        jsonl_path = self.manager._convert_source_root_to_jsonl(ref)
+        row = json.loads(jsonl_path.read_text(encoding="utf-8").splitlines()[0])
+
+        self.assertEqual(row["task"], "VAD")
+        self.assertIn("speech_segments", row)
+        self.assertNotIn("target", row)
 
 
 if __name__ == "__main__":

--- a/sure/skills/sure_infer/scripts/test_source_resolver.py
+++ b/sure/skills/sure_infer/scripts/test_source_resolver.py
@@ -176,6 +176,25 @@ class SourceResolverTests(unittest.TestCase):
         ref = source_resolver.resolve_site_source_entry(str(dataset_root))
         self.assertEqual(source_resolver.read_source_language(ref), "zh")
 
+    def test_read_source_task_from_timestamp_annotations(self) -> None:
+        dataset_root = make_source_tree(self.root, "vad_ds", ["v1.0.1"])
+        version_dir = dataset_root / "sample_files" / "v1.0.1"
+        (version_dir / "sample.jsonl").write_text(
+            '{"sample_id":"s1","annotation":[{"timestamp":{"begin_time":0.1,"end_time":0.2}}]}\n',
+            encoding="utf-8",
+        )
+        ref = source_resolver.resolve_site_source_entry(str(dataset_root))
+        self.assertEqual(source_resolver.read_source_task(ref), "VAD")
+
+    def test_read_source_task_prefers_known_supported_task_over_other(self) -> None:
+        dataset_root = make_source_tree(self.root, "vad_ds", ["v1.0.1"])
+        version_dir = dataset_root / "sample_files" / "v1.0.1"
+        (version_dir / "ds.jsonl").write_text(
+            '{"supported_tasks":["other","vad"]}\n', encoding="utf-8"
+        )
+        ref = source_resolver.resolve_site_source_entry(str(dataset_root))
+        self.assertEqual(source_resolver.read_source_task(ref), "VAD")
+
     def test_at_suffix_selects_among_multiple_versions(self) -> None:
         dataset_root = make_source_tree(self.root, "demo_ds", ["v1.0.1", "v1.0.2"])
         ref = source_resolver.resolve_site_source_entry(f"{dataset_root}@v1.0.1")


### PR DESCRIPTION
Summary
Dataset-pool sources were hardcoded as ASR: task always resolved to ASR, projection always asr_transcription_v1, and the reference field always target (text). VAD pools therefore failed conversion with "missing transcription text". This adds task inference and a VAD projection path.

Changes
- Task inference (source_resolver.read_source_task): explicit task/task_type metadata wins; otherwise the first sample's annotation shape is inspected — timestamp-only annotations → VAD, transcription text → ASR; finally falls back to supported_tasks. Adds a task alias map (vad/voice_activity_detection → VAD, etc.).
- VAD conversion (dataset_manager): extracts {start, end} speech segments from timestamp annotations, validates finite/positive intervals, derives duration from audio attributes (ms → s), and skips malformed rows with a reason instead of failing the run.
- Projection output: VAD uses the new vad_segments_v1 projector, with duration/speech_segments fields and a JSONL / segments io_contract instead of TSV / text.
- Stale cache: an existing projection is rebuilt when its task differs from the resolved source task.
- Metrics: VAD now defaults to f1 when no metrics are requested.

Tests
- New: VAD source resolution from timestamp annotations and from supported_tasks; VAD conversion end-to-end.
- Updated: eval-input policy asserts an unconverted VAD entry resolves to task VAD, language zh, metrics ["f1"].